### PR TITLE
Only create a new user upon customer.subscription.created webhook

### DIFF
--- a/app/Jobs/CreateAnystackLicenseJob.php
+++ b/app/Jobs/CreateAnystackLicenseJob.php
@@ -21,7 +21,7 @@ class CreateAnystackLicenseJob implements ShouldQueue
     public function __construct(
         public User $user,
         public Subscription $subscription,
-        public ?string $subscriptionItemId = null,
+        public ?int $subscriptionItemId = null,
         public ?string $firstName = null,
         public ?string $lastName = null,
     ) {}

--- a/app/Listeners/StripeWebhookReceivedListener.php
+++ b/app/Listeners/StripeWebhookReceivedListener.php
@@ -7,7 +7,6 @@ use Exception;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\WebhookReceived;
-use Stripe\Customer;
 
 class StripeWebhookReceivedListener
 {
@@ -16,11 +15,6 @@ class StripeWebhookReceivedListener
         Log::debug('Webhook received', $event->payload);
 
         match ($event->payload['type']) {
-            // 'customer.created' must be dispatched sync so the user is
-            // created before the cashier webhook handling is executed.
-            'customer.created' => dispatch_sync(new CreateUserFromStripeCustomer(
-                Customer::constructFrom($event->payload['data']['object'])
-            )),
             'customer.subscription.created' => $this->createUserIfNotExists($event->payload['data']['object']['customer']),
             default => null,
         };


### PR DESCRIPTION
Removes the `customer.created` webhook trigger.

Intended to reduce failures from someone attempting a purchase, the charge failing (but stripe still creating a customer, which means we still made a user), and then succeeding with a secondary+ purchase (resulting in conflicting stripe customers).