### PR TITLE
Correct configuration filename

### DIFF
--- a/resources/views/docs/1/getting-started/configuration.md
+++ b/resources/views/docs/1/getting-started/configuration.md
@@ -5,7 +5,7 @@ order: 200
 
 # Configuration
 
-The `native:install` command publishes a configuration file to `config/native.php`. 
+The `native:install` command publishes a configuration file to `config/nativephp.php`. 
 This file contains all the configuration options for NativePHP.
 
 ```php


### PR DESCRIPTION
The file that is published by the command is called `nativephp.php` not `native.php`