### PR TITLE
Docs for settings

### DIFF
--- a/resources/views/docs/1/the-basics/settings.md
+++ b/resources/views/docs/1/the-basics/settings.md
@@ -67,7 +67,7 @@ use Native\Laravel\Events\Notifications\SettingChanged;
 class Settings extends Component
 {
     protected $listeners = [
-        SettingChanged::class => '$refresh',
+        'native:'.SettingChanged::class => '$refresh',
     ];
 }
 ```

--- a/resources/views/docs/1/the-basics/settings.md
+++ b/resources/views/docs/1/the-basics/settings.md
@@ -9,7 +9,7 @@ NativePHP offers an easy method to store and retrieve settings in your applicati
 settings that persist even after closing and reopening the application.
 
 Settings are managed using the `Settings` facade and are stored in a file named `config.json` in the
-[`appdata`](/docs/1/getting-started/debugging#start-from-scratch) directory of your application.
+[`appdata`](/docs/getting-started/debugging#start-from-scratch) directory of your application.
 
 ```php
 use Native\Laravel\Facades\Settings;

--- a/resources/views/docs/1/the-basics/settings.md
+++ b/resources/views/docs/1/the-basics/settings.md
@@ -5,9 +5,12 @@ order: 450
 
 ## Storing Settings
 
-NativePHP offers an easy method to store and retrieve settings in your application. This is helpful for saving application-wide settings that persist even after closing and reopening the application.
+NativePHP offers an easy method to store and retrieve settings in your application. This is helpful for saving application-wide
+settings that persist even after closing and reopening the application.
 
-Settings are managed using the `Settings` facade and  are stored in a file name `config.json` in the [AppData](/docs/1/getting-started/debugging#start-from-scratch) directory of your application.
+Settings are managed using the `Settings` facade and are stored in a file named `config.json` in the
+[`appdata`](/docs/1/getting-started/debugging#start-from-scratch) directory of your application.
+
 ```php
 use Native\Laravel\Facades\Settings;
 ```
@@ -28,10 +31,10 @@ You may also provide a default value to return if the setting does not exist.
 ```php
 $value = Settings::get('key', 'default');
 ```
-If the setting does not exist, "default" will be returned.
+If the setting does not exist, `default` will be returned.
 
 ### Forgetting a value
-If you wanna remove a setting, use the `forget` method.
+If you want to remove a setting altogether, use the `forget` method.
 ```php
 Settings::forget('key');
 ```
@@ -64,7 +67,7 @@ use Native\Laravel\Events\Notifications\SettingChanged;
 class Settings extends Component
 {
     protected $listeners = [
-        SettingChanged::class => '$refresh'
+        SettingChanged::class => '$refresh',
     ];
 }
 ```

--- a/resources/views/docs/1/the-basics/settings.md
+++ b/resources/views/docs/1/the-basics/settings.md
@@ -1,0 +1,71 @@
+---
+title: Settings
+order: 450
+---
+
+## Storing Settings
+
+NativePHP offers an easy method to store and retrieve settings in your application. This is helpful for saving application-wide settings that persist even after closing and reopening the application.
+
+Settings are managed using the `Settings` facade and  are stored in a file name `config.json` in the [AppData](/docs/1/getting-started/debugging#start-from-scratch) directory of your application.
+```php
+use Native\Laravel\Facades\Settings;
+```
+
+### Setting a value
+It's as simple as calling the `set` method. The key must be a string.
+```php
+Settings::set('key', 'value');
+```
+
+### Getting a value
+To retrieve a setting, use the `get` method.
+```php
+$value = Settings::get('key');
+```
+
+You may also provide a default value to return if the setting does not exist.
+```php
+$value = Settings::get('key', 'default');
+```
+If the setting does not exist, "default" will be returned.
+
+### Forgetting a value
+If you wanna remove a setting, use the `forget` method.
+```php
+Settings::forget('key');
+```
+
+### Clearing all settings
+To remove all settings, use the `clear` method.
+```php
+Settings::clear();
+```
+This will remove all settings from the `config.json` file.
+
+## Events
+
+### `SettingChanged`
+The `Native\Laravel\Events\Notifications\SettingChanged` event is dispatched when a setting is changed.
+
+Example usage:
+```php
+Event::listen(SettingChanged::class, function (SettingChanged $event) {
+    $key = $event->key; // Key of the setting that was changed
+    $value = $event->value; // New value of the setting
+});
+```
+
+This event can also be listened with Livewire to refresh your settings page:
+```php
+use Livewire\Component;
+use Native\Laravel\Events\Notifications\SettingChanged;
+
+class Settings extends Component
+{
+    protected $listeners = [
+        SettingChanged::class => '$refresh'
+    ];
+}
+```
+


### PR DESCRIPTION
Docs for https://github.com/NativePHP/laravel/pull/432 and https://github.com/NativePHP/electron/pull/141
On less task for: https://github.com/NativePHP/laravel/issues/364

---- 
I understand you prefer not to include Electron-specific details due to the upcoming Tauri driver, but I thought someone might need them for debugging purposes. I added a note indicating that settings are stored in `config.json`, as mentioned in the package documentation [sindresorhus/electron-store](https://github.com/sindresorhus/electron-store).

I also looked for the equivalent package in Tauri, which is [harshkhandeparkar/tauri-settings](https://github.com/harshkhandeparkar/tauri-settings). They replicate everything from tauri-settings but use `settings.json` for the filename, which is configurable.

I believe the usefulness of those dependencies is debatable. It would only take a few lines in Laravel to write directly to the file. The current method's only advantage is the potential to implement a reactive JavaScript facade, such as with AlpineJS. For now, this approach is acceptable. I'm not trying to start a debate at this moment; we can discuss those details later. I just thought it was worth noting somewhere.

