### PR TITLE
hide line numbers in code block

### DIFF
--- a/config/torchlight.php
+++ b/config/torchlight.php
@@ -47,7 +47,7 @@ return [
     // https://torchlight.dev/docs/options
     'options' => [
         // Turn line numbers on or off globally.
-        // 'lineNumbers' => false,
+        'lineNumbers' => false,
 
         // Control the `style` attribute applied to line numbers.
         // 'lineNumbersStyle' => '',


### PR DESCRIPTION
- it takes up horizontal space.  
- doesn't really add value
- you can reactivate it with `// torchlight! {"lineNumbers": false}` if an example really need them