### PR TITLE
Improve Documentation Routing & Fix All Internal Broken Links

### DIFF
--- a/resources/views/docs/desktop/1/digging-deeper/child-processes.md
+++ b/resources/views/docs/desktop/1/digging-deeper/child-processes.md
@@ -189,7 +189,7 @@ ChildProcess::stop('tail');
 This will attempt to stop the process gracefully. The [`ProcessExited`](#codeprocessexitedcode) event will be
 dispatched if the process exits.
 
-Note that [persistent processes](/docs/desktop/1/digging-deeper/child-process#persistent-processes) will be permanently stopped and will only be restarted when the `start` method is called again. If you want to restart a persistent process, use the `restart` method instead.
+Note that [persistent processes](/docs/digging-deeper/child-processes#persistent-processes) will be permanently stopped and will only be restarted when the `start` method is called again. If you want to restart a persistent process, use the `restart` method instead.
 
 ## Restarting a Child Process
 
@@ -271,11 +271,11 @@ A Child Process may send output via any of the following interfaces:
 -   A custom interface, e.g. a network socket.
 -   Broadcasting a Custom Event
 
-`STDOUT`, `STDERR` & [Custom Events](/docs/desktop/1/digging-deeper/broadcasting#custom-events) are dispatched using
+`STDOUT`, `STDERR` & [Custom Events](/docs/digging-deeper/broadcasting#custom-events) are dispatched using
 Laravel's event system.
 
 You may listen to these events by registering a listener in your app service provider, or on the front end
-using the [Native helper](/docs/desktop/1/digging-deeper/broadcasting#listening-with-javascript).
+using the [Native helper](/docs/digging-deeper/broadcasting#listening-with-javascript).
 
 Please see the [Events](#events) section for a full list of events.
 

--- a/resources/views/docs/desktop/1/getting-started/status.md
+++ b/resources/views/docs/desktop/1/getting-started/status.md
@@ -22,7 +22,7 @@ your ideas and questions through the [forum](https://github.com/orgs/nativephp/d
 #### Can you sponsor?
 
 If you're building an app that you plan to sell,
-[can you sponsor the development of NativePHP](/docs/desktop/1/getting-started/sponsoring)? This will help us to continue
+[can you sponsor the development of NativePHP](/docs/getting-started/sponsoring)? This will help us to continue
 maintaining and supporting NativePHP.
 
 </aside>

--- a/resources/views/docs/mobile/1/concepts/security.md
+++ b/resources/views/docs/mobile/1/concepts/security.md
@@ -32,7 +32,7 @@ care. If you choose to store them anywhere (either in a file or
 ## Secure Storage
 
 NativePHP provides access to your users' device's native Keystore/Keychain through the
-[`SecureStorage`](/docs/mobile/1/apis/secure-storage) facade, which
+[`SecureStorage`](/docs/apis/secure-storage) facade, which
 allow you to store small amounts of data in a secure way.
 
 The device's secure storage encrypts and decrypts data on the fly and that means you can safely rely on it to store

--- a/resources/views/docs/mobile/1/getting-started/installation.md
+++ b/resources/views/docs/mobile/1/getting-started/installation.md
@@ -79,7 +79,7 @@ NATIVEPHP_APP_VERSION_CODE="1"
 ```
 
 Find out more about these options in
-[Configuration](/docs/mobile/1/getting-started/configuration#codenativephp-app-idcode).
+[Configuration](/docs/getting-started/configuration#codenativephp-app-idcode).
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 

--- a/resources/views/docs/mobile/1/getting-started/quick-start.md
+++ b/resources/views/docs/mobile/1/getting-started/quick-start.md
@@ -32,4 +32,4 @@ php artisan native:run
 - **Examples** - Check out the [Kitchen Sink demo app](https://play.google.com/store/apps/details?id=com.nativephp.kitchensinkapp)
     on Android (coming soon to iOS!)
 
-Ready to build your first mobile app with PHP? [Let's get started! 🚀](/docs/mobile/1/getting-started/introduction)
+Ready to build your first mobile app with PHP? [Let's get started! 🚀](/docs/getting-started/introduction)


### PR DESCRIPTION
This PR enhances the documentation routing system to eliminate the need for explicitly including the platform (mobile or desktop) and version in internal docs URLs.

With this change:

- Internal links like /docs/getting-started/configuration are now automatically resolved to the correct platform and version based on the current documentation context.

- Manual addition of version or platform segments in internal link URLs is no longer necessary unless you specifically need to point to a different version or platform.

- All previously broken internal documentation links are fixed and should now work correctly.

- This improvement streamlines maintenance, reduces errors, and makes writing and navigating documentation easier for contributors and users.