### PR TITLE
fix: retrofit laravel-vite changes

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite';
+import {defineConfig, loadEnv} from 'vite';
 import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
+
+    server: {
+        cors: {
+            origin: [
+                /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
+                /^https?:\/\/.*\.test(:\d+)?$/,          // Valet / Herd    (SCHEME://*.test:PORT)
+            ],
+        },
+    },
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.js'],

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import {defineConfig, loadEnv} from 'vite';
+import {defineConfig} from 'vite';
 import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({


### PR DESCRIPTION
`npm run dev` stopped working after the fixes for CVE-2025-24010. 

`laravel-vite` has been updated accordingly, but older versions have not been. 

`vite` has updates for versions 4, 5, and 6, while `laravel-vite` has only the latest version. 

This update resolves a CORS issue when using `npm run dev` with `vite >= 4.5.6`.