### PR TITLE
Fix anchor link on events

### DIFF
--- a/app/Http/Controllers/ShowDocumentationController.php
+++ b/app/Http/Controllers/ShowDocumentationController.php
@@ -192,7 +192,7 @@ class ShowDocumentationController extends Controller
                 return [
                     'level' => strlen(trim(Str::before($line, '# '))) + 1,
                     'title' => $title = trim(Str::after($line, '# ')),
-                    'anchor' => Str::slug($title),
+                    'anchor' => Str::slug(Str::replace('`', 'code', $title)),
                 ];
             })
             ->toArray();


### PR DESCRIPTION
There is a bug where the generated ToC isn't anchoring to the correct heading when in a code block.

- before: #menubarcontextmenuopened
- now: #codemenubarcontextmenuopenedcode