### PR TITLE
fix: java -version instead of java -v

### DIFF
--- a/resources/views/docs/mobile/1/getting-started/installation.md
+++ b/resources/views/docs/mobile/1/getting-started/installation.md
@@ -23,7 +23,7 @@ and start distributing them to your users via the App Store.
 ### For Android
 1. [Android Studio Giraffe (or later)](https://developer.android.com/studio)
 2. The following environment variables set.
-3. You should be able to successfully run `java -v` and `adb devices` from the terminal.
+3. You should be able to successfully run `java -version` and `adb devices` from the terminal.
 4. **Windows only**: You must have [7zip](https://www.7-zip.org/) installed.
 
 #### On macOS


### PR DESCRIPTION
Correcting the Java version command from `java -v` to `java -version` 