### PR TITLE
Add optional icon file support for Windows and macOS

### DIFF
--- a/resources/views/docs/desktop/1/getting-started/development.md
+++ b/resources/views/docs/desktop/1/getting-started/development.md
@@ -102,6 +102,8 @@ For more details, see the [Databases](/docs/digging-deeper/databases) section.
 The `native:serve` and `native:build` commands look for the following icon files when building your application:
 
 - `public/icon.png` - your main icon, used on the Desktop, Dock and app switcher.
+- `public/icon.ico` - if it exists, it is used as an icon file for Windows (optional).
+- `public/icon.icns` - if it exists, it is used as an icon file for macOS (optional).
 - `public/IconTemplate.png` - used in the Menu Bar on non-retina displays.
 - `public/IconTemplate@2x.png` - used in the Menu Bar on retina displays.
 


### PR DESCRIPTION
Updated the documentation to include `public/icon.ico` for Windows and `public/icon.icns` for macOS as optional icon files. This clarifies how these files are utilized when building desktop applications.

NativePHP/electron PR: https://github.com/NativePHP/electron/pull/216