### PR TITLE
Documented compilation of Windows binaries on Linux

### DIFF
--- a/resources/views/docs/1/publishing/building.md
+++ b/resources/views/docs/1/publishing/building.md
@@ -52,7 +52,7 @@ Possible options are: `mac`, `win`, `linux`.
 #### Cross-compilation on Linux
 
 Compiling Windows binaries is possible with [wine](https://www.winehq.org/).
-nsis requires 32-bit wine when building x64 applications.
+NSIS requires 32-bit wine when building x64 applications.
 
 ```bash
 # Example installation of wine for Debian based distributions (Ubuntu)

--- a/resources/views/docs/1/publishing/building.md
+++ b/resources/views/docs/1/publishing/building.md
@@ -49,15 +49,29 @@ Possible options are: `mac`, `win`, `linux`.
 
 **Cross-compilation is not supported on all platforms.**
 
+#### Cross-compilation on Linux
+
+Compiling Windows binaries is possible with [wine](https://www.winehq.org/).
+nsis requires 32-bit wine when building x64 applications.
+
+```bash
+# Example installation of wine for Debian based distributions (Ubuntu)
+dpkg --add-architecture i386
+apt-get -y update
+apt-get -y install wine32
+```
+
 ## Code signing
 Both macOS and Windows require your app to be signed before it can be distributed to your users.
 
 NativePHP makes this as easy for you as it can, but each platform does have slightly different requirements.
 
 ### Windows
+
 [See the Electron documentation](https://www.electronforge.io/guides/code-signing/code-signing-windows) for more details.
 
 ### macOS
+
 [See the Electron documentation](https://www.electronforge.io/guides/code-signing/code-signing-macos) for more details.
 
 To prepare for signing and notarizing, please provide the following environment variables when running `php artisan native:build`:


### PR DESCRIPTION
You cannot create x64 Windows applications on Linux with 64-bit wine. I added that to the documentation. I am using an Ubuntu docker container to build the binaries and needed wine32.

Could this possibly be a bug?
