### PR TITLE
Make every external link has target blank

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -2,8 +2,8 @@
 
 return [
 
-    'users' => str_getcsv(env('FILAMENT_USERS') ?: ''),
-
+    'users' => str_getcsv(env('FILAMENT_USERS') ?: ''), // From PHP v8.4.0 above function `str_getcsv` was deprecated.
+    // 'users' => env('FILAMENT_USERS', ''), // If you are using PHP v8.4.0 uncomment this.
     /*
     |--------------------------------------------------------------------------
     | Broadcasting

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -96,6 +96,7 @@
         >
             <a
                 href="/newsletter"
+                target="_blank"
                 class="group relative z-0 flex items-center gap-6 overflow-hidden rounded-2xl bg-cyan-50/50 py-5 pl-6 pr-7 ring-1 ring-black/5 transition duration-300 ease-in-out hover:bg-cyan-50 hover:ring-black/10 md:max-w-lg dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
             >
                 {{-- Decorative circle --}}

--- a/resources/views/components/social-networks-all.blade.php
+++ b/resources/views/components/social-networks-all.blade.php
@@ -1,6 +1,7 @@
 <div>
     <a
         href="https://x.com/nativephp"
+        target="_blank"
         title="Twitter"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -13,6 +14,7 @@
 <div>
     <a
         href="https://youtube.com/@NativePHPOfficial"
+        target="_blank"
         title="Youtube"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -25,6 +27,7 @@
 <div>
     <a
         href="https://bsky.app/profile/nativephp.com"
+        target="_blank"
         title="Bluesky"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -36,7 +39,8 @@
 
 <div>
     <a
-        href="https://discord.gg/X62tWNStZK"
+        href="{{ $discordLink }}"
+        target="_blank"
         title="Go to discord server"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -48,7 +52,8 @@
 
 <div>
     <a
-        href="https://opencollective.com/nativephp"
+        href="{{ $openCollectiveLink }}"
+        target="_blank"
         title="NativePHP on Open Collective"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -60,7 +65,8 @@
 
 <div>
     <a
-        href="https://github.com/nativephp"
+        href="{{ $githubLink }}"
+        target="_blank"
         title="Source code of NativePHP"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -73,6 +79,7 @@
 <div>
     <a
         href="https://pinkary.com/@nativephp"
+        target="_blank"
         title="NativePHP on Pinkary"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >
@@ -85,6 +92,7 @@
 <div>
     <a
         href="https://www.linkedin.com/company/nativephp/"
+        target="_blank"
         title="NativePHP on LinkedIn"
         class="group dark:hover:bg-haiti inline-grid size-10 place-items-center rounded-xl bg-zinc-200/80 transition duration-200 hover:bg-gray-200/70 dark:bg-gray-700/40"
     >

--- a/resources/views/components/sponsors/lists/home/corporate-sponsors.blade.php
+++ b/resources/views/components/sponsors/lists/home/corporate-sponsors.blade.php
@@ -4,6 +4,7 @@
 >
     <a
         href="https://www.redgalaxy.co.uk/"
+        target="_blank"
         class="inline-grid h-16 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
         title="Learn more about RedGalaxy"
         aria-label="Visit RedGalaxy website"
@@ -24,6 +25,7 @@
 >
     <a
         href="https://sevalla.com/?utm_source=nativephp&utm_medium=Referral&utm_campaign=homepage"
+        target="_blank"
         class="inline-grid h-16 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
         title="Learn more about Sevalla"
         aria-label="Visit Sevalla website"
@@ -61,6 +63,7 @@
 >
     <a
         href="https://www.kaashosting.nl/?lang=en"
+        target="_blank"
         class="inline-grid h-16 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
         title="Learn more about KaasHosting"
         aria-label="Visit KaasHosting website"
@@ -81,6 +84,7 @@
 >
     <a
         href="https://www.quantumweb.co/"
+        target="_blank"
         class="inline-grid h-16 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
         title="Learn more about Quantumweb"
         aria-label="Visit Quantumweb website"

--- a/resources/views/components/sponsors/lists/home/featured-sponsors.blade.php
+++ b/resources/views/components/sponsors/lists/home/featured-sponsors.blade.php
@@ -4,6 +4,7 @@
 >
     <a
         href="https://beyondco.de/?utm_source=nativephp&utm_medium=logo&utm_campaign=nativephp"
+        target="_blank"
         title="Learn more about BeyondCode"
         aria-label="Visit BeyondCode website"
         class="inline-grid h-32 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
@@ -35,6 +36,7 @@
 >
     <a
         href="https://laradevs.com/?ref=nativephp"
+        target="_blank"
         title="Learn more about Laradevs"
         aria-label="Visit Laradevs website"
         class="inline-grid h-32 w-60 shrink-0 place-items-center rounded-2xl bg-gray-100 p-5 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"

--- a/resources/views/docs/desktop/1/digging-deeper/child-processes.md
+++ b/resources/views/docs/desktop/1/digging-deeper/child-processes.md
@@ -42,7 +42,7 @@ appropriate for the problem you're trying to solve:
 ### Queues
 
 The [queue runner](queues) is useful for very simply offloading _Laravel_ tasks to the background. Each task must be a
-Laravel queued [Job](https://laravel.com/docs/queues#creating-jobs).
+Laravel queued <a href="https://laravel.com/docs/queues#creating-jobs" target="_blank">Job</a>.
 
 Any queued jobs that don't get processed before your app is quit, will get processed when your application (and the
 queue runner) starts again.
@@ -50,7 +50,7 @@ queue runner) starts again.
 ### Scheduler
 
 The Laravel scheduler runs as normal (every minute) inside a NativePHP application. You can add
-[scheduled tasks](https://laravel.com/docs/scheduling) to your application just as you normally would, to have them run
+<a href="https://laravel.com/docs/scheduling" target="_blank">scheduled tasks</a> to your application just as you normally would, to have them run
 on a regular schedule.
 
 Any scheduled tasks that would have run while your application isn't running will be skipped.
@@ -62,9 +62,9 @@ only be able to run while your application is running.**
 
 PHP has good built-in support for running arbitrary programs in separate processes. For example:
 
--   [`shell_exec`](https://www.php.net/manual/en/function.shell-exec.php) allows you to run commands and return their
+-   <a href="https://www.php.net/manual/en/function.shell-exec.php" target="_blank">`shell_exec`</a> allows you to run commands and return their
     output to your application.
--   [`proc_open`](https://www.php.net/manual/en/function.proc-open.php) allows you to spin up a command with more control
+-   <a href="https://www.php.net/manual/en/function.proc-open.php" target="_blank">`proc_open`</a> allows you to spin up a command with more control
     over how its input and output streams are handled.
 
 While these can be used in your NativePHP application, consider that they:
@@ -120,7 +120,7 @@ ChildProcess::start(
 ### Persistent Processes
 
 You may mark a process as `persistent` to indicate that the runtime should make sure that once it has been started it
-is always running. This works similarly to tools like [`supervisord`](http://supervisord.org/), ensuring that the
+is always running. This works similarly to tools like <a href="http://supervisord.org/" target="_blank">`supervisord`</a>, ensuring that the
 process gets booted up again in case it crashes.
 
 ```php

--- a/resources/views/docs/desktop/1/digging-deeper/databases.md
+++ b/resources/views/docs/desktop/1/digging-deeper/databases.md
@@ -20,7 +20,7 @@ You can interact with SQLite via PDO or an ORM, such as Eloquent, in exactly the
 
 ## SQLite
 
-[SQLite](https://sqlite.org/) is a feature-rich, portable, lightweight, file-based database. It's perfect for native
+<a href="https://sqlite.org/" target="_blank">SQLite</a> is a feature-rich, portable, lightweight, file-based database. It's perfect for native
 applications that need persistent storage of complex data structures with the speed and tooling of SQL.
 
 Its small footprint and minimal dependencies make it ideal for cross-platform, native applications. Your users
@@ -48,7 +48,7 @@ it doesn't modify any other SQLite databases you may already be using.
 When writing migrations, you need to consider any special recommendations for working with SQLite.
 
 For example, prior to Laravel 11, SQLite foreign key constraints are turned off by default. If your application relies
-upon foreign key constraints, [you need to enable SQLite support for them](https://laravel.com/docs/database#configuration) before running your migrations.
+upon foreign key constraints, <a href="https://laravel.com/docs/database#configuration" target="_blank">you need to enable SQLite support for them</a> before running your migrations.
 
 **It's important to test your migrations on prod builds before releasing updates!** You don't want to accidentally
 delete your user's data when they update your app.
@@ -83,7 +83,7 @@ php artisan native:migrate:fresh
 ## Seeding
 
 When developing, it's especially useful to seed your database with sample data. If you've set up
-[Database Seeders](https://laravel.com/docs/seeding), you can run these using the `native:db:seed` command:
+<a href="https://laravel.com/docs/seeding" target="_blank">Database Seeders</a>, you can run these using the `native:db:seed` command:
 
 ```shell
 php artisan native:db:seed

--- a/resources/views/docs/desktop/1/digging-deeper/files.md
+++ b/resources/views/docs/desktop/1/digging-deeper/files.md
@@ -7,7 +7,7 @@ order: 300
 
 Working with files in NativePHP is just like working with files in a regular Laravel application.
 To achieve this, NativePHP rewrites the `Application::$storagePath()` (and thus `app()->storagePath()` and the `storage_path()` helper)
-to the [Electron `app.getPath('appData')` path](https://www.electronjs.org/docs/latest/api/app#appgetpathname),
+to the <a href="https://www.electronjs.org/docs/latest/api/app#appgetpathname" target="_blank">Electron `app.getPath('appData')` path</a>,
 which is different for each operating system.
 
 This means that you can continue to use Laravel's `Storage` facade to store and retrieve files on your user's file
@@ -31,7 +31,7 @@ It's also the location where your SQLite database will be stored.
 ### Storing files elsewhere
 
 NativePHP doesn't interfere with any of your _existing_ filesystem configuration, so you may continue to configure
-[Filesystem](https://laravel.com/docs/filesystem) as you normally would, however you should be aware that it does
+<a href="https://laravel.com/docs/filesystem" target="_blank">Filesystem</a> as you normally would, however you should be aware that it does
 _add_ some new default filesystems for your convenience.
 
 Consider that your users want to store their files in locations other than the obscure `appdata` directories on their

--- a/resources/views/docs/desktop/1/digging-deeper/php-binaries.md
+++ b/resources/views/docs/desktop/1/digging-deeper/php-binaries.md
@@ -24,14 +24,14 @@ On top of this, fewer PHP extensions means a smaller application size and attack
 extensions has both performance & [security](security) implications for your apps.
 
 The extensions that are included in the default binaries are defined in the 
-[`php-extensions.txt`](https://github.com/NativePHP/php-bin/blob/main/php-extensions.txt) in the `php-bin` repo.
+<a href="https://github.com/NativePHP/php-bin/blob/main/php-extensions.txt" target="_blank">`php-extensions.txt`</a> in the `php-bin` repo.
 
 If you think an extension is missing that would make sense as a default extension, feel free to
-[make a feature request](https://github.com/nativephp/laravel/issues/new/choose) for it.
+<a href="{{ $githubLink }}/laravel/issues/new/choose" target="_blank">make a feature request</a> for it.
 
 ## Building custom binaries
 
-NativePHP uses the awesome [`static-php-cli`](https://static-php.dev/) library to build distributable PHP binaries.
+NativePHP uses the awesome <a href="https://static-php.dev/" target="_blank">`static-php-cli`</a> library to build distributable PHP binaries.
 
 You may use this too to build your own binaries. Of course, you may build static binaries however you prefer.
 

--- a/resources/views/docs/desktop/1/digging-deeper/queues.md
+++ b/resources/views/docs/desktop/1/digging-deeper/queues.md
@@ -6,7 +6,7 @@ order: 500
 
 Queueing tasks to be run in the background is a critical part of creating a great user experience.
 
-NativePHP has built-in support for Laravel's [Queues](https://laravel.com/docs/queues).
+NativePHP has built-in support for Laravel's <a href="https://laravel.com/docs/queues" target="_blank">Queues</a>.
 
 ## Queueing a job
 If you're familiar with queueing jobs in Laravel, you should feel right at home. There's nothing special you need to do.

--- a/resources/views/docs/desktop/1/getting-started/debugging.md
+++ b/resources/views/docs/desktop/1/getting-started/debugging.md
@@ -135,9 +135,9 @@ C:\path\to\your\app\dist\win-unpacked\resources\app.asar.unpacked\resources\php\
 ```
 
 ## Still stuck?
-If you've found a bug, please [open an issue](https://github.com/nativephp/laravel/issues/new) on GitHub.
+If you've found a bug, please <a href="{{ $githubLink }}/laravel/issues/new" target="_blank">open an issue</a> on GitHub.
 
-There's also [Discussions](https://github.com/orgs/NativePHP/discussions) and
-[Discord](https://discord.gg/X62tWNStZK) for live chat.
+There's also <a href="https://github.com/orgs/nativephp/discussions" target="_blank">Discussions</a> and
+[Discord](/discord) for live chat.
 
 Come join us! We want you to succeed.

--- a/resources/views/docs/desktop/1/getting-started/development.md
+++ b/resources/views/docs/desktop/1/getting-started/development.md
@@ -44,7 +44,7 @@ supports hot reloading of certain files within its core and your application, bu
 source code for changes. It is left to you to determine how you want to approach this.
 
 If you're using Vite, hot reloading will just work inside your app as long as you've booted your Vite dev server and
-[included the Vite script tag](https://laravel.com/docs/vite#loading-your-scripts-and-styles) in your views
+<a href="https://laravel.com/docs/vite#loading-your-scripts-and-styles" target="_blank">included the Vite script tag</a> in your views
 (ideally in your app's main layout file).
 
 You can do this easily in Blade using the `@@vite` directive.

--- a/resources/views/docs/desktop/1/getting-started/installation.md
+++ b/resources/views/docs/desktop/1/getting-started/installation.md
@@ -15,7 +15,7 @@ order: 100
 The best development experience for NativePHP is to have PHP and Node running on your development machine directly.
 
 If you're using Mac or Windows, the most painless way to get PHP and Node up and running on your system is with
-[Laravel Herd](https://herd.laravel.com). It's fast and free!
+<a href="https://herd.laravel.com" target="_blank">Laravel Herd</a>. It's fast and free!
 
 Please note that, whilst it's possible to develop and run your application from a virtualized environment or container,
 you may encounter more unexpected issues and have more manual steps to create working builds.
@@ -23,7 +23,7 @@ you may encounter more unexpected issues and have more manual steps to create wo
 ### Laravel
 
 NativePHP is built to work best with Laravel. You can install it into an existing Laravel application, or
-[start a new one](https://laravel.com/docs/installation).
+<a href="https://laravel.com/docs/installation" target="_blank">start a new one</a>.
 
 ## Install a NativePHP runtime
 

--- a/resources/views/docs/desktop/1/getting-started/introduction.md
+++ b/resources/views/docs/desktop/1/getting-started/introduction.md
@@ -72,14 +72,14 @@ that puts cowboy hats on every smiley-face emoji it sees.
 
 (You should totally build that last one.)
 
-Need some inspiration? [Check out our repository of awesome projects](https://github.com/NativePHP/awesome-nativephp) created by people like you!
+Need some inspiration? <a href="https://github.com/NativePHP/awesome-nativephp" target="_blank">Check out our repository of awesome projects</a> created by people like you!
 
 ## What's next?
 
 Go read the docs! We've tried to make them as comprehensive as possible, but if you find something missing, please
-feel free to [contribute](https://github.com/nativephp/nativephp.com).
+feel free to <a href="https://github.com/nativephp/nativephp.com" target="_blank">contribute</a>.
 
-This site and all the NativePHP for Desktop repositories are open source and available on [GitHub](https://github.com/nativephp).
+This site and all the NativePHP for Desktop repositories are open source and available on <a href="https://github.com/nativephp" target="_blank">GitHub</a>.
 
 Ready to jump in? [Let's get started](installation).
 
@@ -87,9 +87,9 @@ Ready to jump in? [Let's get started](installation).
 
 NativePHP wouldn't be possible without the following projects and the hard work of all of their wonderful contributors:
 
-- [PHP](https://php.net)
-- [Electron](https://electronjs.org)
-- [Tauri](https://tauri.app)
-- [Laravel](https://laravel.com)
-- [Symfony](https://symfony.com)
-- [Static PHP CLI](https://github.com/crazywhalecc/static-php-cli/)
+- <a href="https://php.net" target="_blank">PHP</a>
+- <a href="https://electronjs.org" target="_blank">Electron</a>
+- <a href="https://tauri.app" target="_blank">Tauri</a>
+- <a href="https://laravel.com" target="_blank">Laravel</a>
+- <a href="https://symfony.com" target="_blank">Symfony</a>
+- <a href="https://github.com/crazywhalecc/static-php-cli/" target="_blank">Static PHP CLI</a>

--- a/resources/views/docs/desktop/1/getting-started/status.md
+++ b/resources/views/docs/desktop/1/getting-started/status.md
@@ -13,9 +13,9 @@ NativePHP for Desktop is **production-ready**. So you should feel completely rea
 with NativePHP.
 
 But we always need your help! If you spot any bugs or feel that there are any features missing, be sure to share
-your ideas and questions through the [forum](https://github.com/orgs/nativephp/discussions), by
-[raising issues](https://github.com/nativephp/laravel/issues/new/choose)/reporting bugs, and discussing on
-[Discord](https://discord.gg/X62tWNStZK).
+your ideas and questions through the <a href="https://github.com/orgs/nativephp/discussions" target="_blank">forum</a>, by
+<a href="https://github.com/nativephp/laravel/issues/new/choose" target="_blank">raising issues/reporting bugs</a>, and discussing on
+[Discord](/discord).
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 

--- a/resources/views/docs/desktop/1/getting-started/support-policy.md
+++ b/resources/views/docs/desktop/1/getting-started/support-policy.md
@@ -20,7 +20,7 @@ Our support policy reflects our commitment to maintaining high standards of qual
 |-------------------|------------------------|
 | ^1.0              | 8.3, 8.4               |
 
-[PHP: Supported Versions](https://www.php.net/supported-versions.php)
+<a href="https://www.php.net/supported-versions.php" target="_blank">PHP: Supported Versions</a>
 
 NativePHP provides methods of bundling your own static PHP binaries. Support is not provided for these.
 
@@ -29,9 +29,9 @@ NativePHP provides methods of bundling your own static PHP binaries. Support is 
 |-------------------|----------------------------|
 | ^1.0              | 11.x, 12.x                 |
 
-[Laravel: Support Policy](https://laravel.com/docs/master/releases#support-policy)
+<a href="https://laravel.com/docs/master/releases#support-policy" target="_blank">Laravel: Support Policy</a>
 
 ## Requesting Support
-Support can be obtained by opening an issue on the [NativePHP/laravel]({{ $githubLink }}/laravel/issues) repository or by joining the [Discord]({{ $discordLink }}).
+Support can be obtained by opening an issue on the <a href="{{ $githubLink }}/laravel/issues" target="_blank">NativePHP/laravel</a> repository or by joining the [Discord](/discord).
 
 When requesting support, it is requested that you are using a supported version. If you are not, you will be asked to upgrade to a supported version before any support is provided.

--- a/resources/views/docs/desktop/1/publishing/building.md
+++ b/resources/views/docs/desktop/1/publishing/building.md
@@ -26,7 +26,7 @@ You should build your application for each platform you intend to support and te
 publishing to make sure that everything works as expected.
 
 ### Running commands before and after builds
-Many applications rely on a tool such as [Vite](https://vitejs.dev/) or [Webpack](https://webpack.js.org/) to compile their CSS and JS assets before a production build.
+Many applications rely on a tool such as <a href="https://vitejs.dev/" target="_blank">Vite</a> or <a href="https://webpack.js.org/" target="_blank">Webpack</a> to compile their CSS and JS assets before a production build.
 
 To facilitate this, NativePHP provides two hooks that you can use to run commands before and after the build process.
 
@@ -78,7 +78,7 @@ Possible options are: `mac`, `win`, `linux`.
 
 #### Cross-compilation on Linux
 
-Compiling Windows binaries is possible with [wine](https://www.winehq.org/).
+Compiling Windows binaries is possible with <a href="https://www.winehq.org/" target="_blank">wine</a>.
 NSIS requires 32-bit wine when building x64 applications.
 
 ```bash
@@ -134,11 +134,11 @@ These credentials will be automatically stripped from your built application for
 
 #### Traditional Certificate Signing
 
-For traditional certificate-based signing, [see the Electron documentation](https://www.electronforge.io/guides/code-signing/code-signing-windows) for more details.
+For traditional certificate-based signing, <a href="https://www.electronforge.io/guides/code-signing/code-signing-windows" target="_blank">see the Electron documentation</a> for more details.
 
 ### macOS
 
-[See the Electron documentation](https://www.electronforge.io/guides/code-signing/code-signing-macos) for more details.
+<a href="https://www.electronforge.io/guides/code-signing/code-signing-macos" target="_blank">See the Electron documentation</a> for more details.
 
 To prepare for signing and notarizing, please provide the following environment variables when running
 `php artisan native:build`:

--- a/resources/views/docs/desktop/1/publishing/updating.md
+++ b/resources/views/docs/desktop/1/publishing/updating.md
@@ -78,12 +78,12 @@ The default updater configuration looks like this:
 
 How to setup your storage and generate the relevant API credentials:
 
-- [DigitalOcean](https://docs.digitalocean.com/products/spaces/how-to/manage-access/)
-- Amazon S3 - See [this video](https://www.youtube.com/watch?v=FLIp6BLtwjk&ab_channel=CloudCasts) by Chris Fidao or
-  this [Step 2](https://www.twilio.com/docs/video/tutorials/storing-aws-s3#step-2) of this article by Twilio
+- <a href="https://docs.digitalocean.com/products/spaces/how-to/manage-access/" target="_blank">DigitalOcean</a>
+- Amazon S3 - See <a href="https://www.youtube.com/watch?v=FLIp6BLtwjk&ab_channel=CloudCasts" target="_blank">this video</a> by Chris Fidao or
+  this <a href="https://www.twilio.com/docs/video/tutorials/storing-aws-s3#step-2" target="_blank">Step 2</a> of this article by Twilio
 
   If you got the error message "The bucket does not allow ACLs" you can follow this guide
-  from [Learn AWS](https://www.learnaws.org/2023/08/26/aws-s3-bucket-does-not-allow-acls)
+  from <a href="https://www.learnaws.org/2023/08/26/aws-s3-bucket-does-not-allow-acls" target="_blank">Learn AWS</a>
   on how to setup your bucket correctly.
 
 ## Disabling the updater

--- a/resources/views/docs/desktop/1/the-basics/application-menu.md
+++ b/resources/views/docs/desktop/1/the-basics/application-menu.md
@@ -276,7 +276,7 @@ Menu::link('/login', 'Login');
 This will navigate the currently-focused window to the URL provided.
 
 You may use the `Menu::route()` method as a convenience to map to a
-[named route](https://laravel.com/docs/routing#named-routes):
+<a href="https://laravel.com/docs/routing#named-routes" target="_blank">named route</a>:
 
 ```php
 Menu::route('login', 'Login');
@@ -433,7 +433,7 @@ You may wish to add a custom native context menu to the elements in the views of
 You can use the `Native` JavaScript helper provided by NativePHP's preload script.
 
 This object exposes the `contextMenu()` method which takes an array of objects that matches the 
-[MenuItem](https://www.electronjs.org/docs/latest/api/menu-item) constructor's `options` argument.
+<a href="https://www.electronjs.org/docs/latest/api/menu-item" target="_blank">MenuItem</a> constructor's `options` argument.
 
 ```js
 Native.contextMenu([

--- a/resources/views/docs/desktop/1/the-basics/system.md
+++ b/resources/views/docs/desktop/1/the-basics/system.md
@@ -169,7 +169,7 @@ $settings = [
 System::print('<html>...', $printer, $settings);
 ```
 
-For a complete list of available print settings, refer to the [Electron webContents.print()](https://www.electronjs.org/docs/latest/api/web-contents#contentsprintoptions-callback) and [webContents.printToPDF()](https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions) documentation.
+For a complete list of available print settings, refer to the <a href="https://www.electronjs.org/docs/latest/api/web-contents#contentsprintoptions-callback" target="_blank">Electron webContents.print()</a> and <a href="https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions" target="_blank">webContents.printToPDF()</a> documentation.
 
 ## Time Zones
 

--- a/resources/views/docs/mobile/1/concepts/databases.md
+++ b/resources/views/docs/mobile/1/concepts/databases.md
@@ -6,7 +6,7 @@ order: 200
 ## Working with Databases
 
 You'll almost certainly want your application to persist structured data. For this, NativePHP supports
-[SQLite](https://sqlite.org/), which works on both iOS and Android devices.
+<a href="https://sqlite.org/" target="_blank">SQLite</a>, which works on both iOS and Android devices.
 
 You can interact with SQLite from PHP in whichever way you're used to.
 
@@ -22,7 +22,7 @@ You do not need to do anything special to configure your application to use SQLi
 When writing migrations, you need to consider any special recommendations for working with SQLite.
 
 For example, prior to Laravel 11, SQLite foreign key constraints are turned off by default. If your application relies
-upon foreign key constraints, [you need to enable SQLite support for them](https://laravel.com/docs/database#configuration) before running your migrations.
+upon foreign key constraints, <a href="https://laravel.com/docs/database#configuration" target="_blank">you need to enable SQLite support for them</a> before running your migrations.
 
 **It's important to test your migrations on [prod builds](/docs/mobile/1/getting-started/development#releasing)
 before releasing updates!** You don't want to accidentally delete your user's data when they update your app.
@@ -126,7 +126,7 @@ Use industry-standard tools like OAuth-2.0-based providers, Laravel Passport, or
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 
-[Laravel Sanctum](https://laravel.com/docs/sanctum) is an ideal solution for API authentication between your mobile app and Laravel backend.
+<a href="https://laravel.com/docs/sanctum" target="_blank">Laravel Sanctum</a> is an ideal solution for API authentication between your mobile app and Laravel backend.
 It provides secure, token-based authentication without the complexity of OAuth.
 
 </aside>

--- a/resources/views/docs/mobile/1/concepts/push-notifications.md
+++ b/resources/views/docs/mobile/1/concepts/push-notifications.md
@@ -26,7 +26,7 @@ need to configure APNS separately. You only need to configure Firebase with acce
 
 ## Firebase
 
-1. Create a [Firebase](https://firebase.google.com/) account
+1. Create a <a href="https://firebase.google.com/" target="_blank">Firebase</a> account
 2. Create a project
 3. Download the `google-services.json` file (for Android) and `GoogleService-Info.plist` file (for iOS)
 4. These files contain the configuration for your app and is used by the Firebase SDK to retrieve tokens for each device

--- a/resources/views/docs/mobile/1/getting-started/development.md
+++ b/resources/views/docs/mobile/1/getting-started/development.md
@@ -154,8 +154,8 @@ as removing debugging code and unnecessary features (i.e. Composer dev dependenc
 **You should test this build on a real device.** Once you're happy that everything is working as intended you can then
 submit it to the stores for approval and distribution.
 
-- [Google Play Store submission guidelines](https://support.google.com/googleplay/android-developer/answer/9859152?hl=en-GB#zippy=%2Cmaximum-size-limit)
-- [Apple App Store submission guidelines](https://developer.apple.com/ios/submit/)
+- <a href="https://support.google.com/googleplay/android-developer/answer/9859152?hl=en-GB#zippy=%2Cmaximum-size-limit" target="_blank">Google Play Store submission guidelines</a>
+- <a href="https://developer.apple.com/ios/submit/" target="_blank">Apple App Store submission guidelines</a>
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 

--- a/resources/views/docs/mobile/1/getting-started/environment-setup.md
+++ b/resources/views/docs/mobile/1/getting-started/environment-setup.md
@@ -10,7 +10,7 @@ order: 100
 3. [A NativePHP for Mobile license](https://nativephp.com/mobile)
 
 If you don't already have PHP installed on your machine, the most painless way to get PHP up and running on Mac and
-Windows is with [Laravel Herd](https://herd.laravel.com). It's fast and free!
+Windows is with <a href="https://herd.laravel.com" target="_blank">Laravel Herd</a>. It's fast and free!
 
 ## iOS Requirements
 
@@ -23,7 +23,7 @@ You cannot build iOS apps on Windows or Linux. This is a limitation imposed by A
 </aside>
 
 1. macOS (required - iOS development is only possible on a Mac)
-2. [Xcode 16.0 or later](https://apps.apple.com/app/xcode/id497799835)
+2. <a href="https://apps.apple.com/app/xcode/id497799835" target="_blank">Xcode 16.0 or later</a>
 3. Xcode Command Line Tools
 4. Homebrew & CocoaPods
 5. _Optional_ iOS device for testing
@@ -31,7 +31,7 @@ You cannot build iOS apps on Windows or Linux. This is a limitation imposed by A
 ### Setting up iOS Development Environment
 
 1. **Install Xcode**
-   - Download from the [Mac App Store](https://apps.apple.com/app/xcode/id497799835)
+   - Download from the <a href="https://apps.apple.com/app/xcode/id497799835" target="_blank">Mac App Store</a>
    - Minimum version: Xcode 16.0
 
 2. **Install Xcode Command Line Tools**
@@ -58,16 +58,16 @@ You cannot build iOS apps on Windows or Linux. This is a limitation imposed by A
    ```
 
 ### Apple Developer Account
-You **do not** need to enroll in the [Apple Developer Program](https://developer.apple.com/programs/enroll/) ($99/year)
+You **do not** need to enroll in the <a href="https://developer.apple.com/programs/enroll/" target="_blank">Apple Developer Program</a> ($99/year)
 to develop and test your apps on a Simulator. However, you will need to enroll when you want to:
 - Test your apps on real devices
 - Distribute your apps via the App Store
 
 ## Android Requirements
 
-1. [Android Studio 2024.2.1 or later](https://developer.android.com/studio)
+1. <a href="https://developer.android.com/studio" target="_blank">Android Studio 2024.2.1 or later</a>
 2. Android SDK with API 23 or higher
-3. **Windows only**: You must have [7zip](https://www.7-zip.org/) installed.
+3. **Windows only**: You must have <a href="https://www.7-zip.org/" target="_blank">7zip</a> installed.
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 
@@ -81,7 +81,7 @@ proper JDK for you.
 ### Setting up Android Studio and SDK
 
 1. **Download and Install Android Studio**
-   - Download from the [Android Studio download page](https://developer.android.com/studio)
+   - Download from the <a href="https://developer.android.com/studio" target="_blank">Android Studio download page</a>
    - Minimum version required: Android Studio 2024.2.1
 
 2. **Install Android SDK**
@@ -123,10 +123,10 @@ before submitting to the Apple App Store and Google Play Store.
 
 ### On iOS
 If you want to run your app on a real iOS device, you need to make sure it is in
-[Developer Mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device)
+<a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device" target="_blank">Developer Mode</a>
 and that it's been added to your Apple Developer account as
-[a registered device](https://developer.apple.com/account/resources/devices/list).
+<a href="https://developer.apple.com/account/resources/devices/list" target="_blank">a registered device</a>.
 
 ### On Android
-On Android you need to [enable developer options](https://developer.android.com/studio/debug/dev-options#enable)
+On Android you need to <a href="https://developer.android.com/studio/debug/dev-options#enable" target="_blank">enable developer options</a>
 and have USB debugging (ADB) enabled.

--- a/resources/views/docs/mobile/1/getting-started/installation.md
+++ b/resources/views/docs/mobile/1/getting-started/installation.md
@@ -27,7 +27,7 @@ Thank you for supporting the project in this way! 🙏
 #### We love Laravel
 
 NativePHP for Mobile is built to work with Laravel. We recommend that you create a
-[new Laravel application](https://laravel.com/docs/installation) for your NativePHP application.
+<a href="https://laravel.com/docs/installation" target="_blank">new Laravel application</a> for your NativePHP application.
 
 </aside>
 
@@ -86,7 +86,7 @@ Find out more about these options in
 #### Setting your Apple Developer Team ID
 
 It may be useful to set your development team. You can do this via your `.env` file. Your development team ID can be
-found in your [Apple Developer account](https://developer.apple.com/account), under 'Membership details'.
+found in your <a href="https://developer.apple.com/account" target="_blank">Apple Developer account</a>, under 'Membership details'.
 
 ![](/img/docs/team-id.png)
 
@@ -148,12 +148,12 @@ Just follow the prompts! This will start compiling your application and boot it 
 
 #### On iOS
 If you want to run your app on a real iOS device, you need to make sure it is in
-[Developer Mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device)
+<a href="https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device" target="_blank">Developer Mode</a>
 and that it's been added to your Apple Developer account as
-[a registered device](https://developer.apple.com/account/resources/devices/list).
+<a href="https://developer.apple.com/account/resources/devices/list" target="_blank">a registered device</a>.
 
 #### On Android
-On Android you need to [enable developer options](https://developer.android.com/studio/debug/dev-options#enable)
+On Android you need to <a href="https://developer.android.com/studio/debug/dev-options#enable" target="_blank">enable developer options</a>
 and have USB debugging (ADB) enabled.
 
 And that's it! You should now see your Laravel application running as a native app! 🎉

--- a/resources/views/docs/mobile/1/getting-started/quick-start.md
+++ b/resources/views/docs/mobile/1/getting-started/quick-start.md
@@ -29,7 +29,7 @@ php artisan native:run
 ## Need help?
 
 - **Community** - Join our [Discord](/discord) for support and discussions.
-- **Examples** - Check out the [Kitchen Sink demo app](https://play.google.com/store/apps/details?id=com.nativephp.kitchensinkapp)
-    on Android (coming soon to iOS!)
+- **Examples** - Check out the <a href="https://play.google.com/store/apps/details?id=com.nativephp.kitchensinkapp" target="_blank">Kitchen Sink demo app</a>
+  on Android (coming soon to iOS!)
 
 Ready to build your first mobile app with PHP? [Let's get started! 🚀](/docs/getting-started/introduction)

--- a/resources/views/docs/mobile/1/getting-started/roadmap.md
+++ b/resources/views/docs/mobile/1/getting-started/roadmap.md
@@ -7,31 +7,32 @@ NativePHP for Mobile is stable and already deployed in production apps released 
 days. We haven't yet built interfaces to all of the available mobile APIs.
 
 We're working on adding more and more features, including (in no particular order):
- - Microphone access
- - Bluetooth
- - SMS (Android only)
- - File picker
- - Video camera access
- - Document scanner
- - Background tasks
- - Geofencing
- - Calendar access
- - Local notifications, scheduled notifications
- - Clipboard API
- - Contacts access
- - App badges
- - OTA Updates
- - App review prompt
- - Proximity sensor
- - Gyroscope
- - Accelerometer
- - Screen brightness
- - More Haptic feedback
- - Network info access
- - Battery status 
- - CPU/Device information
- - Ads
- - In-app billing
+
+- Microphone access
+- Bluetooth
+- SMS (Android only)
+- File picker
+- Video camera access
+- Document scanner
+- Background tasks
+- Geofencing
+- Calendar access
+- Local notifications, scheduled notifications
+- Clipboard API
+- Contacts access
+- App badges
+- OTA Updates
+- App review prompt
+- Proximity sensor
+- Gyroscope
+- Accelerometer
+- Screen brightness
+- More Haptic feedback
+- Network info access
+- Battery status
+- CPU/Device information
+- Ads
+- In-app billing
 
 <aside class="relative z-0 mt-5 overflow-hidden rounded-2xl bg-pink-50 px-5 ring-1 ring-black/5 dark:bg-pink-600/10">
 
@@ -39,7 +40,7 @@ We're working on adding more and more features, including (in no particular orde
 
 The mobile platforms are very mature and we're working hard to catch up with all their features.
 If you've got a **Max** or **Ultra** license, you can help us prioritize what we build next by
-[suggesting and voting for](https://github.com/nativephp/mobile/discussions?discussions_q=is%3Aopen+sort%3Atop)
+<a href="https://github.com/orgs/NativePHP/discussions?discussions_q=is%3Aopen+sort%3Atop" target="_blank">suggesting and voting for</a>
 the features you want most.
 
 </aside>

--- a/resources/views/docs/mobile/1/getting-started/versioning.md
+++ b/resources/views/docs/mobile/1/getting-started/versioning.md
@@ -3,7 +3,7 @@ title: Versioning Policy
 order: 50
 ---
 
-NativePHP for Mobile follows [semantic versioning](https://semver.org) with a mobile-specific approach that distinguishes between
+NativePHP for Mobile follows <a href="https://semver.org" target="_blank">semantic versioning</a> with a mobile-specific approach that distinguishes between
 Laravel-only changes and native code changes. This ensures predictable updates and optimal compatibility.
 
 Our aim is to limit the amount of work you need to do to get the latest updates and ensure everything works.
@@ -25,7 +25,7 @@ This means that you can:
 - Avoid a complete rebuild (no need to `native:install --force`).
 - Allow for easier app updates avoiding the app stores.
 
-### Minor releases  
+### Minor releases
 
 Minor releases may contain **native code changes**. Respecting semantic versioning, these still should not contain
 breaking changes, but there may be new native APIs, Kotlin/Swift updates, platform-specific features, or native
@@ -44,14 +44,14 @@ time to make the necessary changes to your application code.
 
 ## Version constraints
 
-We recommend using the [tilde range operator](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-)
+We recommend using the <a href="https://getcomposer.org/doc/articles/versions.md#tilde-version-range-" target="_blank">tilde range operator</a>
 with a full minimum patch release defined in your `composer.json`:
 
 ```json
 {
-    "require": {
-        "nativephp/mobile": "~1.1.0"
-    }
+  "require": {
+    "nativephp/mobile": "~1.1.0"
+  }
 }
 ```
 

--- a/resources/views/docs/mobile/1/the-basics/assets.md
+++ b/resources/views/docs/mobile/1/the-basics/assets.md
@@ -21,7 +21,7 @@ make available to your application wherever makes the most sense for you.
 #### Accessing arbitrary files
 
 All files must be accessed using _relative_ paths from the root of your app. Use Laravel's
-[Path helpers](https://laravel.com/docs/12.x/helpers#paths) to access files in the appropriate location.
+<a href="https://laravel.com/docs/12.x/helpers#paths" target="_blank">Path helpers</a> to access files in the appropriate location.
 
 Note that the `storage_path()` helper points to a location _outside_ of your Laravel application's root.
 

--- a/resources/views/docs/mobile/1/the-basics/events.md
+++ b/resources/views/docs/mobile/1/the-basics/events.md
@@ -35,7 +35,7 @@ PushNotifications::enrollForPushNotifications(); // → TokenGenerated event
 
 ## Basic Event Structure
 
-All events are standard [Laravel Event classes](https://laravel.com/docs/12.x/events#defining-events). The public
+All events are standard <a href="https://laravel.com/docs/12.x/events#defining-events" target="_blank">Laravel Event classes</a>. The public
 properties of the events contain the pertinent data coming from the native app side.
 
 ## Event Handling
@@ -90,7 +90,7 @@ public function handlePhoto(string $path)
 
 You can also listen for these events on the PHP side as they are simultaneously passed to your Laravel application.
 
-Simply [add a listener](https://laravel.com/docs/12.x/events#registering-events-and-listeners) as you normally would:
+Simply <a href="https://laravel.com/docs/12.x/events#registering-events-and-listeners" target="_blank">add a listener</a> as you normally would:
 
 ```php
 use App\Services\APIService;

--- a/resources/views/early-adopter.blade.php
+++ b/resources/views/early-adopter.blade.php
@@ -860,6 +860,7 @@
                     For purchases made before this, you simply need to
                     <a
                         href="https://zenvoice.io/p/67a61665e7a3400c73fb75af"
+                        target="_blank"
                         onclick="event.stopPropagation()"
                         class="inline-block underline hover:text-violet-400"
                     >

--- a/resources/views/livewire/mobile-pricing.blade.php
+++ b/resources/views/livewire/mobile-pricing.blade.php
@@ -75,6 +75,7 @@
     >
         <a
             href="https://bifrost.nativephp.com/"
+            target="_blank"
             class="group relative z-0 mt-10 flex flex-col-reverse items-center justify-between gap-x-10 gap-y-3 overflow-hidden rounded-2xl bg-slate-50 px-5 pt-6 pb-5 ring-6 ring-slate-100 transition duration-300 hover:bg-slate-100/80 sm:flex-row sm:px-8 sm:py-2 dark:bg-slate-800/30 dark:ring-slate-800/35 dark:hover:bg-slate-900/30 dark:hover:ring-slate-900/30"
         >
             {{-- Left side --}}

--- a/resources/views/livewire/order-success.blade.php
+++ b/resources/views/livewire/order-success.blade.php
@@ -433,7 +433,7 @@
                 </a>
 
                 <a
-                    href="https://discord.gg/X62tWNStZK"
+                    href="{{ $discordLink }}" target="_blank"
                     class="rounded-2xl bg-gray-100 p-6 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60 dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud"
                 >
                     <div

--- a/resources/views/sponsoring.blade.php
+++ b/resources/views/sponsoring.blade.php
@@ -113,7 +113,7 @@
             </p>
 
             <ul>
-                <li><a href="https://opencollective.com/nativephp">OpenCollective</a></li>
+                <li><a href="{{ $openCollectiveLink }}" target="_blank">OpenCollective</a></li>
             </ul>
 
             <p>
@@ -123,7 +123,7 @@
 
             <p>
                 All monthly sponsors above $10/month will be bestowed the <b>Sponsor</b> role on the NativePHP
-                <a href="https://discord.gg/X62tWNStZK">Discord</a>, granting access to private channels, early access to new releases, and
+                <a href="{{ $discordLink }}" target="_blank">Discord</a>, granting access to private channels, early access to new releases, and
                 discounts on future premium services.
             </p>
 


### PR DESCRIPTION
**Change:**
1. This PR updates all external links to include target="_blank" so they open in a new browser tab.
2. In `config/filament.php` file `str_getcsv` are deprecated in PHP v8.4.0 [Here the Ref](https://www.php.net/manual/en/function.str-getcsv.php)

**Reason:**
Opening external links in a new tab improves user experience by preventing users from unintentionally navigating away from our site. This is especially useful when linking to third-party resources, documentation, or external tools.

**Implementation Details:**
- Identified external links
- Ensured all such links now include target="_blank"
- Verified that internal links remain unaffected