### PR TITLE
Store the Anystack id of licenses

### DIFF
--- a/app/Jobs/CreateAnystackLicenseJob.php
+++ b/app/Jobs/CreateAnystackLicenseJob.php
@@ -38,6 +38,7 @@ class CreateAnystackLicenseJob implements ShouldQueue
         $licenseData = $this->createLicense($this->user->anystack_contact_id);
 
         $license = License::create([
+            'anystack_id' => $licenseData['id'],
             'user_id' => $this->user->id,
             'subscription_item_id' => $this->subscriptionItemId,
             'policy_name' => $this->subscription->value,

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -19,6 +19,7 @@ class LicenseFactory extends Factory
     public function definition(): array
     {
         return [
+            'anystack_id' => fake()->uuid(),
             'user_id' => User::factory(),
             'subscription_item_id' => SubscriptionItem::factory(),
             'policy_name' => fake()->randomElement(Subscription::cases())->value,

--- a/database/migrations/2025_05_15_190315_alter_licenses_table.php
+++ b/database/migrations/2025_05_15_190315_alter_licenses_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->uuid('anystack_id')->nullable()->after('id');
+            $table->uuid('key')->change();
+
+            $table->unique('anystack_id');
+            $table->unique('key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropUnique(['anystack_id']);
+            $table->dropUnique(['key']);
+
+            $table->dropColumn(['anystack_id']);
+            $table->string('key')->change();
+        });
+    }
+};

--- a/tests/Feature/Jobs/CreateAnystackLicenseJobTest.php
+++ b/tests/Feature/Jobs/CreateAnystackLicenseJobTest.php
@@ -140,6 +140,7 @@ class CreateAnystackLicenseJobTest extends TestCase
         $job->handle();
 
         $this->assertDatabaseHas('licenses', [
+            'anystack_id' => 'license-123',
             'user_id' => $user->id,
             'subscription_item_id' => null,
             'policy_name' => 'max',


### PR DESCRIPTION
- Adds an `anystack_id` uuid column to the `licenses` table.
- Fills new column when creating a license on Anystack.
- Also adds unique indexes on the licenses table for `anystack_id` and `key`.