### PR TITLE
V2 purchase flow

### DIFF
--- a/app/Livewire/MobilePricing.php
+++ b/app/Livewire/MobilePricing.php
@@ -12,10 +12,10 @@ use Livewire\Component;
 class MobilePricing extends Component
 {
     protected $listeners = [
-        'email-submitted' => 'handleEmailSubmitted',
+        'purchase-request-submitted' => 'handlePurchaseRequest',
     ];
 
-    public function handleEmailSubmitted(array $data)
+    public function handlePurchaseRequest(array $data)
     {
         $user = $this->findOrCreateUser($data['email']);
 
@@ -24,15 +24,11 @@ class MobilePricing extends Component
 
     public function createCheckoutSession(string $plan, ?User $user = null)
     {
-        $user ??= Auth::user();
-
-        if (! $user) {
+        if (! ($user ??= Auth::user())) {
             return;
         }
 
-        $subscription = Subscription::tryFrom($plan);
-
-        if (! $subscription) {
+        if (! ($subscription = Subscription::tryFrom($plan))) {
             return;
         }
 
@@ -60,7 +56,14 @@ class MobilePricing extends Component
 
     private function successUrl(): string
     {
-        return Str::replace('abc', '{CHECKOUT_SESSION_ID}', route('order.success', ['checkoutSessionId' => 'abc']));
+        // This is a hack to get the route() function to work. If you try
+        // to pass {CHECKOUT_SESSION_ID} to the route function, it will
+        // throw an error.
+        return Str::replace(
+            'abc',
+            '{CHECKOUT_SESSION_ID}',
+            route('order.success', ['checkoutSessionId' => 'abc'])
+        );
     }
 
     public function render()

--- a/app/Livewire/MobilePricing.php
+++ b/app/Livewire/MobilePricing.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Enums\Subscription;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Livewire\Component;
+
+class MobilePricing extends Component
+{
+    protected $listeners = [
+        'email-submitted' => 'handleEmailSubmitted',
+    ];
+
+    public function handleEmailSubmitted(array $data)
+    {
+        $user = $this->findOrCreateUser($data['email']);
+
+        return $this->createCheckoutSession($data['plan'], $user);
+    }
+
+    public function createCheckoutSession(string $plan, ?User $user = null)
+    {
+        $user ??= Auth::user();
+
+        if (! $user) {
+            return;
+        }
+
+        $subscription = Subscription::tryFrom($plan);
+
+        if (! $subscription) {
+            return;
+        }
+
+        $user->createOrGetStripeCustomer();
+
+        $checkout = $user
+            ->newSubscription('default', $subscription->stripePriceId())
+            ->allowPromotionCodes()
+            ->checkout([
+                'success_url' => $this->successUrl(),
+                'cancel_url' => route('early-adopter'),
+            ]);
+
+        return redirect($checkout->url);
+    }
+
+    private function findOrCreateUser(string $email): User
+    {
+        return User::firstOrCreate([
+            'email' => $email,
+        ], [
+            'password' => Hash::make(Str::random(72)),
+        ]);
+    }
+
+    private function successUrl(): string
+    {
+        return Str::replace('abc', '{CHECKOUT_SESSION_ID}', route('order.success', ['checkoutSessionId' => 'abc']));
+    }
+
+    public function render()
+    {
+        return view('livewire.mobile-pricing');
+    }
+}

--- a/app/Livewire/PurchaseModal.php
+++ b/app/Livewire/PurchaseModal.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use Livewire\Attributes\Renderless;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
@@ -18,10 +19,10 @@ class PurchaseModal extends Component
         'email' => 'required|email',
     ];
 
-    public function openModal($plan): void
+    #[Renderless]
+    public function setPlan(string $plan): void
     {
         $this->selectedPlan = $plan;
-        $this->showModal = true;
     }
 
     public function closeModal(): void
@@ -31,11 +32,11 @@ class PurchaseModal extends Component
         $this->resetValidation();
     }
 
-    public function emitEmail()
+    public function submit(): void
     {
         $this->validate();
 
-        $this->dispatch('email-submitted', [
+        $this->dispatch('purchase-request-submitted', [
             'email' => $this->email,
             'plan' => $this->selectedPlan,
         ]);

--- a/app/Livewire/PurchaseModal.php
+++ b/app/Livewire/PurchaseModal.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+class PurchaseModal extends Component
+{
+    public bool $showModal = false;
+
+    #[Validate]
+    public string $email = '';
+
+    public ?string $selectedPlan = null;
+
+    protected $rules = [
+        'email' => 'required|email',
+    ];
+
+    public function openModal($plan): void
+    {
+        $this->selectedPlan = $plan;
+        $this->showModal = true;
+    }
+
+    public function closeModal(): void
+    {
+        $this->showModal = false;
+        $this->reset('email', 'selectedPlan');
+        $this->resetValidation();
+    }
+
+    public function emitEmail()
+    {
+        $this->validate();
+
+        $this->dispatch('email-submitted', [
+            'email' => $this->email,
+            'plan' => $this->selectedPlan,
+        ]);
+
+        $this->closeModal();
+    }
+
+    public function render()
+    {
+        return view('livewire.purchase-modal');
+    }
+}

--- a/resources/views/early-adopter.blade.php
+++ b/resources/views/early-adopter.blade.php
@@ -676,11 +676,14 @@
                 </p>
             </x-faq-card>
 
-            <x-faq-card question="Will there ever be a free & open source version?">
+            <x-faq-card
+                question="Will there ever be a free & open source version?"
+            >
                 <p>
-                    Yes! Once we've hit sustainability and can afford to continue
-                    investing in this project indirectly, then a version of it will
-                    be fully open source and made available for free.
+                    Yes! Once we've hit sustainability and can afford to
+                    continue investing in this project indirectly, then a
+                    version of it will be fully open source and made available
+                    for free.
                 </p>
             </x-faq-card>
 
@@ -694,9 +697,7 @@
             </x-faq-card>
 
             <x-faq-card question="When will Android support be ready?">
-                <p>
-                   It's READY! Sign up and build apps for Android today!
-                </p>
+                <p>It's READY! Sign up and build apps for Android today!</p>
             </x-faq-card>
 
             <x-faq-card question="When will the EAP end?">
@@ -744,14 +745,15 @@
             </x-faq-card>
             <x-faq-card question="Can I get an invoice?">
                 <p>
-                    If you purchased after May 6, 2025, you should get an invoice with your receipt via email.
+                    If you purchased after May 6, 2025, you should get an
+                    invoice with your receipt via email.
                 </p>
                 <p class="mt-4">
                     For purchases made before this, you simply need to
                     <a
                         href="https://zenvoice.io/p/67a61665e7a3400c73fb75af"
                         onclick="event.stopPropagation()"
-                        class="underline inline-block"
+                        class="inline-block underline"
                     >
                         follow the instructions here
                     </a>
@@ -843,5 +845,4 @@
             </p>
         </article>
     </section>
-    <!-- Purchase Modal Component is now included in the mobile-pricing component -->
 </x-layout>

--- a/resources/views/early-adopter.blade.php
+++ b/resources/views/early-adopter.blade.php
@@ -608,7 +608,7 @@
     </section>
 
     {{-- Pricing Section --}}
-    <x-mobile-pricing />
+    <livewire:mobile-pricing />
 
     {{-- Testimonials Section --}}
     {{-- <x-testimonials /> --}}
@@ -843,4 +843,5 @@
             </p>
         </article>
     </section>
+    <!-- Purchase Modal Component is now included in the mobile-pricing component -->
 </x-layout>

--- a/resources/views/livewire/mobile-pricing.blade.php
+++ b/resources/views/livewire/mobile-pricing.blade.php
@@ -118,14 +118,25 @@
                 </p>
             </div>
 
-            {{-- Button --}}
-            <a
-                href="{{ \App\Enums\Subscription::Mini->stripePaymentLink() }}"
-                class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
-                aria-label="Get started with Mini plan"
-            >
-                Get started
-            </a>
+            @auth
+                <button
+                    type="button"
+                    wire:click="createCheckoutSession('mini')"
+                    class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
+                    aria-label="Get started with Mini plan"
+                >
+                    Get started
+                </button>
+            @else
+                <button
+                    type="button"
+                    @click="$dispatch('open-purchase-modal', { plan: 'mini' })"
+                    class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
+                    aria-label="Get started with Mini plan"
+                >
+                    Get started
+                </button>
+            @endauth
 
             {{-- Features --}}
             <div
@@ -281,14 +292,25 @@
                 </p>
             </div>
 
-            {{-- Button --}}
-            <a
-                href="{{ \App\Enums\Subscription::Pro->stripePaymentLink() }}"
-                class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
-                aria-label="Get started with Pro plan"
-            >
-                Get started
-            </a>
+            @auth
+                <button
+                    type="button"
+                    wire:click="createCheckoutSession('pro')"
+                    class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
+                    aria-label="Get started with Pro plan"
+                >
+                    Get started
+                </button>
+            @else
+                <button
+                    type="button"
+                    @click="$dispatch('open-purchase-modal', { plan: 'pro' })"
+                    class="my-5 block w-full rounded-2xl bg-zinc-200 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
+                    aria-label="Get started with Pro plan"
+                >
+                    Get started
+                </button>
+            @endauth
 
             {{-- Features --}}
             <div
@@ -452,14 +474,25 @@
                 </p>
             </div>
 
-            {{-- Button --}}
-            <a
-                href="{{ \App\Enums\Subscription::Max->stripePaymentLink() }}"
-                class="my-5 block w-full rounded-2xl bg-zinc-800 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
-                aria-label="Get started with Max plan"
-            >
-                Get started
-            </a>
+            @auth
+                <button
+                    type="button"
+                    wire:click="createCheckoutSession('max')"
+                    class="my-5 block w-full rounded-2xl bg-zinc-800 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
+                    aria-label="Get started with Max plan"
+                >
+                    Get started
+                </button>
+            @else
+                <button
+                    type="button"
+                    @click="$dispatch('open-purchase-modal', { plan: 'max' })"
+                    class="my-5 block w-full rounded-2xl bg-zinc-800 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
+                    aria-label="Get started with Max plan"
+                >
+                    Get started
+                </button>
+            @endauth
 
             {{-- Features --}}
             <div
@@ -569,4 +602,7 @@
             </div>
         </div>
     </div>
+    @guest
+        <livewire:purchase-modal />
+    @endguest
 </section>

--- a/resources/views/livewire/purchase-modal.blade.php
+++ b/resources/views/livewire/purchase-modal.blade.php
@@ -1,0 +1,96 @@
+<div>
+    <div
+        x-data="{
+            open: @entangle('showModal'),
+            selectedPlan: @entangle('selectedPlan'),
+        }"
+        @open-purchase-modal.window="
+            open = true;
+            selectedPlan = $event.detail.plan;
+            $wire.openModal($event.detail.plan);
+        "
+    >
+        <!-- Modal Backdrop -->
+        <div
+            x-show="open"
+            x-transition:enter="transition duration-300 ease-out"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
+            x-transition:leave="transition duration-200 ease-in"
+            x-transition:leave-start="opacity-100"
+            x-transition:leave-end="opacity-0"
+            class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+            x-cloak
+        ></div>
+
+        <!-- Modal Content -->
+        <div
+            x-show="open"
+            x-transition:enter="transition duration-300 ease-out"
+            x-transition:enter-start="scale-95 opacity-0"
+            x-transition:enter-end="scale-100 opacity-100"
+            x-transition:leave="transition duration-200 ease-in"
+            x-transition:leave-start="scale-100 opacity-100"
+            x-transition:leave-end="scale-95 opacity-0"
+            class="fixed inset-0 z-50 flex items-center justify-center p-4"
+            x-cloak
+        >
+            <div
+                @click.away="open = false"
+                class="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl dark:bg-mirage"
+            >
+                <div class="mb-6 text-center">
+                    <h3 class="text-xl font-semibold dark:text-white">
+                        Get Started with NativePHP
+                    </h3>
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                        Enter your email to continue to checkout
+                    </p>
+                </div>
+
+                <form
+                    wire:submit.prevent="emitEmail"
+                    class="space-y-6"
+                >
+                    <div>
+                        <label
+                            for="email"
+                            class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >
+                            Email Address
+                        </label>
+                        <input
+                            type="email"
+                            id="email"
+                            wire:model.blur="email"
+                            class="w-full rounded-lg border border-gray-300 px-4 py-2.5 focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-purple-400"
+                            placeholder="your@email.com"
+                            required
+                        />
+                        @error('email')
+                            <p class="mt-1 text-sm text-red-600">
+                                {{ $message }}
+                            </p>
+                        @enderror
+                    </div>
+
+                    <div class="flex items-center justify-between gap-3">
+                        <button
+                            type="button"
+                            wire:click="closeModal"
+                            class="rounded-xl bg-zinc-200 px-8 py-4 text-center text-sm font-medium transition duration-200 ease-in-out hover:bg-zinc-800 hover:text-white dark:bg-slate-700/30 dark:hover:bg-slate-700/40"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            class="rounded-xl bg-zinc-800 px-8 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
+                        >
+                            Next
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/purchase-modal.blade.php
+++ b/resources/views/livewire/purchase-modal.blade.php
@@ -50,7 +50,7 @@
 
                 <form
                     wire:submit.prevent="emitEmail"
-                    class="space-y-6"
+                    class="space-y-8"
                 >
                     <div>
                         <label
@@ -63,9 +63,10 @@
                             type="email"
                             id="email"
                             wire:model.blur="email"
-                            class="w-full rounded-lg border border-gray-300 px-4 py-2.5 focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-purple-400"
+                            class="w-full rounded-lg border border-gray-300 px-4 py-2.5 focus:border-purple-400 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                             placeholder="your@email.com"
                             required
+                            x-effect="if (open) $nextTick(() => $el.focus())"
                         />
                         @error('email')
                             <p class="mt-1 text-sm text-red-600">

--- a/resources/views/livewire/purchase-modal.blade.php
+++ b/resources/views/livewire/purchase-modal.blade.php
@@ -2,12 +2,10 @@
     <div
         x-data="{
             open: @entangle('showModal'),
-            selectedPlan: @entangle('selectedPlan'),
         }"
         @open-purchase-modal.window="
             open = true;
-            selectedPlan = $event.detail.plan;
-            $wire.openModal($event.detail.plan);
+            $wire.setPlan($event.detail.plan);
         "
     >
         <!-- Modal Backdrop -->
@@ -23,7 +21,6 @@
             x-cloak
         ></div>
 
-        <!-- Modal Content -->
         <div
             x-show="open"
             x-transition:enter="transition duration-300 ease-out"
@@ -49,7 +46,7 @@
                 </div>
 
                 <form
-                    wire:submit.prevent="emitEmail"
+                    wire:submit.prevent="submit"
                     class="space-y-8"
                 >
                     <div>

--- a/tests/Feature/Livewire/PurchaseModalTest.php
+++ b/tests/Feature/Livewire/PurchaseModalTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\PurchaseModal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PurchaseModalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function purchase_modal_can_be_opened_with_plan()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->call('openModal', 'mini')
+            ->assertSet('selectedPlan', 'mini')
+            ->assertSet('showModal', true);
+    }
+
+    #[Test]
+    public function purchase_modal_can_be_closed()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->set('showModal', true)
+            ->set('email', 'test@example.com')
+            ->set('selectedPlan', 'mini')
+            ->call('closeModal')
+            ->assertSet('showModal', false)
+            ->assertSet('email', '')
+            ->assertSet('selectedPlan', null);
+    }
+
+    #[Test]
+    public function purchase_modal_validates_email()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->call('openModal', 'mini')
+            ->set('email', 'invalid-email')
+            ->call('emitEmail')
+            ->assertHasErrors(['email' => 'email']);
+    }
+
+    #[Test]
+    public function purchase_modal_requires_email()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->call('openModal', 'mini')
+            ->set('email', '')
+            ->call('emitEmail')
+            ->assertHasErrors(['email' => 'required']);
+    }
+
+    #[Test]
+    public function purchase_modal_emits_event_with_valid_email()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->call('openModal', 'mini')
+            ->set('email', 'valid@example.com')
+            ->call('emitEmail')
+            ->assertDispatched('email-submitted', [
+                'email' => 'valid@example.com',
+                'plan' => 'mini',
+            ]);
+    }
+
+    #[Test]
+    public function purchase_modal_closes_after_emitting_event()
+    {
+        Livewire::test(PurchaseModal::class)
+            ->call('openModal', 'mini')
+            ->set('email', 'valid@example.com')
+            ->call('emitEmail')
+            ->assertSet('showModal', false);
+    }
+
+    #[Test]
+    public function purchase_modal_can_be_opened_via_alpine_event()
+    {
+        $component = Livewire::test(PurchaseModal::class);
+
+        // Simulate the Alpine.js event
+        $component->dispatch('open-purchase-modal', ['plan' => 'pro'])
+            ->assertDispatched('open-purchase-modal');
+
+        // Since we can't directly test Alpine.js event handling in PHPUnit,
+        // we'll verify that the openModal method works as expected
+        $component->call('openModal', 'pro')
+            ->assertSet('selectedPlan', 'pro')
+            ->assertSet('showModal', true);
+    }
+}

