### PR TITLE
Fix plugin approval notification bypass and add resend command

### DIFF
--- a/app/Console/Commands/ResendNewPluginNotifications.php
+++ b/app/Console/Commands/ResendNewPluginNotifications.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginAvailable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+
+class ResendNewPluginNotifications extends Command
+{
+    protected $signature = 'plugins:resend-new-plugin-notifications
+        {plugins* : Plugin names (vendor/package) to resend notifications for}
+        {--dry-run : Preview what would happen without sending notifications}';
+
+    protected $description = 'Resend NewPluginAvailable notifications to opted-in users for specified plugins';
+
+    public function handle(): int
+    {
+        $pluginNames = $this->argument('plugins');
+        $dryRun = $this->option('dry-run');
+
+        $plugins = Plugin::query()
+            ->whereIn('name', $pluginNames)
+            ->where('status', 'approved')
+            ->get();
+
+        $missingNames = collect($pluginNames)->diff($plugins->pluck('name'));
+
+        if ($missingNames->isNotEmpty()) {
+            foreach ($missingNames as $name) {
+                $this->error("Plugin not found or not approved: {$name}");
+            }
+
+            return Command::FAILURE;
+        }
+
+        $recipients = User::query()
+            ->where('receives_new_plugin_notifications', true)
+            ->whereNotIn('id', $plugins->pluck('user_id'))
+            ->get();
+
+        if ($recipients->isEmpty()) {
+            $this->warn('No opted-in users found to notify.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Plugins: {$plugins->pluck('name')->implode(', ')}");
+        $this->info("Recipients: {$recipients->count()} opted-in users");
+
+        if ($dryRun) {
+            $this->warn('[DRY RUN] No notifications will be sent.');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($plugins as $plugin) {
+            $pluginRecipients = $recipients->where('id', '!=', $plugin->user_id);
+
+            Notification::send($pluginRecipients, new NewPluginAvailable($plugin));
+
+            $this->info("Sent NewPluginAvailable for {$plugin->name} to {$pluginRecipients->count()} users.");
+        }
+
+        $this->newLine();
+        $this->info('Done. All notifications queued.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -75,7 +75,9 @@ class PluginResource extends Resource
                             ->suffixIconColor('gray'),
 
                         Forms\Components\Select::make('status')
-                            ->options(PluginStatus::class),
+                            ->options(PluginStatus::class)
+                            ->disabled()
+                            ->helperText('Use the Approve/Reject actions to change status'),
 
                         Forms\Components\Toggle::make('is_official')
                             ->label('Official (First-Party)')

--- a/tests/Feature/ResendNewPluginNotificationsTest.php
+++ b/tests/Feature/ResendNewPluginNotificationsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginAvailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class ResendNewPluginNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_notifications_to_opted_in_users(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $optedIn = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $optedOut = User::factory()->create(['receives_new_plugin_notifications' => false]);
+
+        $plugin = Plugin::factory()->approved()->for($author)->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+        ])->assertSuccessful();
+
+        Notification::assertSentTo($optedIn, NewPluginAvailable::class);
+        Notification::assertNotSentTo($optedOut, NewPluginAvailable::class);
+    }
+
+    public function test_does_not_send_to_plugin_author(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin = Plugin::factory()->approved()->for($author)->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+        ])->assertSuccessful();
+
+        Notification::assertNotSentTo($author, NewPluginAvailable::class);
+    }
+
+    public function test_fails_when_plugin_not_found(): void
+    {
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => ['nonexistent/plugin'],
+        ])->assertFailed();
+    }
+
+    public function test_fails_when_plugin_is_not_approved(): void
+    {
+        $plugin = Plugin::factory()->pending()->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+        ])->assertFailed();
+    }
+
+    public function test_dry_run_does_not_send_notifications(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin = Plugin::factory()->approved()->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+            '--dry-run' => true,
+        ])->assertSuccessful();
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_handles_multiple_plugins(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin1 = Plugin::factory()->approved()->create();
+        $plugin2 = Plugin::factory()->approved()->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin1->name, $plugin2->name],
+        ])->assertSuccessful();
+
+        Notification::assertSentTo($user, NewPluginAvailable::class, 2);
+    }
+
+    public function test_succeeds_with_no_opted_in_users(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->approved()->create();
+        User::query()->update(['receives_new_plugin_notifications' => false]);
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+        ])->assertSuccessful();
+
+        Notification::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## Summary
- **Disabled** the `status` select field in the Filament plugin edit form so plugin approvals must go through the dedicated Approve/Reject action buttons, which properly call `Plugin::approve()`. Previously an admin could change the status to "Approved" via the form, bypassing notifications, activity logging, and Satis sync.
- **Added** `plugins:resend-new-plugin-notifications` artisan command to resend `NewPluginAvailable` notifications for specified approved plugins. Supports `--dry-run` and multiple plugin names.
- **Added** 7 tests for the resend command covering opted-in/out users, author exclusion, missing/non-approved plugins, dry run, multiple plugins, and no recipients.

## Test plan
- [x] All 7 new tests pass
- [x] Existing notification tests still pass
- [x] Pint lint passes
- [x] Verify the disabled status field renders correctly in the Filament admin
- [x] Run `plugins:resend-new-plugin-notifications <plugin> --dry-run` in production to preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)