### PR TITLE
Proposal: documentation uniformisation 

### DIFF
--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -10,9 +10,8 @@ When your NativePHP application starts - whether it's in development or producti
 1. The native shell (Electron or Tauri) is started.
 2. NativePHP runs `php artisan migrate` to ensure your database is up-to-date.
 3. NativePHP runs `php artisan serve` to start the PHP development server.
-4. NativePHP boots your application by running the `boot()` method on your `NativeAppServiceProvider`.
-
-In addition to the `boot()` method, NativePHP also dispatches a `Native\Laravel\Events\App\ApplicationBooted` event.
+4. NativePHP boots your application by running the `boot()` method on your `NativeAppServiceProvider`. 
+5. NativePHP also dispatches a `ApplicationBooted` event.
 
 ## The NativeAppServiceProvider
 
@@ -50,3 +49,8 @@ class NativeAppServiceProvider implements ProvidesPhpIni
     }
 }
 ```
+
+## Events
+
+### ApplicationBooted
+Like mentioned above, the `Native\Laravel\Events\App\ApplicationBooted` event is dispatched when your application has been booted.

--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -52,5 +52,5 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 
 ## Events
 
-### ApplicationBooted
+### `ApplicationBooted`
 Like mentioned above, the `Native\Laravel\Events\App\ApplicationBooted` event is dispatched when your application has been booted.

--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -53,4 +53,4 @@ class NativeAppServiceProvider implements ProvidesPhpIni
 ## Events
 
 ### `ApplicationBooted`
-Like mentioned above, the `Native\Laravel\Events\App\ApplicationBooted` event is dispatched when your application has been booted.
+As mentioned above, the `Native\Laravel\Events\App\ApplicationBooted` event is dispatched when your application has been booted.

--- a/resources/views/docs/1/the-basics/application-menu.md
+++ b/resources/views/docs/1/the-basics/application-menu.md
@@ -8,6 +8,10 @@ order: 300
 NativePHP allows you to configure the native menu of your application, as well as context menus or dock menus.
 You can use the `Menu` facade which provides you with a single re-usable abstraction for building all of these menus.
 
+```php
+use Native\Laravel\Facades\Menu;
+```
+
 The configuration of your application menu should happen in the `boot` method of your `NativeAppServiceProvider`.
 
 ### Creating a menu

--- a/resources/views/docs/1/the-basics/clipboard.md
+++ b/resources/views/docs/1/the-basics/clipboard.md
@@ -8,13 +8,15 @@ order: 700
 NativePHP allows you to easily read from and write to the system clipboard using just PHP, thanks to the `Clipboard`
 facade.
 
+```php
+use Native\Laravel\Facades\Clipboard;
+```
+
 ### Reading from the Clipboard
 
 You can read `text`, `html` or `image` data from the clipboard using the appropriate method:
 
 ```php
-use Native\Laravel\Facades\Clipboard;
-
 Clipboard::text();
 Clipboard::html();
 Clipboard::image();
@@ -25,8 +27,6 @@ Clipboard::image();
 You can write `text`, `html` or `image` data to the clipboard using the appropriate method:
 
 ```php
-use Native\Laravel\Facades\Clipboard;
-
 Clipboard::text('Some copied text');
 Clipboard::html('<div>Some copied HTML</div>');
 Clipboard::image('path/to/image.png');
@@ -40,8 +40,6 @@ serializing the image data for you.
 You may also programmatically clear the clipboard using the `clear()` method.
 
 ```php
-use Native\Laravel\Facades\Clipboard;
-
 Clipboard::clear();
 ```
 

--- a/resources/views/docs/1/the-basics/dialogs.md
+++ b/resources/views/docs/1/the-basics/dialogs.md
@@ -7,6 +7,11 @@ order: 400
 
 NativePHP allows you to open native file dialogs. They can be used to give the user the ability to select a file or folder, or to save a file.
 
+Dialogs are created using the `Dialog` facade.
+```php
+use Native\Laravel\Dialog;
+```
+
 ### Opening File Dialogs
 
 To open a file dialog, you may use the `Dialog` class and its `open()` method.
@@ -15,8 +20,6 @@ The return value of the `open()` method is the path to the file or folder that t
 This could be null, a file path (string), or an array of file paths, depending on the type of dialog you open.
 
 ```php
-use Native\Laravel\Dialog;
-
 Dialog::new()
     ->title('Select a file')
     ->open();