--- a/tests/Feature/Livewire/PurchaseModalTest.php
+++ b/tests/Feature/Livewire/PurchaseModalTest.php
@@ -3,22 +3,18 @@
 namespace Tests\Feature\Livewire;
 
 use App\Livewire\PurchaseModal;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class PurchaseModalTest extends TestCase
 {
-    use RefreshDatabase;
-
     #[Test]
-    public function purchase_modal_can_be_opened_with_plan()
+    public function purchase_modal_can_set_a_plan()
     {
         Livewire::test(PurchaseModal::class)
-            ->call('openModal', 'mini')
-            ->assertSet('selectedPlan', 'mini')
-            ->assertSet('showModal', true);
+            ->call('setPlan', 'mini')
+            ->assertSet('selectedPlan', 'mini');
     }
 
     #[Test]
@@ -38,9 +34,8 @@ class PurchaseModalTest extends TestCase
     public function purchase_modal_validates_email()
     {
         Livewire::test(PurchaseModal::class)
-            ->call('openModal', 'mini')
             ->set('email', 'invalid-email')
-            ->call('emitEmail')
+            ->call('submit')
             ->assertHasErrors(['email' => 'email']);
     }
 
@@ -48,20 +43,19 @@ class PurchaseModalTest extends TestCase
     public function purchase_modal_requires_email()
     {
         Livewire::test(PurchaseModal::class)
-            ->call('openModal', 'mini')
             ->set('email', '')
-            ->call('emitEmail')
+            ->call('submit')
             ->assertHasErrors(['email' => 'required']);
     }
 
     #[Test]
-    public function purchase_modal_emits_event_with_valid_email()
+    public function test_submit_action()
     {
         Livewire::test(PurchaseModal::class)
-            ->call('openModal', 'mini')
+            ->call('setPlan', 'mini')
             ->set('email', 'valid@example.com')
-            ->call('emitEmail')
-            ->assertDispatched('email-submitted', [
+            ->call('submit')
+            ->assertDispatched('purchase-request-submitted', [
                 'email' => 'valid@example.com',
                 'plan' => 'mini',
             ]);
@@ -71,25 +65,9 @@ class PurchaseModalTest extends TestCase
     public function purchase_modal_closes_after_emitting_event()
     {
         Livewire::test(PurchaseModal::class)
-            ->call('openModal', 'mini')
+            ->call('setPlan', 'mini')
             ->set('email', 'valid@example.com')
-            ->call('emitEmail')
+            ->call('submit')
             ->assertSet('showModal', false);
-    }
-
-    #[Test]
-    public function purchase_modal_can_be_opened_via_alpine_event()
-    {
-        $component = Livewire::test(PurchaseModal::class);
-
-        // Simulate the Alpine.js event
-        $component->dispatch('open-purchase-modal', ['plan' => 'pro'])
-            ->assertDispatched('open-purchase-modal');
-
-        // Since we can't directly test Alpine.js event handling in PHPUnit,
-        // we'll verify that the openModal method works as expected
-        $component->call('openModal', 'pro')
-            ->assertSet('selectedPlan', 'pro')
-            ->assertSet('showModal', true);
     }
 }

--- a/tests/Feature/MobilePricingTest.php
+++ b/tests/Feature/MobilePricingTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\MobilePricing;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MobilePricingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $testPriceId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Make sure we're using Stripe test keys
+        $this->assertStringStartsWith('sk_test_', config('cashier.secret'));
+
+        // Create a test price in Stripe for our tests
+        $product = Cashier::stripe()->products->create([
+            'name' => 'Test Product',
+            'description' => 'Created for testing',
+        ]);
+
+        $price = Cashier::stripe()->prices->create([
+            'product' => $product->id,
+            'unit_amount' => 5000, // $50.00
+            'currency' => 'usd',
+            'recurring' => [
+                'interval' => 'year',
+            ],
+        ]);
+
+        $this->testPriceId = $price->id;
+
+        // Configure our test price ID in the app
+        Config::set('subscriptions.plans.mini.stripe_price_id', $this->testPriceId);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up Stripe resources
+        if (isset($this->testPriceId)) {
+            $price = Cashier::stripe()->prices->retrieve($this->testPriceId);
+            Cashier::stripe()->products->delete($price->product, []);
+            // Prices cannot be deleted in Stripe, but the product can be
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function authenticated_users_can_directly_create_checkout_session()
+    {
+        // Create and authenticate a user
+        $user = User::factory()->create();
+        Auth::login($user);
+
+        // Test the component with real Stripe integration
+        $component = Livewire::test(MobilePricing::class);
+
+        // Call the method and assert the redirect
+        $response = $component->call('createCheckoutSession', 'mini', $user);
+
+        // The response should be a redirect to Stripe checkout
+        $response->assertRedirect();
+        $redirectUrl = $response->effects['redirect'];
+
+        // Verify it's a Stripe checkout URL
+        $this->assertStringContainsString('checkout.stripe.com', $redirectUrl);
+
+        // Verify the user has a Stripe customer ID
+        $user->refresh();
+        $this->assertNotNull($user->stripe_id);
+
+        // Verify the customer exists in Stripe
+        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
+        $this->assertEquals($user->email, $customer->email);
+    }
+
+    #[Test]
+    public function guest_users_see_purchase_modal_component()
+    {
+        // Make sure no user is authenticated
+        Auth::logout();
+
+        $response = $this->get(route('early-adopter'));
+
+        // Assert that the page contains the purchase modal component
+        $response->assertSeeLivewire('purchase-modal');
+    }
+
+    #[Test]
+    public function it_can_find_or_create_user_by_email()
+    {
+        $email = 'test-find-create-'.Str::random(10).'@example.com';
+
+        // Test with a new email
+        $component = Livewire::test(MobilePricing::class);
+        $method = new \ReflectionMethod(MobilePricing::class, 'findOrCreateUser');
+        $method->setAccessible(true);
+
+        $user = $method->invoke($component->instance(), $email);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals($email, $user->email);
+        $this->assertDatabaseHas('users', ['email' => $email]);
+
+        // Test with an existing email
+        $existingEmail = 'existing-'.Str::random(10).'@example.com';
+        $existingUser = User::factory()->create(['email' => $existingEmail]);
+        $foundUser = $method->invoke($component->instance(), $existingEmail);
+
+        $this->assertEquals($existingUser->id, $foundUser->id);
+    }
+
+    #[Test]
+    public function it_handles_email_submission_and_creates_checkout_session()
+    {
+        $email = 'test-email-submission-'.Str::random(10).'@example.com';
+
+        // Test the component with real Stripe integration
+        $component = Livewire::test(MobilePricing::class);
+
+        // Call the method with test data
+        $response = $component->call('handleEmailSubmitted', [
+            'email' => $email,
+            'plan' => 'mini',
+        ]);
+
+        // The response should be a redirect to Stripe checkout
+        $response->assertRedirect();
+        $redirectUrl = $response->effects['redirect'];
+
+        // Verify it's a Stripe checkout URL
+        $this->assertStringContainsString('checkout.stripe.com', $redirectUrl);
+
+        // Verify a user was created with the email
+        $this->assertDatabaseHas('users', ['email' => $email]);
+
+        // Verify the user has a Stripe customer ID
+        $user = User::where('email', $email)->first();
+        $this->assertNotNull($user->stripe_id);
+
+        // Verify the customer exists in Stripe
+        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
+        $this->assertEquals($email, $customer->email);
+    }
+
+    #[Test]
+    public function success_url_contains_checkout_session_id_placeholder()
+    {
+        $component = Livewire::test(MobilePricing::class);
+        $method = new \ReflectionMethod(MobilePricing::class, 'successUrl');
+        $method->setAccessible(true);
+
+        $url = $method->invoke($component->instance());
+
+        $this->assertStringContainsString('{CHECKOUT_SESSION_ID}', $url);
+    }
+
+    #[Test]
+    public function it_creates_stripe_customer_for_new_users()
+    {
+        $email = 'new-stripe-customer-'.Str::random(10).'@example.com';
+
+        // Create a new user
+        $user = User::create([
+            'email' => $email,
+            'password' => Hash::make(Str::random(72)),
+        ]);
+
+        // Test the component with real Stripe integration
+        $component = Livewire::test(MobilePricing::class);
+
+        // Call the method and assert the redirect
+        $response = $component->call('createCheckoutSession', 'mini', $user);
+
+        // Refresh the user to get the updated stripe_id
+        $user->refresh();
+
+        // Verify the user has a Stripe customer ID
+        $this->assertNotNull($user->stripe_id);
+
+        // Verify the customer exists in Stripe
+        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
+        $this->assertEquals($email, $customer->email);
+    }
+
+    #[Test]
+    public function it_uses_existing_stripe_customer_for_existing_users()
+    {
+        $email = 'existing-stripe-customer-'.Str::random(10).'@example.com';
+
+        // Create a new user
+        $user = User::create([
+            'email' => $email,
+            'password' => Hash::make(Str::random(72)),
+        ]);
+
+        // Create a Stripe customer for this user
+        $user->createAsStripeCustomer();
+        $originalStripeId = $user->stripe_id;
+
+        // Test the component with real Stripe integration
+        $component = Livewire::test(MobilePricing::class);
+
+        // Call the method and assert the redirect
+        $response = $component->call('createCheckoutSession', 'mini', $user);
+
+        // Refresh the user to get the updated stripe_id
+        $user->refresh();
+
+        // Verify the user still has the same Stripe customer ID
+        $this->assertEquals($originalStripeId, $user->stripe_id);
+    }
+}

--- a/tests/Feature/MobilePricingTest.php
+++ b/tests/Feature/MobilePricingTest.php
@@ -6,10 +6,6 @@ use App\Livewire\MobilePricing;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
-use Laravel\Cashier\Cashier;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -18,211 +14,50 @@ class MobilePricingTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected string $testPriceId;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Make sure we're using Stripe test keys
-        $this->assertStringStartsWith('sk_test_', config('cashier.secret'));
-
-        // Create a test price in Stripe for our tests
-        $product = Cashier::stripe()->products->create([
-            'name' => 'Test Product',
-            'description' => 'Created for testing',
-        ]);
-
-        $price = Cashier::stripe()->prices->create([
-            'product' => $product->id,
-            'unit_amount' => 5000, // $50.00
-            'currency' => 'usd',
-            'recurring' => [
-                'interval' => 'year',
-            ],
-        ]);
-
-        $this->testPriceId = $price->id;
-
-        // Configure our test price ID in the app
-        Config::set('subscriptions.plans.mini.stripe_price_id', $this->testPriceId);
-    }
-
-    protected function tearDown(): void
-    {
-        // Clean up Stripe resources
-        if (isset($this->testPriceId)) {
-            $price = Cashier::stripe()->prices->retrieve($this->testPriceId);
-            Cashier::stripe()->products->delete($price->product, []);
-            // Prices cannot be deleted in Stripe, but the product can be
-        }
-
-        parent::tearDown();
-    }
-
     #[Test]
-    public function authenticated_users_can_directly_create_checkout_session()
+    public function authenticated_users_will_directly_create_checkout_session()
     {
-        // Create and authenticate a user
         $user = User::factory()->create();
         Auth::login($user);
 
-        // Test the component with real Stripe integration
         $component = Livewire::test(MobilePricing::class);
-
-        // Call the method and assert the redirect
-        $response = $component->call('createCheckoutSession', 'mini', $user);
-
-        // The response should be a redirect to Stripe checkout
-        $response->assertRedirect();
-        $redirectUrl = $response->effects['redirect'];
-
-        // Verify it's a Stripe checkout URL
-        $this->assertStringContainsString('checkout.stripe.com', $redirectUrl);
-
-        // Verify the user has a Stripe customer ID
-        $user->refresh();
-        $this->assertNotNull($user->stripe_id);
-
-        // Verify the customer exists in Stripe
-        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
-        $this->assertEquals($user->email, $customer->email);
+        $component->assertSeeHtml([
+            'wire:click="createCheckoutSession(\'mini\')"',
+            'wire:click="createCheckoutSession(\'pro\')"',
+            'wire:click="createCheckoutSession(\'max\')"',
+        ]);
+        $component->assertDontSeeHtml([
+            '@click="$dispatch(\'open-purchase-modal\', { plan: \'mini\' })"',
+            '@click="$dispatch(\'open-purchase-modal\', { plan: \'pro\' })"',
+            '@click="$dispatch(\'open-purchase-modal\', { plan: \'max\' })"',
+        ]);
     }
 
     #[Test]
     public function guest_users_see_purchase_modal_component()
     {
-        // Make sure no user is authenticated
         Auth::logout();
 
-        $response = $this->get(route('early-adopter'));
-
-        // Assert that the page contains the purchase modal component
-        $response->assertSeeLivewire('purchase-modal');
+        Livewire::test(MobilePricing::class)
+            ->assertSeeLivewire('purchase-modal')
+            ->assertSeeHtml([
+                '@click="$dispatch(\'open-purchase-modal\', { plan: \'mini\' })"',
+                '@click="$dispatch(\'open-purchase-modal\', { plan: \'pro\' })"',
+                '@click="$dispatch(\'open-purchase-modal\', { plan: \'max\' })"',
+            ])
+            ->assertDontSeeHtml([
+                'wire:click="createCheckoutSession(\'mini\')"',
+                'wire:click="createCheckoutSession(\'pro\')"',
+                'wire:click="createCheckoutSession(\'max\')"',
+            ]);
     }
 
     #[Test]
-    public function it_can_find_or_create_user_by_email()
+    public function authenticated_users_do_not_see_purchase_modal_component()
     {
-        $email = 'test-find-create-'.Str::random(10).'@example.com';
+        Auth::login(User::factory()->create());
 
-        // Test with a new email
-        $component = Livewire::test(MobilePricing::class);
-        $method = new \ReflectionMethod(MobilePricing::class, 'findOrCreateUser');
-        $method->setAccessible(true);
-
-        $user = $method->invoke($component->instance(), $email);
-
-        $this->assertInstanceOf(User::class, $user);
-        $this->assertEquals($email, $user->email);
-        $this->assertDatabaseHas('users', ['email' => $email]);
-
-        // Test with an existing email
-        $existingEmail = 'existing-'.Str::random(10).'@example.com';
-        $existingUser = User::factory()->create(['email' => $existingEmail]);
-        $foundUser = $method->invoke($component->instance(), $existingEmail);
-
-        $this->assertEquals($existingUser->id, $foundUser->id);
-    }
-
-    #[Test]
-    public function it_handles_email_submission_and_creates_checkout_session()
-    {
-        $email = 'test-email-submission-'.Str::random(10).'@example.com';
-
-        // Test the component with real Stripe integration
-        $component = Livewire::test(MobilePricing::class);
-
-        // Call the method with test data
-        $response = $component->call('handleEmailSubmitted', [
-            'email' => $email,
-            'plan' => 'mini',
-        ]);
-
-        // The response should be a redirect to Stripe checkout
-        $response->assertRedirect();
-        $redirectUrl = $response->effects['redirect'];
-
-        // Verify it's a Stripe checkout URL
-        $this->assertStringContainsString('checkout.stripe.com', $redirectUrl);
-
-        // Verify a user was created with the email
-        $this->assertDatabaseHas('users', ['email' => $email]);
-
-        // Verify the user has a Stripe customer ID
-        $user = User::where('email', $email)->first();
-        $this->assertNotNull($user->stripe_id);
-
-        // Verify the customer exists in Stripe
-        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
-        $this->assertEquals($email, $customer->email);
-    }
-
-    #[Test]
-    public function success_url_contains_checkout_session_id_placeholder()
-    {
-        $component = Livewire::test(MobilePricing::class);
-        $method = new \ReflectionMethod(MobilePricing::class, 'successUrl');
-        $method->setAccessible(true);
-
-        $url = $method->invoke($component->instance());
-
-        $this->assertStringContainsString('{CHECKOUT_SESSION_ID}', $url);
-    }
-
-    #[Test]
-    public function it_creates_stripe_customer_for_new_users()
-    {
-        $email = 'new-stripe-customer-'.Str::random(10).'@example.com';
-
-        // Create a new user
-        $user = User::create([
-            'email' => $email,
-            'password' => Hash::make(Str::random(72)),
-        ]);
-
-        // Test the component with real Stripe integration
-        $component = Livewire::test(MobilePricing::class);
-
-        // Call the method and assert the redirect
-        $response = $component->call('createCheckoutSession', 'mini', $user);
-
-        // Refresh the user to get the updated stripe_id
-        $user->refresh();
-
-        // Verify the user has a Stripe customer ID
-        $this->assertNotNull($user->stripe_id);
-
-        // Verify the customer exists in Stripe
-        $customer = Cashier::stripe()->customers->retrieve($user->stripe_id);
-        $this->assertEquals($email, $customer->email);
-    }
-
-    #[Test]
-    public function it_uses_existing_stripe_customer_for_existing_users()
-    {
-        $email = 'existing-stripe-customer-'.Str::random(10).'@example.com';
-
-        // Create a new user
-        $user = User::create([
-            'email' => $email,
-            'password' => Hash::make(Str::random(72)),
-        ]);
-
-        // Create a Stripe customer for this user
-        $user->createAsStripeCustomer();
-        $originalStripeId = $user->stripe_id;
-
-        // Test the component with real Stripe integration
-        $component = Livewire::test(MobilePricing::class);
-
-        // Call the method and assert the redirect
-        $response = $component->call('createCheckoutSession', 'mini', $user);
-
-        // Refresh the user to get the updated stripe_id
-        $user->refresh();
-
-        // Verify the user still has the same Stripe customer ID
-        $this->assertEquals($originalStripeId, $user->stripe_id);
+        Livewire::test(MobilePricing::class)
+            ->assertDontSeeLivewire('purchase-modal');
     }
 }

--- a/tests/Feature/MobileRouteTest.php
+++ b/tests/Feature/MobileRouteTest.php
@@ -2,27 +2,26 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MobileRouteTest extends TestCase
 {
     #[Test]
-    public function mobile_route_includes_stripe_payment_links()
+    public function mobile_route_does_not_include_stripe_payment_links()
     {
-        $mockLinks = [
-            'mini' => ['stripe_payment_link' => 'https://buy.stripe.com/mini-payment'],
-            'pro' => ['stripe_payment_link' => 'https://buy.stripe.com/pro-payment'],
-            'max' => ['stripe_payment_link' => 'https://buy.stripe.com/max-payment'],
-        ];
+        $this
+            ->withoutVite()
+            ->get(route('early-adopter'))
+            ->assertDontSee('buy.stripe.com');
+    }
 
-        Config::set('subscriptions.plans', $mockLinks);
-
-        $response = $this->withoutVite()->get(route('early-adopter'))->getContent();
-
-        $this->assertStringContainsString($mockLinks['mini']['stripe_payment_link'], $response);
-        $this->assertStringContainsString($mockLinks['pro']['stripe_payment_link'], $response);
-        $this->assertStringContainsString($mockLinks['max']['stripe_payment_link'], $response);
+    #[Test]
+    public function mobile_route_includes_mobile_pricing_livewire_component()
+    {
+        $this
+            ->withoutVite()
+            ->get(route('early-adopter'))
+            ->assertSeeLivewire('mobile-pricing');
     }
 }


### PR DESCRIPTION
- When a guest visits the `/mobile` route (everyone, before auth is in place) and clicks one of the buttons to purchase a license, we'll now show them a modal to collect their email.
- Upon submitting the email, we'll determine if a user already exists for that email. If one does not, we create one with the supplied email. Then, we create a stripe customer record for the user record if necessary and then redirect to a customer-specific checkout session in Stripe for the correct plan.
- Once a purchase is completed, we do the regular work:
    - Cashier handles subscription info for the existing user record.
    - We create an anystack contact (if necessary) and create a license.

This has been coded to also handle an authenticated user visiting the `/mobile` page. When this happens, we do not show a modal and upon clicking one of buttons, we would immediately redirect to a stripe checkout.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/9a9da0c5-a2d6-4256-9302-6dfcf8f72c70" />
<img width="988" alt="image" src="https://github.com/user-attachments/assets/297f1028-6ab1-4b60-a12a-befd7897cc75" />
^^^ Note the email is fixed in this screenshot, indicating a customer-specific checkout session for the correct user.
