### PR TITLE
Add documentation for new closure support

### DIFF
--- a/resources/views/docs/desktop/1/the-basics/settings.md
+++ b/resources/views/docs/desktop/1/the-basics/settings.md
@@ -27,11 +27,16 @@ To retrieve a setting, use the `get` method.
 $value = Settings::get('key');
 ```
 
-You may also provide a default value to return if the setting does not exist.
+You may also provide a default value to return if the setting does not exist. You can provide either a static default value, or a closure:
 ```php
 $value = Settings::get('key', 'default');
 ```
-If the setting does not exist, `default` will be returned.
+```php
+$value = Settings::get('key', function () {
+        return 'default';
+    });
+```
+If the setting does not exist, and no default value is provided, `null` will be returned.
 
 ### Forgetting a value
 If you want to remove a setting altogether, use the `forget` method.


### PR DESCRIPTION
Docs Update for https://github.com/NativePHP/laravel/pull/562

This pull request updates the documentation for the `Settings::get` method to clarify the use of default values and provide an example of using a closure as a default.

Documentation updates:

* [`resources/views/docs/desktop/1/the-basics/settings.md`](diffhunk://#diff-bd2d9d896efb265349d39ac862c141461ce0e71c2f7cb625d3d65b86e8ea2481L30-R39): Enhanced the explanation of the `Settings::get` method to include the option of providing a closure as a default value. Added an example demonstrating how to use a closure and clarified the behavior when no default value is provided (returns `null`).