@@ -31,8 +34,6 @@ This method will return the path to the file that the user wants to save.
 Please note that the `save()` method will not actually save the file for you, it will only return the path to the file that the user wants to save.
 
 ```php
-use Native\Laravel\Dialog;
-
 Dialog::new()
     ->title('Save a file')
     ->save();

--- a/resources/views/docs/1/the-basics/menu-bar.md
+++ b/resources/views/docs/1/the-basics/menu-bar.md
@@ -223,16 +223,16 @@ window events to the `nativephp` broadcast channel.
 
 To learn more about NativePHP's broadcasting capabilities, please refer to the [Broadcasting](/docs/digging-deeper/broadcasting) section.
 
-### MenuBarShown
+### `MenuBarShown`
 
 The `Native\Laravel\Events\MenuBar\MenuBarShown` event will be dispatched when the user clicks on the menu bar icon and the menu bar window opens, or when
 the menu bar gets shown by using the `MenuBar::show()` method.
 
-### MenuBarHidden
+### `MenuBarHidden`
 
 The `Native\Laravel\Events\MenuBar\MenuBarHidden` event will be dispatched when the user clicks out of the menu bar window and the menu bar window closes, or when
 the menu bar gets hidden by using the `MenuBar::hide()` method.
 
-### MenuBarContextMenuOpened
+### `MenuBarContextMenuOpened`
 
 The `Native\Laravel\Events\MenuBar\MenuBarContextMenuOpened` event will be dispatched when the user right-clicks on the menu bar icon and the context menu opens.

--- a/resources/views/docs/1/the-basics/menu-bar.md
+++ b/resources/views/docs/1/the-basics/menu-bar.md
@@ -213,7 +213,7 @@ MenuBar::create()
     );
 ```
 
-## Menu Bar Events
+## Events
 
 NativePHP provides a simple way to listen for menu bar events.
 All events get dispatched as regular Laravel events, so you may use your `EventServiceProvider` to register listeners.
@@ -223,16 +223,16 @@ window events to the `nativephp` broadcast channel.
 
 To learn more about NativePHP's broadcasting capabilities, please refer to the [Broadcasting](/docs/digging-deeper/broadcasting) section.
 
-### Menu Bar Opened
+### MenuBarShown
 
 The `Native\Laravel\Events\MenuBar\MenuBarShown` event will be dispatched when the user clicks on the menu bar icon and the menu bar window opens, or when
 the menu bar gets shown by using the `MenuBar::show()` method.
 
-### Menu Bar Closed
+### MenuBarHidden
 
 The `Native\Laravel\Events\MenuBar\MenuBarHidden` event will be dispatched when the user clicks out of the menu bar window and the menu bar window closes, or when
 the menu bar gets hidden by using the `MenuBar::hide()` method.
 
-### Menu Bar Context Menu Opened
+### MenuBarContextMenuOpened
 
 The `Native\Laravel\Events\MenuBar\MenuBarContextMenuOpened` event will be dispatched when the user right-clicks on the menu bar icon and the context menu opens.

--- a/resources/views/docs/1/the-basics/notifications.md
+++ b/resources/views/docs/1/the-basics/notifications.md
@@ -42,6 +42,6 @@ Notification::title('Hello from NativePHP')
 
 ## Events
 
-### NotificationClicked
-The `NotificationClicked` event is dispatched when a user clicks on a notification.
+### `NotificationClicked`
+The `Native\Laravel\Events\Notifications\NotificationClicked` event is dispatched when a user clicks on a notification.
 

--- a/resources/views/docs/1/the-basics/notifications.md
+++ b/resources/views/docs/1/the-basics/notifications.md
@@ -26,7 +26,7 @@ Notification::title('Hello from NativePHP')
 
 This will show a system-wide notification to the user with the given title and message.
 
-### Handle click on a notification
+### Handling clicks on notifications
 
 You may register a custom event along with your NativePHP notification. 
 This event will be fired when a user clicks on the notification, so that you may add some custom logic within your application in this scenario.

--- a/resources/views/docs/1/the-basics/notifications.md
+++ b/resources/views/docs/1/the-basics/notifications.md
@@ -9,13 +9,16 @@ NativePHP allows you to send system notifications using an elegant PHP API. Thes
 
 When used sparingly, notifications can be a great way to inform the user about events that are occurring in your application and to bring their attention back to it, especially if further input from them is required.
 
