### PR TITLE
fix: update JAVA_HOME comment in environment setup instructions

### DIFF
--- a/resources/views/docs/mobile/1/getting-started/environment-setup.md
+++ b/resources/views/docs/mobile/1/getting-started/environment-setup.md
@@ -101,7 +101,9 @@ That's it! Android Studio handles all the necessary configuration automatically.
 
 #### On macOS
 ```shell
-export JAVA_HOME=$(/usr/libexec/java_home -v 17) // This isn't required if JAVA_HOME is already set in your environment variables (check using `printenv | grep JAVA_HOME`)
+# This isn't required if JAVA_HOME is already set in your environment variables (check using `printenv | grep JAVA_HOME`)
+export JAVA_HOME=$(/usr/libexec/java_home -v 17) 
+
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$JAVA_HOME/bin:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools
 ```


### PR DESCRIPTION
`//` is not a valida character for commenting bash commands. 

If visitors use the copy button and paste it on their Mac, it won't work.