### PR TITLE
Make navigation sticky

### DIFF
--- a/resources/views/docs/navigation.blade.php
+++ b/resources/views/docs/navigation.blade.php
@@ -1,7 +1,7 @@
 <div
     class="hidden lg:block absolute z-20 w-[18rem] inset-0 top-24 left-[max(0px,calc(50%-45rem))] right-auto ">
 
-    <div class="w-full border-r border-red-600 border-opacity-10 pt-8 pb-12 pl-4">
+    <div class="w-full sticky top-0 border-r border-red-600 border-opacity-10 pt-8 pb-12 pl-4">
 
         <nav class="flex flex-1 flex-col">
             {!! $navigation !!}

--- a/resources/views/docs/navigation.blade.php
+++ b/resources/views/docs/navigation.blade.php
@@ -1,7 +1,7 @@
 <div
     class="hidden lg:block absolute z-20 w-[18rem] inset-0 top-24 left-[max(0px,calc(50%-45rem))] right-auto ">
 
-    <div class="w-full sticky top-0 border-r border-red-600 border-opacity-10 pt-8 pb-12 pl-4">
+    <div class="sticky top-0 w-full border-r border-red-600 border-opacity-10 pt-8 pb-12 pl-4">
 
         <nav class="flex flex-1 flex-col">
             {!! $navigation !!}


### PR DESCRIPTION
Some of the pages are quite long, so needing to scroll all the way up to navigate to another page can be annoying.

With a sticky position it looks like this:

<img width="1174" alt="image" src="https://github.com/NativePHP/nativephp.com/assets/25956751/979caec2-b918-4e57-a94b-d5a8e05eb2a8">