+Notifications are sent using the `Notification` facade.
+```php
+use Native\Laravel\Facades\Notification;
+```
+
 ### Sending Notifications
 
 You may send a notification using the `Notification` facade.
 
 ```php
-use Native\Laravel\Facades\Notification;
-
 Notification::title('Hello from NativePHP')
     ->message('This is a detail message coming from your Laravel app.')
     ->show();
@@ -23,9 +26,7 @@ Notification::title('Hello from NativePHP')
 
 This will show a system-wide notification to the user with the given title and message.
 
-## Events
-
-### Notification Click Events
+### Handle click on a notification
 
 You may register a custom event along with your NativePHP notification. 
 This event will be fired when a user clicks on the notification, so that you may add some custom logic within your application in this scenario.
@@ -33,10 +34,14 @@ This event will be fired when a user clicks on the notification, so that you may
 To attach an event to your notification, you may use the `event` method. The argument passed to this method is the class name of the event that should get dispatched upon clicking on the notification.
 
 ```php
-use Native\Laravel\Facades\Notification;
-
 Notification::title('Hello from NativePHP')
     ->message('This is a detail message coming from your Laravel app.')
     ->event(\App\Events\MyNotificationEvent::class)
     ->show();
 ```
+
+## Events
+
+### NotificationClicked
+The `NotificationClicked` event is dispatched when a user clicks on a notification.
+

--- a/resources/views/docs/1/the-basics/power-monitor.md
+++ b/resources/views/docs/1/the-basics/power-monitor.md
@@ -81,19 +81,19 @@ if (PowerMonitor::isOnBatteryPower()) {
 
 You can listen to the following events to get handle when the system's power state changes:
 
-### PowerStateChanged
+### `PowerStateChanged`
 
 This `Native\Laravel\Events\PowerStateChanged` event is fired whenever the power state of the system changes. For example, when the system goes from battery power to AC power, or vice versa.
 
 The event contains a public `$state` property which is an enum value of `Native\Laravel\Enums\PowerStatesEnum`.
 
-### SpeedLimitChanged
+### `SpeedLimitChanged`
 
 This `Native\Laravel\Events\SpeedLimitChanged` event is fired whenever the CPU speed limit changes, usually due to thermal throttling or low battery.
 
 The event contains a public `$limit` property which is the percentage of the maximum CPU speed that is currently allowed.
 
-### ThermalStateChanged
+### `ThermalStateChanged`
 
 The `Native\Laravel\Events\ThermalStateChanged` event is fired whenever the thermal state of the system changes.
 

--- a/resources/views/docs/1/the-basics/power-monitor.md
+++ b/resources/views/docs/1/the-basics/power-monitor.md
@@ -81,20 +81,20 @@ if (PowerMonitor::isOnBatteryPower()) {
 
 You can listen to the following events to get handle when the system's power state changes:
 
-### `Native\Laravel\Events\PowerStateChanged`
+### PowerStateChanged
 
-This is fired whenever the power state of the system changes. For example, when the system goes from battery power to AC power, or vice versa.
+This `Native\Laravel\Events\PowerStateChanged` event is fired whenever the power state of the system changes. For example, when the system goes from battery power to AC power, or vice versa.
 
 The event contains a public `$state` property which is an enum value of `Native\Laravel\Enums\PowerStatesEnum`.
 
-### `Native\Laravel\Events\SpeedLimitChanged`
+### SpeedLimitChanged
 
-This is fired whenever the CPU speed limit changes, usually due to thermal throttling or low battery.
+This `Native\Laravel\Events\SpeedLimitChanged` event is fired whenever the CPU speed limit changes, usually due to thermal throttling or low battery.
 
 The event contains a public `$limit` property which is the percentage of the maximum CPU speed that is currently allowed.
 
-### `Native\Laravel\Events\ThermalStateChanged`
+### ThermalStateChanged
 
-This is fired whenever the thermal state of the system changes.
+The `Native\Laravel\Events\ThermalStateChanged` event is fired whenever the thermal state of the system changes.
 
 The event contains a public `$state` property which is an enum value of `Native\Laravel\Enums\ThermalStatesEnum`.

--- a/resources/views/docs/1/the-basics/shell.md
+++ b/resources/views/docs/1/the-basics/shell.md
@@ -7,14 +7,17 @@ order: 850
 The `Shell` facade lets you perform some basic operations with files on the user's system in the context of the system's
 default behaviour.
 
+To use the `Shell` facade, add the following to the top of your file:
+```php
+use Native\Laravel\Facades\Shell;
+```
+
 ## Showing a file
 
 The `showInFolder` method will attempt to open the given `$path` in the user's default file manager, e.g. File Explorer,
 Finder etc.
 
 ```php
