### PR TITLE
Add documentation for context menu

### DIFF
--- a/resources/views/docs/desktop/1/the-basics/application-menu.md
+++ b/resources/views/docs/desktop/1/the-basics/application-menu.md
@@ -428,7 +428,7 @@ Menu::make()
 
 ## Context Menu
 
-You may need to add custom context menu to the elements in the views of your application and override the default one.
+You may need to add custom native context menu to the elements in the views of your application and override the default one.
 
 You can use the `Native` JavaScript object provvided by NativePHP's preload script.
 

--- a/resources/views/docs/desktop/1/the-basics/application-menu.md
+++ b/resources/views/docs/desktop/1/the-basics/application-menu.md
@@ -428,9 +428,9 @@ Menu::make()
 
 ## Context Menu
 
-You may need to add custom native context menu to the elements in the views of your application and override the default one.
+You may wish to add a custom native context menu to the elements in the views of your application and override the default one.
 
-You can use the `Native` JavaScript object provvided by NativePHP's preload script.
+You can use the `Native` JavaScript helper provided by NativePHP's preload script.
 
 This object exposes the `contextMenu()` method which takes an array of objects that matches the 
 [MenuItem](https://www.electronjs.org/docs/latest/api/menu-item) constructor's `options` argument.
@@ -448,7 +448,7 @@ Native.contextMenu([
 ]);
 ```
 
-You can use the `contextmenu` event to capture the user's action and show your menu:
+You can listen for the `contextmenu` event to show your custom context menu:
 
 ```js
 const element = document.getElementById('your-element');

--- a/resources/views/docs/desktop/1/the-basics/application-menu.md
+++ b/resources/views/docs/desktop/1/the-basics/application-menu.md
@@ -425,3 +425,60 @@ Menu::make()
     Menu::quit(),
 );
 ```
+
+## Context Menu
+
+You may need to add custom context menu to the elements in the views of your application and override the default one.
+
+You can use the `Native` JavaScript object provvided by NativePHP's preload script.
+
+This object exposes the `contextMenu()` method which takes an array of objects that matches the 
+[MenuItem](https://www.electronjs.org/docs/latest/api/menu-item) constructor's `options` argument.
+
+```js
+Native.contextMenu([
+    {
+        label: 'Edit',
+        accelerator: 'e',
+        click(menuItem, window, event) {
+            // Code to execute when the menu item is clicked
+        },
+    },
+    // Other options
+]);
+```
+
+You can use the `contextmenu` event to capture the user's action and show your menu:
+
+```js
+const element = document.getElementById('your-element');
+
+element.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+
+    Native.contextMenu([
+        {
+            label: 'Duplicate',
+            accelerator: 'd',
+            click() {
+                duplicateEntry(element.dataset.id);
+            },
+        },
+        {
+            label: 'Edit',
+            accelerator: 'e',
+            click() {
+                showEditForm(element.dataset.id);
+            },
+        },
+        {
+            label: 'Delete',
+            click() {
+                if (confirm('Are you sure you want to delete this entry?')) {
+                    deleteEntry(element.dataset.id);
+                }
+            },
+        },
+    ]);
+});
+```


### PR DESCRIPTION
Described how to use the `Native.contextMenu()` method to define a custom native context menu in the Application Menu page of the documentation.