### PR TITLE
Fix: Prevent duplicate <title> tags by conditionally rendering manual title in layout

### DIFF
--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -27,7 +27,14 @@
             content="{{ csrf_token() }}"
         />
 
-        <title>NativePHP{{ isset($title) ? ' | ' . $title : '' }}</title>
+        @php
+            $seoTitle = SEOMeta::getTitle();
+            $defaultSeoTitle = config('seotools.meta.defaults.title');
+        @endphp
+        
+        @if($seoTitle === $defaultSeoTitle || empty($seoTitle))
+            <title>NativePHP{{ isset($title) ? ' | ' . $title : '' }}</title>
+        @endif
 
         {{-- Favicon --}}
         <link


### PR DESCRIPTION
The <title> tag is now only rendered if the SEO meta title is the default or empty, preventing duplicate title.