-use Native\Laravel\Facades\Shell;
-
 Shell::showInFolder($path);
 ```
 
@@ -25,8 +28,6 @@ type. If it was successful, this method will return an empty string (`""`); if u
 contain an error message.
 
 ```php
-use Native\Laravel\Facades\Shell;
-
 $result = Shell::openFile($path);
 ```
 
@@ -35,8 +36,6 @@ $result = Shell::openFile($path);
 The `trashFile` method will attempt to send the given `$path` to the system's trash.
 
 ```php
-use Native\Laravel\Facades\Shell;
-
 Shell::trashFile($path);
 ```
 
@@ -46,7 +45,5 @@ The `openExternal` method will attempt to open the given `$url` using the defaul
 scheme on the system's, e.g. the `http` and `https` schemes will most likely open the user's default web browser.
 
 ```php
-use Native\Laravel\Facades\Shell;
-
 Shell::openExternal($url);
 ```

--- a/resources/views/docs/1/the-basics/system.md
+++ b/resources/views/docs/1/the-basics/system.md
@@ -18,6 +18,11 @@ the platform on which your app is running.
 While some features are platform-specific, NativePHP gracefully handles this for you so that you don't have to think
 about whether something is Linux-, Mac-, or Windows-only.
 
+Most of the system-related features are available through the `System` facade.
+```php
+use Native\Laravel\Facades\System;
+```
+
 ## Encryption / Decryption
 
 Almost every non-trivial application will require some concept of secure data storage and retrieval. For example, if
@@ -40,8 +45,6 @@ decrypt the secrets that you need to store on behalf of your user.
 NativePHP allows you to encrypt and decrypt data in your application easily:
 
 ```php
