### PR TITLE
docs: fix link to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ We welcome any contributions to improve the documentation. Please feel free to o
 
 ## Issues
 
-Please raise any issues on the [NativePHP/laravel](/nativephp/laravel/issues/new/choose) repo
+Please raise any issues on the [NativePHP/laravel](https://github.com/NativePHP/laravel/issues) repo.


### PR DESCRIPTION
It was pointing to a file, not the issues tab of the repository