### PR TITLE
Document Vite plugin auto-configuration during native:install

### DIFF
--- a/resources/views/docs/mobile/3/getting-started/development.md
+++ b/resources/views/docs/mobile/3/getting-started/development.md
@@ -38,8 +38,14 @@ To facilitate ease of development, you should install the `nativephpMobile` Vite
 
 ### The `nativephpMobile` Vite plugin
 
-To make your frontend build process works well with NativePHP, simply add the `nativephpMobile` plugin to your
-`vite.config.js`:
+If you're using an Inertia (React or Vue) starter kit, `php artisan native:install` will offer to configure this for
+you automatically. You can also skip the prompt by passing the `--with-vite` flag:
+
+```shell
+php artisan native:install --with-vite
+```
+
+If you need to set it up manually, add the `nativephpMobile` plugin to your `vite.config.js`:
 
 ```js
 import { nativephpMobile, nativephpHotFile } from './vendor/nativephp/mobile/resources/js/vite-plugin.js'; // [tl! focus]

--- a/resources/views/docs/mobile/3/getting-started/installation.md
+++ b/resources/views/docs/mobile/3/getting-started/installation.md
@@ -64,6 +64,11 @@ php artisan native:install
 
 The NativePHP installer takes care of setting up and configuring your Laravel application to work with iOS and Android.
 
+If you're using an Inertia starter kit (React or Vue), the installer will offer to automatically configure the
+[`nativephpMobile` Vite plugin](/docs/getting-started/development#the-codenativephpmobilecode-vite-plugin) in your
+`vite.config.js`. This is required for HMR and correct asset loading on iOS. You can also pass `--with-vite` to skip
+the prompt.
+
 You may be prompted about whether you would like to install the ICU-enabled PHP binaries. You should install these if
 your application relies on the `intl` PHP extension.
 


### PR DESCRIPTION
## Summary

- Document that `native:install` now auto-configures the `nativephpMobile` Vite plugin for Inertia (React/Vue) projects
- Document the `--with-vite` flag for skipping the confirmation prompt
- Add a note on the installation page linking to the Vite plugin details

## Files changed

- `resources/views/docs/mobile/3/getting-started/development.md`
- `resources/views/docs/mobile/3/getting-started/installation.md`