### PR TITLE
Add link to billing portal

### DIFF
--- a/app/Notifications/LicenseKeyGenerated.php
+++ b/app/Notifications/LicenseKeyGenerated.php
@@ -42,6 +42,7 @@ class LicenseKeyGenerated extends Notification implements ShouldQueue
             ->line("**{$this->licenseKey}**")
             ->line('When prompted by Composer, use your email address as the username and this license key as the password.')
             ->action('View Installation Guide', url('/docs/mobile/1/getting-started/installation'))
+            ->line('If you need to manage your subscription for this license, you can do so on [Stripe](https://billing.stripe.com/p/login/4gwaGV5VK0uU44E288).')
             ->line("If you have any questions, please don't hesitate to reach out to our support team.")
             ->lineIf($this->subscription === Subscription::Max, 'As a Max subscriber, you also have access to the NativePHP/mobile repository. To access it, please log in to [Anystack.sh](https://auth.anystack.sh/?accountType=customer) using the same email address you used for your purchase.')
             ->salutation("Happy coding!\n\nThe NativePHP Team")

--- a/resources/views/early-adopter.blade.php
+++ b/resources/views/early-adopter.blade.php
@@ -811,11 +811,26 @@
                     <a
                         href="https://zenvoice.io/p/67a61665e7a3400c73fb75af"
                         onclick="event.stopPropagation()"
-                        class="inline-block underline"
+                        class="inline-block underline hover:text-violet-400"
                     >
                         follow the instructions here
                     </a>
                     to generate your invoice.
+                </p>
+            </x-faq-card>
+
+            <x-faq-card question="How can I manage my subscription?">
+                <p>
+                    You can manage your subscription via the
+                    <a
+                        href="https://billing.stripe.com/p/login/4gwaGV5VK0uU44E288"
+                        onclick="event.stopPropagation()"
+                        class="inline-block underline hover:text-violet-400"
+                        aria-label="Stripe billing portal"
+                        target="_blank"
+                    >
+                        Stripe billing portal.
+                    </a>
                 </p>
             </x-faq-card>
         </div>


### PR DESCRIPTION
Adds a link to the billing portal on:
- the /mobile page.
- the license key generated notification.