### PR TITLE
Fix Route [login] not defined on paid plugin show page

### DIFF
--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -165,7 +165,7 @@
                                 @auth
                                     Manage your credentials on your <a href="{{ route('customer.purchased-plugins.index') }}" class="font-medium underline hover:no-underline">Purchased Plugins</a> dashboard.
                                 @else
-                                    <a href="{{ route('login') }}" class="font-medium underline hover:no-underline">Log in</a> to see your credentials, or find them on your <a href="{{ route('customer.purchased-plugins.index') }}" class="font-medium underline hover:no-underline">Purchased Plugins</a> dashboard.
+                                    <a href="{{ route('customer.login') }}" class="font-medium underline hover:no-underline">Log in</a> to see your credentials, or find them on your <a href="{{ route('customer.purchased-plugins.index') }}" class="font-medium underline hover:no-underline">Purchased Plugins</a> dashboard.
                                 @endauth
                                 <a href="{{ url('docs/mobile/3/plugins/using-plugins') }}" class="font-medium underline hover:no-underline">Learn more &rarr;</a>
                             </p>

--- a/tests/Feature/PluginShowPaidGuestTest.php
+++ b/tests/Feature/PluginShowPaidGuestTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginShowPaidGuestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_paid_plugin_show_page_renders_for_guest(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create();
+
+        PluginPrice::factory()->regular()->create([
+            'plugin_id' => $plugin->id,
+            'amount' => 2999,
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Installing this plugin')
+            ->assertSee('Log in');
+    }
+}


### PR DESCRIPTION
## Summary

- Fixed `route('login')` → `route('customer.login')` in `plugin-show.blade.php` for unauthenticated users viewing paid plugin pages
- Added `PluginShowPaidGuestTest` to verify paid plugin pages render correctly for guests

## Problem

Unauthenticated users visiting paid plugin pages (e.g. `/plugins/nativephp/mobile-firebase`) got a 500 error because `route('login')` was used but no route with that name exists. The correct route name is `customer.login`.

Closes #56

## Test plan

- [x] New test `PluginShowPaidGuestTest` passes — verifies guest can view paid plugin page with login link
- [x] Existing `PluginShowMobileVersionTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)