### PR TITLE
Change requirements: minimum Laravel version to 10 and OS to Linux/MacOS

### DIFF
--- a/resources/views/docs/1/getting-started/installation.md
+++ b/resources/views/docs/1/getting-started/installation.md
@@ -6,8 +6,9 @@ order: 100
 # Requirements
 
 1. PHP 8.1
-2. Laravel 9 or higher
+2. Laravel 10 or higher
 3. NPM
+4. Linux/MacOS
 
 # Installation
 


### PR DESCRIPTION
The minimum required Laravel version is 10, not 9. I tried installing it on a project on 9 and it gives this error:
```Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nativephp/electron * -> satisfiable by nativephp/electron[0.1.0].
    - nativephp/electron 0.1.0 requires illuminate/contracts ^10.0 -> found illuminate/contracts[v10.0.0, ..., v10.15.0] but these were not loaded, likely because it conflicts with another require.

You can also try re-running composer require with an explicit version constraint, e.g. "composer require nativephp/electron:*" to figure out if any version is installable, or "composer require nativephp/electron:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Also Windows is not supported
```
Starting NativePHP app…

   Symfony\Component\Process\Exception\RuntimeException

  TTY mode is not supported on Windows platform.

  at vendor\symfony\process\Process.php:1019
    1015▕      */
    1016▕     public function setTty(bool $tty): static
    1017▕     {
    1018▕         if ('\\' === \DIRECTORY_SEPARATOR && $tty) {
  ➜ 1019▕             throw new RuntimeException('TTY mode is not supported on Windows platform.');
    1020▕         }
    1021▕
    1022▕         if ($tty && !self::isTtySupported()) {
    1023▕             throw new RuntimeException('TTY mode requires /dev/tty to be read/writable.');

  1   vendor\laravel\framework\src\Illuminate\Process\PendingProcess.php:316
      Symfony\Component\Process\Process::setTty()

  2   vendor\laravel\framework\src\Illuminate\Process\PendingProcess.php:246
      Illuminate\Process\PendingProcess::toSymfonyProcess("yarn run dev")
```