### PR TITLE
Create a license upon invoice.paid event

### DIFF
--- a/app/Exceptions/InvalidStateException.php
+++ b/app/Exceptions/InvalidStateException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class InvalidStateException extends Exception
+{
+    //
+}

--- a/app/Jobs/HandleInvoicePaidJob.php
+++ b/app/Jobs/HandleInvoicePaidJob.php
@@ -20,6 +20,8 @@ class HandleInvoicePaidJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public int $maxExceptions = 1;
+
     public function __construct(public Invoice $invoice) {}
 
     public function handle(): void

--- a/app/Jobs/HandleInvoicePaidJob.php
+++ b/app/Jobs/HandleInvoicePaidJob.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\Subscription;
+use App\Exceptions\InvalidStateException;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\SubscriptionItem;
+use Stripe\Invoice;
+use UnexpectedValueException;
+
+class HandleInvoicePaidJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Invoice $invoice) {}
+
+    public function handle(): void
+    {
+        match ($this->invoice->billing_reason) {
+            Invoice::BILLING_REASON_SUBSCRIPTION_CREATE => $this->createLicense(),
+            Invoice::BILLING_REASON_SUBSCRIPTION_UPDATE => null, // TODO: Handle subscription update
+            Invoice::BILLING_REASON_SUBSCRIPTION_CYCLE => null, // TODO: Handle subscription renewal
+            default => null,
+        };
+    }
+
+    private function createLicense(): void
+    {
+        // Assert the invoice line item is for a price_id that relates to a license plan.
+        $plan = Subscription::fromStripePriceId($this->invoice->lines->first()->price->id);
+
+        // Assert the invoice line item relates to a subscription and has a subscription item id.
+        if (blank($subscriptionItemId = $this->invoice->lines->first()->subscription_item)) {
+            throw new UnexpectedValueException('Failed to retrieve the Stripe subscription item id from invoice lines.');
+        }
+
+        // Assert we have a subscription item record for this subscription item id.
+        $subscriptionItemModel = SubscriptionItem::query()->where('stripe_id', $subscriptionItemId)->firstOrFail();
+
+        // Assert we don't already have an existing license for this subscription item.
+        if ($license = License::query()->whereBelongsTo($subscriptionItemModel)->first()) {
+            throw new InvalidStateException("A license [{$license->id}] already exists for subscription item [{$subscriptionItemModel->id}].");
+        }
+
+        $user = $this->billable();
+
+        dispatch(new CreateAnystackLicenseJob(
+            $user,
+            $plan,
+            $subscriptionItemModel->id,
+            $user->first_name,
+            $user->last_name,
+        ));
+    }
+
+    private function billable(): User
+    {
+        if ($user = Cashier::findBillable($this->invoice->customer)) {
+            return $user;
+        }
+
+        $customer = Cashier::stripe()->customers->retrieve($this->invoice->customer);
+
+        dispatch_sync(new CreateUserFromStripeCustomer($customer));
+
+        return Cashier::findBillable($this->invoice->customer);
+    }
+}

--- a/app/Listeners/StripeWebhookHandledListener.php
+++ b/app/Listeners/StripeWebhookHandledListener.php
@@ -2,7 +2,6 @@
 
 namespace App\Listeners;
 
-use App\Jobs\HandleCustomerSubscriptionCreatedJob;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Events\WebhookHandled;
 
@@ -11,10 +10,5 @@ class StripeWebhookHandledListener
     public function handle(WebhookHandled $event): void
     {
         Log::debug('Webhook handled', $event->payload);
-
-        match ($event->payload['type']) {
-            'customer.subscription.created' => dispatch(new HandleCustomerSubscriptionCreatedJob($event)),
-            default => null,
-        };
     }
 }


### PR DESCRIPTION
Added `invoice.paid` to our production webhook events on Stripe.

I tested this locally for:
- a new user performs a checkout and pays successfully (license created)
- a new user performs a checkout, payment fails, and then payment succeeds (license created)
- a user performs a checkout, payment fails, and then they use the billing portal to pay the invoice at a slightly later time (license created)
- an existing user that doesn't already exist on stripe yet already has a license (old anystack contacts) performs a checkout and pays (new license created)

I can still think of some edge cases this won't handle. I will get going on those as soon as I can.

Also... definitely some refactoring that needs to be done to clean this all up once we've hit a steady state and our logic stops changing. There are a lot of code smells in here from moving fast that I'm not too happy about.