### PR TITLE
Provide documentation on pre and postbuild hooks

### DIFF
--- a/resources/views/docs/desktop/1/publishing/building.md
+++ b/resources/views/docs/desktop/1/publishing/building.md
@@ -25,6 +25,25 @@ your app to provide automatic updates.
 You should build your application for each platform you intend to support and test it on each platform _before_
 publishing to make sure that everything works as expected.
 
+### Running commands before and after builds
+Many applications rely on a tool such as [Vite](https://vitejs.dev/) or [Webpack](https://webpack.js.org/) to compile their CSS and JS assets before a production build.
+
+To facilitate this, NativePHP provides two hooks that you can use to run commands before and after the build process.
+
+To utilise these hooks, add the following to your `config/nativephp.php` file:
+
+```php
+'prebuild' => [
+    'npm run build:js', // Run a command before the build
+    'npm run build:css', // Run another command before the build
+],
+'postbuild' => [
+    'npm run release', // Run a command after the build
+],
+```
+
+These commands will be run in the root of your project directory and you can specify as many as required.
+
 ## Versioning
 
 For every build you create, you should change the version of your application in your app's `config/nativephp.php` file.


### PR DESCRIPTION
This pull request adds a new section to the documentation for building applications, specifically detailing how to run commands before and after the build process using hooks in the `config/nativephp.php` file.

Documentation updates:

* [`resources/views/docs/desktop/1/publishing/building.md`](diffhunk://#diff-82c2e00d609526ff9522e83b7b9b7aa8c0461ebaa4e9c464fb6430c6b421e587R28-R46): Added a section on running commands before and after builds, including examples of how to configure the `prebuild` and `postbuild` hooks in the `config/nativephp.php` file.