### PR TITLE
Fixed invalid $PATH reference to $ANDROID_HOME

### DIFF
--- a/resources/views/docs/mobile/1/getting-started/installation.md
+++ b/resources/views/docs/mobile/1/getting-started/installation.md
@@ -28,7 +28,7 @@ order: 100
 ```shell
 export JAVA_HOME=$(/usr/libexec/java_home -v 17) // This isn't required if JAVA_HOME is already set in the Windows Env Variables
 export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
-export PATH=$PATH:$JAVA_HOME/bin:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools
+export PATH=$PATH:$JAVA_HOME/bin:$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/tools/bin:$ANDROID_SDK_ROOT/platform-tools
 ```
 
 #### For Windows


### PR DESCRIPTION
When following the installation steps, noticed that the Android SDK paths weren't configured correctly, and then spotted this incorrect reference in the paths.