### PR TITLE
Add documentation for new locale information methods

### DIFF
--- a/resources/views/docs/desktop/1/the-basics/application.md
+++ b/resources/views/docs/desktop/1/the-basics/application.md
@@ -76,14 +76,20 @@ The facade offers several methods for accessing some of the system's localisatio
 This data can be helpful for localising your application, e.g. if you want to suggest the corresponding language to the user on first launch.
 
 ```php
-App::getLocale();
-App::getLocaleCountryCode();
-App::getSystemLocale();
+App::getLocale(); // e.g. "de", "fr-FR"
+App::getLocaleCountryCode(); // e.g. "US", "DE"
+App::getSystemLocale(); // e.g. "it-IT", "de-DE"
 ```
 
-The `getLocale` method will return the full locale string used by the app. This includes both the language and the country or region.
-`getLocaleCountryCode` returns only the country code part of the locale.
+The `getLocale` method will return the locale used by the app.
+Dependening on the user's settings, this might include both the language and the country / region or the language only.
+It is based on Chromiums `l10n_util` library; see [this page](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/l10n/l10n_util.cc) to see possible values.
+
+`getLocaleCountryCode` returns the user's system country code (using the [ISO 3166 code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+This information is pulled from native OS APIs. If it is not possible to detect this information, an empty string will be returned.
+
 With `getSystemLocale` you can access the system-wide locale setting. This is the locale set at the operating system level, not necessarily what the app is using.
+Under Windows and Linux, Chromium's `i18n` library is used to evaluate this information. macOS will use `[NSLocale currentLocale]`.
 
 
 ### App Badge Count

--- a/resources/views/docs/desktop/1/the-basics/application.md
+++ b/resources/views/docs/desktop/1/the-basics/application.md
@@ -70,6 +70,22 @@ To get the current app version, use the `version` method. The version is defined
 $version = App::version();
 ```
 
+### Locale information
+
+The facade offers several methods for accessing some of the system's localisation information.
+This data can be helpful for localising your application, e.g. if you want to suggest the corresponding language to the user on first launch.
+
+```php
+App::getLocale();
+App::getLocaleCountryCode();
+App::getSystemLocale();
+```
+
+The `getLocale` method will return the full locale string used by the app. This includes both the language and the country or region.
+`getLocaleCountryCode` returns only the country code part of the locale.
+With `getSystemLocale` you can access the system-wide locale setting. This is the locale set at the operating system level, not necessarily what the app is using.
+
+
 ### App Badge Count
 _Only available on macOS and Linux_
 


### PR DESCRIPTION
**This PR allows developers to obtain localisation information of the application and the system via the `App` facade.**

It adds three new methods to the facade that are proxies for the Electron methods `app.getLocale()`, `app.getLocaleCountryCode()`, and `app.getSystemLocale()` (see details on the [Electron documentation](https://www.electronjs.org/docs/latest/api/app#appgetlocale)). This allows developers to improve the localisation of their application, e.g. by automatically setting or suggesting a language that matches the system language when a NativePHP application is first launched.

_Electron PR:_ https://github.com/NativePHP/electron/pull/247
_Laravel PR:_ https://github.com/NativePHP/laravel/pull/681

If there's anything you'd like me to tweak or improve in this PR, please let me know. 😊