### PR TITLE
Store licenses

### DIFF
--- a/app/Jobs/HandleCustomerSubscriptionCreatedJob.php
+++ b/app/Jobs/HandleCustomerSubscriptionCreatedJob.php
@@ -38,6 +38,7 @@ class HandleCustomerSubscriptionCreatedJob implements ShouldQueue
         }
 
         $subscriptionPlan = \App\Enums\Subscription::fromStripeSubscription($stripeSubscription);
+        $subscriptionItemId = $stripeSubscription->items->first()->id;
 
         $nameParts = explode(' ', $user->name ?? '', 2);
         $firstName = $nameParts[0] ?: null;
@@ -46,6 +47,7 @@ class HandleCustomerSubscriptionCreatedJob implements ShouldQueue
         dispatch(new CreateAnystackLicenseJob(
             $user,
             $subscriptionPlan,
+            $subscriptionItemId,
             $firstName,
             $lastName,
         ));

--- a/app/Livewire/OrderSuccess.php
+++ b/app/Livewire/OrderSuccess.php
@@ -3,7 +3,7 @@
 namespace App\Livewire;
 
 use App\Enums\Subscription;
-use Illuminate\Support\Facades\Cache;
+use App\Models\User;
 use Laravel\Cashier\Cashier;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
@@ -63,11 +63,21 @@ class OrderSuccess extends Component
             return null;
         }
 
-        if ($licenseKey = Cache::get($this->email.'.license_key')) {
-            session()->put($this->sessionKey('license_key'), $licenseKey);
+        $user = User::where('email', $this->email)->first();
+
+        if (! $user) {
+            return null;
         }
 
-        return $licenseKey;
+        $license = $user->licenses()->latest()->first();
+
+        if (! $license) {
+            return null;
+        }
+
+        session()->put($this->sessionKey('license_key'), $license->key);
+
+        return $license->key;
     }
 
     private function loadSubscription(): ?Subscription

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Cashier\SubscriptionItem;
+
+class License extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'expires_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<SubscriptionItem>
+     */
+    public function subscriptionItem(): BelongsTo
+    {
+        return $this->belongsTo(SubscriptionItem::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Cashier\Billable;
@@ -24,4 +25,12 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    /**
+     * @return HasMany<License>
+     */
+    public function licenses(): HasMany
+    {
+        return $this->hasMany(License::class);
+    }
 }

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -14,6 +14,8 @@ use Laravel\Cashier\SubscriptionItem;
  */
 class LicenseFactory extends Factory
 {
+    protected $model = License::class;
+
     public function definition(): array
     {
         return [

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Subscription;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Date;
+use Laravel\Cashier\SubscriptionItem;
+
+/**
+ * @extends Factory<License>
+ */
+class LicenseFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'subscription_item_id' => SubscriptionItem::factory(),
+            'policy_name' => fake()->randomElement(Subscription::cases())->value,
+            'key' => fake()->uuid(),
+            'created_at' => fake()->dateTimeBetween('-1 year', 'now'),
+            'updated_at' => fn (array $attrs) => $attrs['created_at'],
+            'expires_at' => fn (array $attrs) => Date::parse($attrs['created_at'])->addYear(),
+        ];
+    }
+}

--- a/database/migrations/2025_05_14_013051_create_licenses_table.php
+++ b/database/migrations/2025_05_14_013051_create_licenses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('licenses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->foreignId('subscription_item_id')->nullable();
+            $table->string('policy_name');
+            $table->string('key');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('subscription_item_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('licenses');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
- Creates `licenses` table.
- Stores newly created licenses and relates them to a user & (cashier) subscription_item_id (when available).
- Uses the db to retrieve license key for web view vs. cache.
- Updates and hardens tests.