### PR TITLE
Fix: Application Lifecycle doc

### DIFF
--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -40,21 +40,7 @@ class NativeAppServiceProvider
      */
     public function boot(): void
     {
-        Menu::new()
-            ->appMenu()
-            ->submenu('About', Menu::new()
-                ->link('https://nativephp.com', 'NativePHP')
-            )
-            ->submenu('View', Menu::new()
-                ->toggleFullscreen()
-                ->separator()
-                ->toggleDevTools()
-            )
-            ->register();
-
-        Window::open()
-            ->width(800)
-            ->height(800);
+        Window::open();
     }
 }
 ```

--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -24,15 +24,14 @@ For example, you may want to open a window, register global shortcuts, or config
 The default `NativeAppServiceProvider` looks like this:
 
 ```php
+<?php
+
 namespace App\Providers;
 
-use Native\Laravel\Facades\ContextMenu;
-use Native\Laravel\Facades\Dock;
 use Native\Laravel\Facades\Window;
-use Native\Laravel\GlobalShortcut;
-use Native\Laravel\Menu\Menu;
+use Native\Laravel\Contracts\ProvidesPhpIni;
 
-class NativeAppServiceProvider
+class NativeAppServiceProvider implements ProvidesPhpIni
 {
     /**
      * Executed once the native application has been booted.
@@ -42,5 +41,15 @@ class NativeAppServiceProvider
     {
         Window::open();
     }
+
+    /**
+     * Return an array of php.ini directives to be set.
+     */
+    public function phpIni(): array
+    {
+        return [
+        ];
+    }
 }
+
 ```


### PR DESCRIPTION
In this commit: https://github.com/NativePHP/laravel/commit/430fe14e88accad7e0c2c47914e596308d22e178 the default `NativeAppServiceProvider` class is updated. 

In this PR, I've updated the doc accordingly. 