### PR TITLE
Show the mobile navigation on mobile

### DIFF
--- a/resources/views/components/navigation-bar.blade.php
+++ b/resources/views/components/navigation-bar.blade.php
@@ -115,7 +115,7 @@
                 <a
                     href="{{ route('early-adopter') }}"
                     @class([
-                        'hidden transition duration-200 lg:block',
+                        'transition duration-200',
                         'font-medium' => request()->routeIs('early-adopter*'),
                         'opacity-60 hover:opacity-100' => ! request()->routeIs('early-adopter*'),
                     ])


### PR DESCRIPTION
When viewing the NativePHP website on a mobile device, it is difficult for users to navigate to the mobile page to purchase a licence directly form the home page.

This PR ensures the mobile navigation item is present on mobile devices - as currently the user meeds to navigate to the docs, then go to installation page and then select to obtain a licence.