-use Native\Laravel\Facades\System;
-
 if (System::canEncrypt()) {
     $encrypted = System::encrypt('secret_key_a79hiunfw86...');
 
@@ -54,8 +57,6 @@ You can then safely store the encrypted string in a database or the filesystem.
 When you need to get the original value, you can decrypt it:
 
 ```php
-use Native\Laravel\Facades\System;
-
 if (System::canEncrypt()) {
     $decrypted = System::decrypt('djEwJo+Huv+aeBgUoav5nIJWRQ==');
 
@@ -68,8 +69,6 @@ if (System::canEncrypt()) {
 For Mac systems that support TouchID, you can use TouchID to protect and unlock various parts of your application.
 
 ```php
-use Native\Laravel\Facades\System;
-
 if (System::canPromptTouchID() && System::promptTouchID('access your Contacts')) {
     // Do your super secret activity here
 }

--- a/resources/views/docs/1/the-basics/windows.md
+++ b/resources/views/docs/1/the-basics/windows.md
@@ -356,54 +356,7 @@ In order to keep the window draggable, you should add an HTML element with the f
 NativePHP provides a simple way to listen for native window events.
 All events get dispatched as regular Laravel events, so you may use your `EventServiceProvider` to register listeners.
 
-Sometimes you may want to listen and react to window events in real-time, which is why NativePHP also broadcasts all
-window events to the `nativephp` broadcast channel. 
-
-To learn more about NativePHP's broadcasting capabilities, please refer to the [Broadcasting](/docs/digging-deeper/broadcasting) section.
-
-### Window Shown Event
-
-The `Native\Laravel\Events\Windows\WindowShown` event will be dispatched when a window is shown to the user.
-The payload of this event contains the window ID.
-
-### Window Closed Event
-
-The `Native\Laravel\Events\Windows\WindowClosed` event will be dispatched when a window is closed.
-The payload of this event contains the window ID.
-
-### Window Focused Event
-
-The `Native\Laravel\Events\Windows\WindowFocused` event will be dispatched when a window is focused.
-The payload of this event contains the window ID.
-
-### Window Blurred Event
-
-The `Native\Laravel\Events\Windows\WindowBlurred` event will be dispatched when a window is blurred.
-The payload of this event contains the window ID.
-
-### Window Minimized Event
-
-The `Native\Laravel\Events\Windows\WindowMinimized` event will be dispatched when a window is minimized.
-The payload of this event contains the window ID.
-
-### Window Maximized Event
-
-The `Native\Laravel\Events\Windows\WindowMaximized` event will be dispatched when a window is maximized.
-The payload of this event contains the window ID.
-
-### Window Resized Event
-
-The `Native\Laravel\Events\Windows\WindowResized` event will be dispatched after a window has been resized.
-The payload of this event contains the window ID and the new window `$width` and `$height`.
-
-You may register listeners for these events in your `EventServiceProvider`:
-
 ```php
-/**
- * The event listener mappings for the application.
- *
- * @var array
- */
 protected $listen = [
     'Native\Laravel\Events\Windows\WindowShown' => [
         'App\Listeners\WindowWasShownListener',
@@ -411,3 +364,44 @@ protected $listen = [
     // ...
 ];
 ```
+
+Sometimes you may want to listen and react to window events in real-time, which is why NativePHP also broadcasts all
+window events to the `nativephp` broadcast channel. 
+
+To learn more about NativePHP's broadcasting capabilities, please refer to the [Broadcasting](/docs/digging-deeper/broadcasting) section.
+
+### WindowShown
+
+The `Native\Laravel\Events\Windows\WindowShown` event will be dispatched when a window is shown to the user.
+The payload of this event contains the window ID.
+
+### WindowClosed
+
+The `Native\Laravel\Events\Windows\WindowClosed` event will be dispatched when a window is closed.
+The payload of this event contains the window ID.
+
+### WindowFocused
+
+The `Native\Laravel\Events\Windows\WindowFocused` event will be dispatched when a window is focused.
+The payload of this event contains the window ID.
+
+### WindowBlurred
+
+The `Native\Laravel\Events\Windows\WindowBlurred` event will be dispatched when a window is blurred.
+The payload of this event contains the window ID.
+
+### WindowMinimized
+
+The `Native\Laravel\Events\Windows\WindowMinimized` event will be dispatched when a window is minimized.
+The payload of this event contains the window ID.
+
+### WindowMaximized
+
+The `Native\Laravel\Events\Windows\WindowMaximized` event will be dispatched when a window is maximized.
+The payload of this event contains the window ID.
+
+### WindowResized
+
+The `Native\Laravel\Events\Windows\WindowResized` event will be dispatched after a window has been resized.
+The payload of this event contains the window ID and the new window `$width` and `$height`.
+

--- a/resources/views/docs/1/the-basics/windows.md
+++ b/resources/views/docs/1/the-basics/windows.md
@@ -370,37 +370,37 @@ window events to the `nativephp` broadcast channel.
 
 To learn more about NativePHP's broadcasting capabilities, please refer to the [Broadcasting](/docs/digging-deeper/broadcasting) section.
 
-### WindowShown
+### `WindowShown`
 
 The `Native\Laravel\Events\Windows\WindowShown` event will be dispatched when a window is shown to the user.
 The payload of this event contains the window ID.
 
-### WindowClosed
+### `WindowClosed`
 
 The `Native\Laravel\Events\Windows\WindowClosed` event will be dispatched when a window is closed.
 The payload of this event contains the window ID.
 
-### WindowFocused
+### `WindowFocused`
 
 The `Native\Laravel\Events\Windows\WindowFocused` event will be dispatched when a window is focused.
 The payload of this event contains the window ID.
 
-### WindowBlurred
+### `WindowBlurred`
 
 The `Native\Laravel\Events\Windows\WindowBlurred` event will be dispatched when a window is blurred.
 The payload of this event contains the window ID.
 
-### WindowMinimized
+### `WindowMinimized`
 
 The `Native\Laravel\Events\Windows\WindowMinimized` event will be dispatched when a window is minimized.
 The payload of this event contains the window ID.
 
-### WindowMaximized
+### `WindowMaximized`
 
 The `Native\Laravel\Events\Windows\WindowMaximized` event will be dispatched when a window is maximized.
 The payload of this event contains the window ID.
 
-### WindowResized
+### `WindowResized`
 
 The `Native\Laravel\Events\Windows\WindowResized` event will be dispatched after a window has been resized.
 The payload of this event contains the window ID and the new window `$width` and `$height`.


### PR DESCRIPTION
I think these kinds of details matter.

Here is my argument for each case:

**Use statement:**  
- Use statements are presented at the beginning of the documentation but not in the subsequent examples, makes it clearer. 
- Each example is copyable and can be directly pasted into your code. If not imported yet, most code editors help the user import the correct class.

**Events:**  
- The same presentation for each "Facade emitting event."  
- At first glance, the user goes through the list of events. Having the name of the event as an h2 allows a user to search for a particular event that they have seen in their logs.
- I’m not trying to transform the documentation into an ApiDoc, I promise.

**Side note:** I don’t think notification events are working. The default event is fired without a payload. -> event() doesn’t seem to change this behavior.