### PR TITLE
fix: TOC not showing every titles

### DIFF
--- a/app/Http/Controllers/ShowDocumentationController.php
+++ b/app/Http/Controllers/ShowDocumentationController.php
@@ -200,13 +200,14 @@ class ShowDocumentationController extends Controller
     protected function extractTableOfContents(string $document): array
     {
         // Remove code blocks which might contain headers.
-        $document = preg_replace('(```[a-z]*\n[\s\S]*?\n```)', '', $document);
+        $document = preg_replace('/```[a-z]*\s(.*?)```/s', '', $document);
 
         return collect(explode(PHP_EOL, $document))
             ->reject(function (string $line) {
                 // Only search for level 2 and 3 headings.
                 return ! Str::startsWith($line, '## ') && ! Str::startsWith($line, '### ');
             })
+
             ->map(function (string $line) {
                 return [
                     'level' => strlen(trim(Str::before($line, '# '))) + 1,

--- a/resources/views/docs/1/getting-started/configuration.md
+++ b/resources/views/docs/1/getting-started/configuration.md
@@ -3,7 +3,6 @@ title: Configuration
 order: 200
 ---
 
-# Configuration
 
 The `native:install` command publishes a configuration file to `config/nativephp.php`. 
 This file contains all the configuration options for NativePHP.

--- a/resources/views/docs/1/getting-started/debugging.md
+++ b/resources/views/docs/1/getting-started/debugging.md
@@ -3,7 +3,7 @@ title: Debugging
 order: 350
 ---
 
-# When things go wrong
+## When things go wrong
 
 Building native applications is a complex task with many moving parts. There will be errors, crashes and lots of
 head-scratching.
@@ -16,7 +16,7 @@ maintained by many developers outside the NativePHP team.**
 
 This means that while some issues can be solved within NativePHP it's also very likely that the problem lies elsewhere.
 
-## The layers
+### The layers
 
 - Your application, built on Laravel, using your local installations of PHP & Node.
 - NativePHP's development tools (`native:serve` and `native:build`) manage the Electron/Tauri build processes - this is

--- a/resources/views/docs/1/getting-started/development.md
+++ b/resources/views/docs/1/getting-started/development.md
@@ -3,7 +3,7 @@ title: Development
 order: 300
 ---
 
-# Development
+## Development
 
 ```shell
 php artisan native:serve
@@ -18,7 +18,7 @@ application to see changes.
 
 This is known as 'running a dev build'.
 
-## What does the `native:serve` command do?
+### What does the `native:serve` command do?
 
 The `native:serve` command runs the Electron/Tauri 'debug build' commands, which build your application with various
 debug options set to help make debugging easier, such as allowing you to show the Dev Tools in the embedded web view.
@@ -59,7 +59,7 @@ Now changes you make to files in your source code will cause a hot reload in you
 
 Which files trigger reloads will depend on your Vite configuration.
 
-## `composer native:dev`
+### `composer native:dev`
 
 You may find the `native:dev` script convenient. By default, it is setup to run both `native:serve` and `npm run dev`
 concurrently in a single command:

--- a/resources/views/docs/1/getting-started/env-files.md
+++ b/resources/views/docs/1/getting-started/env-files.md
@@ -3,7 +3,7 @@ title: Environment Files
 order: 400
 ---
 
-# Environment Files
+## Environment Files
 
 When NativePHP bundles your application, it will copy your entire application directory into the bundle, including your
 `.env` file.

--- a/resources/views/docs/1/getting-started/installation.md
+++ b/resources/views/docs/1/getting-started/installation.md
@@ -3,14 +3,14 @@ title: Installation
 order: 100
 ---
 
-# Requirements
+## Requirements
 
 1. PHP 8.1+
 2. Laravel 10 or higher
 3. Node 20+
 4. Windows 10+ / macOS 12+ / Linux
 
-## PHP & Node
+### PHP & Node
 
 The best development experience for NativePHP is to have PHP and Node running on your development machine directly.
 
@@ -20,7 +20,7 @@ If you're using Mac or Windows, the most painless way to get PHP and Node up and
 Please note that, whilst it's possible to develop and run your application from a virtualized environment or container,
 you may encounter more unexpected issues and have more manual steps to create working builds.
 
-## Laravel
+### Laravel
 
 NativePHP is built to work best with Laravel. You can install it into an existing Laravel application, or
 [start a new one](https://laravel.com/docs/installation).

--- a/resources/views/docs/1/getting-started/introduction.md
+++ b/resources/views/docs/1/getting-started/introduction.md
@@ -3,7 +3,7 @@ title: Introduction
 order: 001
 ---
 
-# Hello, NativePHP!
+## Hello, NativePHP!
 
 NativePHP is a new framework for rapidly building rich, native desktop applications using PHP. If you're already a PHP
 developer, you'll feel right at home. If you're new to PHP, we think you'll find NativePHP easy to pick up and use.

--- a/resources/views/docs/1/getting-started/sponsoring.md
+++ b/resources/views/docs/1/getting-started/sponsoring.md
@@ -2,7 +2,7 @@
 title: Sponsoring
 order: 002
 ---
-# Support NativePHP
+## Support NativePHP
 
 NativePHP is wholly dependent on the dedication of its maintainers and contributors, who volunteer their free time to
 ensure its continued development and improvement. As we prioritize our paid client work to sustain ourselves, your

--- a/resources/views/docs/1/publishing/building.md
+++ b/resources/views/docs/1/publishing/building.md
@@ -2,7 +2,7 @@
 title: Building
 order: 100
 ---
-# Building Your App
+## Building Your App
 
 Building your app is the process of compiling your application into a production-ready state. When building, NativePHP
 attempts to sign and notarize your application. Once signed, your app is ready to be distributed.

--- a/resources/views/docs/1/publishing/publishing.md
+++ b/resources/views/docs/1/publishing/publishing.md
@@ -2,7 +2,7 @@
 title: Publishing
 order: 200
 ---
-# Publishing Your App
+## Publishing Your App
 
 Publishing your app is similar to building, but in addition NativePHP will upload the build artifacts to your chosen
 [updater provider](/docs/publishing/updating) automatically.

--- a/resources/views/docs/1/publishing/updating.md
+++ b/resources/views/docs/1/publishing/updating.md
@@ -2,7 +2,7 @@
 title: Updating
 order: 300
 ---
-# The Updater
+## The Updater
 NativePHP ships with a built-in auto-update tool, which allows your users to update your application without needing to
 manually download and install new releases.
 

--- a/resources/views/docs/1/the-basics/app-lifecycle.md
+++ b/resources/views/docs/1/the-basics/app-lifecycle.md
@@ -3,7 +3,7 @@ title: Application Lifecycle
 order: 1
 ---
 
-# NativePHP Application Lifecycle
+## NativePHP Application Lifecycle
 
 When your NativePHP application starts - whether it's in development or production - it performs a series of steps to get your application up and running.
 

--- a/resources/views/docs/1/the-basics/screens.md
+++ b/resources/views/docs/1/the-basics/screens.md
@@ -2,7 +2,6 @@
 title: Screens
 order: 850
 ---
-# Screens
 
 The `Screen` facade lets you get information about the screens currently connected to the computer.
 

--- a/resources/views/docs/1/the-basics/shell.md
+++ b/resources/views/docs/1/the-basics/shell.md
@@ -2,7 +2,7 @@
 title: Shell
 order: 850
 ---
-# Shell operations
+## Shell operations
 
 The `Shell` facade lets you perform some basic operations with files on the user's system in the context of the system's
 default behaviour.
@@ -12,7 +12,7 @@ To use the `Shell` facade, add the following to the top of your file:
 use Native\Laravel\Facades\Shell;
 ```
 
-## Showing a file
+### Showing a file
 
 The `showInFolder` method will attempt to open the given `$path` in the user's default file manager, e.g. File Explorer,
 Finder etc.
@@ -21,7 +21,7 @@ Finder etc.
 Shell::showInFolder($path);
 ```
 
-## Opening a file
+### Opening a file
 
 The `openFile` method will attempt to open the given `$path` using the default application associated with that file
 type. If it was successful, this method will return an empty string (`""`); if unsuccessful, the returned string may
@@ -31,7 +31,7 @@ contain an error message.
 $result = Shell::openFile($path);
 ```
 
-## Trashing a file
+### Trashing a file
 
 The `trashFile` method will attempt to send the given `$path` to the system's trash.
 
@@ -39,7 +39,7 @@ The `trashFile` method will attempt to send the given `$path` to the system's tr
 Shell::trashFile($path);
 ```
 
-## Open a URL
+### Open a URL
 
 The `openExternal` method will attempt to open the given `$url` using the default handler registered for that URL's
 scheme on the system's, e.g. the `http` and `https` schemes will most likely open the user's default web browser.

--- a/resources/views/docs/1/the-basics/system.md
+++ b/resources/views/docs/1/the-basics/system.md
@@ -2,7 +2,7 @@
 title: System
 order: 800
 ---
-# The System
+## The System
 
 One of the main advantages of building a native application is having more direct access to system resources, such as
 peripherals connected to the physical device and APIs that aren't typically accessible inside a browser's sandbox. 

--- a/resources/views/docs/index.blade.php
+++ b/resources/views/docs/index.blade.php
@@ -7,9 +7,9 @@
 
             <div class="overflow-hidden lg:ml-[240px] max-w-prose w-full py-8 sm:px-8">
 
-                <div class="text-5xl font-bold tracking-tight mb-4 text-[#00aaa6]">
+                <h1 class="text-5xl font-bold tracking-tight mb-4 text-[#00aaa6]">
                     {{$title}}
-                </div>
+                </h1>
 
                 <x-alert-beta/>
 


### PR DESCRIPTION
Fixing this report: 
>  I've noticed that the TOC on this page (http://nativephp.com.test/docs/1/the-basics/menu-bar) doesn't show all the headers and I'm not sure why - maybe it's happening on other pages too?
