### PR TITLE
fix: code snippet copy trimmed

### DIFF
--- a/resources/js/alpine/codeBlock.js
+++ b/resources/js/alpine/codeBlock.js
@@ -4,7 +4,7 @@ export default () => ({
     copyToClipboard() {
         navigator.clipboard.writeText(
             // This requires torchlight.options.copyable to be "true" on the PHP side.
-            this.$root.querySelector('.torchlight-copy-target').textContent
+            this.$root.querySelector('.torchlight-copy-target').textContent.trim()
         ).then(() => this.showMessage = true)
 
         setTimeout(() => (this.showMessage = false), 2000)


### PR DESCRIPTION
I have a leading line break in Chrome and Safari. 
Something must have changed on torchlight.dev.

this PR fixes it.