### PR TITLE
Docs for Screen facade

### DIFF
--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -1,0 +1,34 @@
+---
+title: Screens
+order: 850
+---
+# Screens
+
+The `Screen` facade lets you get information about the screens currently connected to the computer.
+
+```php
+use Native\Laravel\Facades\Screen;
+```
+
+## Displays
+
+The `displays` method gives you an array of information about all the displays actually used. 
+
+If you use an external display with your laptop screen closed, the internal screen of your laptop will not be part of the array.
+
+See [Display object](https://www.electronjs.org/docs/latest/api/structures/display) documentation.
+
+```php
+$screens = Screen::displays();
+```
+
+## Cursor position
+
+The `cursorPosition` method gives you the coordinates of the current absolute position of the mouse cursor.
+
+```php
+$position = Screen::cursorPosition();
+
+$position->x
+$position->y
+```

--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -20,42 +20,52 @@ See [Display object](https://www.electronjs.org/docs/latest/api/structures/displ
 
 ```php
 $screens = Screen::displays();
+
+[
+  0 => [
+    'bounds' => [
+      'x' => 0,
+      'y' => 0,
+      'width' => 2560,
+      'height' => 1440,
+    ],
+    'detected' => true,
+    'id' => 2026675401,
+    'internal' => false,
+    'label' => 'U3277WB',
+    'size' => [
+      'width' => 2560,
+      'height' => 1440,
+    ],
+    'workArea' => [
+      'x' => 0,
+      'y' => 25,
+      'width' => 2560,
+      'height' => 1345,
+    ],
+    // ... 
+  ],
+  // ... 
+]
 ```
 
 The screen bounds are the desktop area that the screen covers. The `x` and `y` values are the top-left corner of the screen relative to the primary display, and the `width` and `height` values are the width and height of the screen.
-
-You can use this to find out which screen a particular window is located on:
-
-```php
-function getCurrentScreen()
-{
-    $screens = Screen::displays();
-    $window = Window::current();
-
-    foreach ($screens as $screen) {
-        $bounds = $screen['bounds'];
-        if ($window->x >= $bounds['x'] && $window->x <= $bounds['x'] + $bounds['width'] && $window->y >= $bounds['y'] && $window->y <= $bounds['y'] + $bounds['height']) {
-            return $screen;
-        }
-    }
-
-    return null;
-}
-```
 
 
 ## Cursor position
 
 The `cursorPosition` method gives you the coordinates of the current absolute position of the mouse cursor.
 
+```php
+$position = Screen::cursorPosition();
+
+(object) [
+   'x' => 627,
+   'y' => 168,
+]
+```
 The position of the cursor is relative to the top-left corner of the primary display. These values can be
 negative as well as positive.
 
 For example, a secondary display may be oriented by your system to the right of your primary display.
 If your mouse cursor is on the secondary display when calling `Screen::cursorPosition()`, the `x` value will be a negative integer.
-```php
-$position = Screen::cursorPosition();
-
-$position->x
-$position->y
-```

--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -24,7 +24,7 @@ $screens = Screen::displays();
 
 The screen bounds are the desktop area that the screen covers. The `x` and `y` values are the top-left corner of the screen relative to the primary display, and the `width` and `height` values are the width and height of the screen.
 
-Example to found out in what screen the window is located:
+You can use this to find out which screen a particular window is located on:
 
 ```php
 function getCurrentScreen()

--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -12,9 +12,9 @@ use Native\Laravel\Facades\Screen;
 
 ## Displays
 
-The `displays` method gives you an array of information about all the displays actually used. 
+The `displays` method gives you an array of information about all the displays actually used.
 
-If you use an external display with your laptop screen closed, the internal screen of your laptop will not be part of the array.
+The Display object represents a physical display connected to the system. A fake display may exist on a headless system, or a display may correspond to a remote, virtual display. If you use an external display with your laptop screen closed, the internal screen of your laptop will not be part of the array.
 
 See [Display object](https://www.electronjs.org/docs/latest/api/structures/display) documentation.
 
@@ -22,10 +22,33 @@ See [Display object](https://www.electronjs.org/docs/latest/api/structures/displ
 $screens = Screen::displays();
 ```
 
+The screen bounds are the desktop area that the screen covers. The `x` and `y` values are the top-left corner of the screen relative to the primary display, and the `width` and `height` values are the width and height of the screen.
+
+Example to found out in what screen the window is located:
+
+```php
+function getCurrentScreen()
+{
+    $screens = Screen::displays();
+    $window = Window::current();
+
+    foreach ($screens as $screen) {
+        $bounds = $screen['bounds'];
+        if ($window->x >= $bounds['x'] && $window->x <= $bounds['x'] + $bounds['width'] && $window->y >= $bounds['y'] && $window->y <= $bounds['y'] + $bounds['height']) {
+            return $screen;
+        }
+    }
+
+    return null;
+}
+```
+
+
 ## Cursor position
 
 The `cursorPosition` method gives you the coordinates of the current absolute position of the mouse cursor.
 
+The position of the cursor is relative to the top-left corner of the primary display. So if your external display is on the right of your laptop screen, the `x` value will be negative.
 ```php
 $position = Screen::cursorPosition();
 

--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -48,7 +48,11 @@ function getCurrentScreen()
 
 The `cursorPosition` method gives you the coordinates of the current absolute position of the mouse cursor.
 
-The position of the cursor is relative to the top-left corner of the primary display. So if your external display is on the right of your laptop screen, the `x` value will be negative.
+The position of the cursor is relative to the top-left corner of the primary display. These values can be
+negative as well as positive.
+
+For example, a secondary display may be oriented by your system to the right of your primary display.
+If your mouse cursor is on the secondary display when calling `Screen::cursorPosition()`, the `x` value will be a negative integer.
 ```php
 $position = Screen::cursorPosition();
 


### PR DESCRIPTION
Base documentation for Screens

I took the part not to repeat the `use` statement in each example.

**Note:** In the first release of NativePHP, I experimented with Screens and wrote some helper functions, like the one I included in the documentation. While digging to write this page, I found some [handy functions](https://www.electronjs.org/docs/latest/api/screen#screengetdisplaymatchingrect) that do the same thing in Electron. Should we implement all those functions?