### PR TITLE
add webPreferences to docs

### DIFF
--- a/resources/views/docs/desktop/1/the-basics/menu-bar.md
+++ b/resources/views/docs/desktop/1/the-basics/menu-bar.md
@@ -252,21 +252,6 @@ MenuBar::create()
 
 To learn more about the `Menu` facade, please refer to the [Application Menu](/docs/the-basics/application-menu) documentation.
 
-### Setting webpage features
-
-You may control various web page features by passing an optional `webPreferences` configuration array, similar to how it works with [Windows](/docs/the-basics/windows#setting-webpage-features). This allows you to customize how the menu bar window behaves and what features are available to the web content.
-
-```php
-MenuBar::create()
-    ->webPreferences([
-        'nodeIntegration' => true,
-        'spellcheck' => true,
-        'backgroundThrottling' => true,
-    ]);
-```
-
-The same defaults and restrictions apply as with Windows. For more details about available options and default settings, see the [Windows documentation](/docs/the-basics/windows#setting-webpage-features).
-
 ## Events
 
 NativePHP provides a simple way to listen for menu bar events.

--- a/resources/views/docs/desktop/1/the-basics/windows.md
+++ b/resources/views/docs/desktop/1/the-basics/windows.md
@@ -468,36 +468,6 @@ In order to keep the window draggable, you should add an HTML element with the f
 </div>
 ```
 
-### Setting webpage features
-
-You may control various web page features by passing an optional `webPreferences` configuration array. This allows you to customize how the Electron window behaves and what features are available to the web content.
-
-```php
-Window::open()
-    ->webPreferences([
-        'nodeIntegration' => true,
-        'spellcheck' => true,
-        'backgroundThrottling' => true,
-    ]);
-```
-
-#### Default Settings
-
-NativePHP sets the following defaults for security and compatibility:
-
-```php
-[
-    'sandbox' => false, // locked
-    'preload' => '{preload-path}', // locked  
-    'contextIsolation' => true, // locked
-    'spellcheck' => false,
-    'nodeIntegration' => false,
-    'backgroundThrottling' => false,
-]
-```
-
-The `preload`, `contextIsolation`, and `sandbox` options are locked and cannot be changed for security reasons. All other options from the [Electron WebPreferences documentation](https://www.electronjs.org/docs/latest/api/structures/web-preferences) may be passed and will override the defaults.
-
 ## Events
 
 NativePHP provides a simple way to listen for native window events.

--- a/resources/views/docs/desktop/2/the-basics/menu-bar.md
+++ b/resources/views/docs/desktop/2/the-basics/menu-bar.md
@@ -252,6 +252,21 @@ MenuBar::create()
 
 To learn more about the `Menu` facade, please refer to the [Application Menu](/docs/the-basics/application-menu) documentation.
 
+### Setting webpage features
+
+You may control various web page features by passing an optional `webPreferences` configuration array, similar to how it works with [Windows](/docs/the-basics/windows#setting-webpage-features). This allows you to customize how the menu bar window behaves and what features are available to the web content.
+
+```php
+MenuBar::create()
+    ->webPreferences([
+        'nodeIntegration' => true,
+        'spellcheck' => true,
+        'backgroundThrottling' => true,
+    ]);
+```
+
+The same defaults and restrictions apply as with Windows. For more details about available options and default settings, see the [Windows documentation](/docs/the-basics/windows#setting-webpage-features).
+
 ## Events
 
 NativePHP provides a simple way to listen for menu bar events.

--- a/resources/views/docs/desktop/2/the-basics/windows.md
+++ b/resources/views/docs/desktop/2/the-basics/windows.md
@@ -469,6 +469,36 @@ In order to keep the window draggable, you should add an HTML element with the f
 </div>
 ```
 
+### Setting webpage features
+
+You may control various web page features by passing an optional `webPreferences` configuration array. This allows you to customize how the Electron window behaves and what features are available to the web content.
+
+```php
+Window::open()
+    ->webPreferences([
+        'nodeIntegration' => true,
+        'spellcheck' => true,
+        'backgroundThrottling' => true,
+    ]);
+```
+
+#### Default Settings
+
+NativePHP sets the following defaults for security and compatibility:
+
+```php
+[
+    'sandbox' => false, // locked
+    'preload' => '{preload-path}', // locked
+    'contextIsolation' => true, // locked
+    'spellcheck' => false,
+    'nodeIntegration' => false,
+    'backgroundThrottling' => false,
+]
+```
+
+The `preload`, `contextIsolation`, and `sandbox` options are locked and cannot be changed for security reasons. All other options from the [Electron WebPreferences documentation](https://www.electronjs.org/docs/latest/api/structures/web-preferences) may be passed and will override the defaults.
+
 ## Events
 
 NativePHP provides a simple way to listen for native window events.


### PR DESCRIPTION
This PR updates the documentation for both the `MenuBar` and `Window` components to clarify how to configure web page features using the `webPreferences` option. 

This accompanies both https://github.com/NativePHP/electron/pull/255 & https://github.com/NativePHP/laravel/pull/694
These should be released first