### PR TITLE
Separate plugin creation from submission with draft status

### DIFF
--- a/app/Console/Commands/SendPluginSubmissionReminders.php
+++ b/app/Console/Commands/SendPluginSubmissionReminders.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\PluginStatus;
+use App\Models\User;
+use App\Notifications\PluginSubmissionReminder;
+use Illuminate\Console\Command;
+
+class SendPluginSubmissionReminders extends Command
+{
+    protected $signature = 'plugins:send-submission-reminders
+                            {--dry-run : Show what would be sent without actually sending}';
+
+    protected $description = 'Send a reminder to users with unapproved plugin submissions to finalize their configuration';
+
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('DRY RUN - No notifications will be sent');
+        }
+
+        $users = User::query()
+            ->whereHas('plugins', function ($query) {
+                $query->whereIn('status', [PluginStatus::Draft, PluginStatus::Pending, PluginStatus::Rejected]);
+            })
+            ->with(['plugins' => function ($query) {
+                $query->whereIn('status', [PluginStatus::Draft, PluginStatus::Pending, PluginStatus::Rejected])
+                    ->orderBy('name');
+            }])
+            ->get();
+
+        $this->info("Found {$users->count()} user(s) with unapproved plugins");
+
+        $sent = 0;
+
+        foreach ($users as $user) {
+            $pluginNames = $user->plugins->pluck('name')->join(', ');
+
+            if ($dryRun) {
+                $this->line("Would send to: {$user->email} ({$user->plugins->count()} plugin(s): {$pluginNames})");
+            } else {
+                $user->notify(new PluginSubmissionReminder($user->plugins));
+                $this->line("Sent to: {$user->email} ({$user->plugins->count()} plugin(s): {$pluginNames})");
+            }
+
+            $sent++;
+        }
+
+        $this->newLine();
+        $this->info($dryRun ? "Would send: {$sent} notification(s)" : "Sent: {$sent} notification(s)");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Enums/PluginActivityType.php
+++ b/app/Enums/PluginActivityType.php
@@ -9,6 +9,8 @@ enum PluginActivityType: string
     case Approved = 'approved';
     case Rejected = 'rejected';
     case DescriptionUpdated = 'description_updated';
+    case Withdrawn = 'withdrawn';
+    case ReturnedToDraft = 'returned_to_draft';
 
     public function label(): string
     {
@@ -18,6 +20,8 @@ enum PluginActivityType: string
             self::Approved => 'Approved',
             self::Rejected => 'Rejected',
             self::DescriptionUpdated => 'Description Updated',
+            self::Withdrawn => 'Withdrawn',
+            self::ReturnedToDraft => 'Returned to Draft',
         };
     }
 
@@ -29,6 +33,8 @@ enum PluginActivityType: string
             self::Approved => 'success',
             self::Rejected => 'danger',
             self::DescriptionUpdated => 'gray',
+            self::Withdrawn => 'warning',
+            self::ReturnedToDraft => 'warning',
         };
     }
 
@@ -40,6 +46,8 @@ enum PluginActivityType: string
             self::Approved => 'heroicon-o-check-circle',
             self::Rejected => 'heroicon-o-x-circle',
             self::DescriptionUpdated => 'heroicon-o-pencil-square',
+            self::Withdrawn => 'heroicon-o-arrow-uturn-left',
+            self::ReturnedToDraft => 'heroicon-o-arrow-uturn-left',
         };
     }
 }

--- a/app/Enums/PluginStatus.php
+++ b/app/Enums/PluginStatus.php
@@ -4,6 +4,7 @@ namespace App\Enums;
 
 enum PluginStatus: string
 {
+    case Draft = 'draft';
     case Pending = 'pending';
     case Approved = 'approved';
     case Rejected = 'rejected';
@@ -11,6 +12,7 @@ enum PluginStatus: string
     public function label(): string
     {
         return match ($this) {
+            self::Draft => 'Draft',
             self::Pending => 'Pending Review',
             self::Approved => 'Approved',
             self::Rejected => 'Rejected',
@@ -20,6 +22,7 @@ enum PluginStatus: string
     public function color(): string
     {
         return match ($this) {
+            self::Draft => 'zinc',
             self::Pending => 'yellow',
             self::Approved => 'green',
             self::Rejected => 'red',

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -245,6 +245,7 @@ class PluginResource extends Resource
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->color(fn (PluginStatus $state): string => match ($state) {
+                        PluginStatus::Draft => 'gray',
                         PluginStatus::Pending => 'warning',
                         PluginStatus::Approved => 'success',
                         PluginStatus::Rejected => 'danger',

--- a/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
+++ b/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
@@ -2,9 +2,11 @@
 
 namespace App\Filament\Resources\PluginResource\Pages;
 
+use App\Enums\PluginStatus;
 use App\Filament\Resources\PluginResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListPlugins extends ListRecords
 {
@@ -15,5 +17,11 @@ class ListPlugins extends ListRecords
         return [
             Actions\CreateAction::make(),
         ];
+    }
+
+    protected function getTableQuery(): ?Builder
+    {
+        return parent::getTableQuery()
+            ->where('status', '!=', PluginStatus::Draft);
     }
 }

--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -421,6 +421,7 @@ class CartController extends Controller
                 'id' => $license->id,
                 'plugin_id' => $license->plugin->id,
                 'plugin_name' => $license->plugin->name,
+                'plugin_display_name' => $license->plugin->display_name,
                 'plugin_slug' => $license->plugin->slug,
             ]),
             'products' => $productLicenses->map(fn ($license) => [

--- a/app/Http/Controllers/PluginDirectoryController.php
+++ b/app/Http/Controllers/PluginDirectoryController.php
@@ -15,6 +15,7 @@ class PluginDirectoryController extends Controller
 
         $featuredPlugins = Plugin::query()
             ->approved()
+            ->where('is_active', true)
             ->featured()
             ->latest()
             ->take(16)
@@ -24,6 +25,7 @@ class PluginDirectoryController extends Controller
 
         $latestPlugins = Plugin::query()
             ->approved()
+            ->where('is_active', true)
             ->where('featured', false)
             ->latest()
             ->take(16)
@@ -52,11 +54,12 @@ class PluginDirectoryController extends Controller
         $user = Auth::user();
 
         $isAdmin = $user?->isAdmin() ?? false;
+        $isOwner = $user && $plugin->user_id === $user->id;
 
-        abort_unless($plugin->isApproved() || $isAdmin, 404);
+        abort_unless(($plugin->isApproved() && $plugin->is_active) || $isAdmin || $isOwner, 404);
 
-        // For paid plugins, check if user has an accessible price (admins bypass)
-        if (! $isAdmin && $plugin->isPaid() && ! $plugin->hasAccessiblePriceFor($user)) {
+        // For paid plugins, check if user has an accessible price (admins and owners bypass)
+        if (! $isAdmin && ! $isOwner && $plugin->isPaid() && ! $plugin->hasAccessiblePriceFor($user)) {
             abort(404);
         }
 
@@ -74,7 +77,7 @@ class PluginDirectoryController extends Controller
             'bestPrice' => $bestPrice,
             'regularPrice' => $regularPrice,
             'hasDiscount' => $bestPrice && $regularPrice && $bestPrice->id !== $regularPrice->id,
-            'isAdminPreview' => ! $plugin->isApproved(),
+            'isAdminPreview' => (! $plugin->isApproved() || ! $plugin->is_active) && ($isAdmin || $isOwner),
         ]);
     }
 

--- a/app/Livewire/Customer/Plugins/Create.php
+++ b/app/Livewire/Customer/Plugins/Create.php
@@ -4,9 +4,7 @@ namespace App\Livewire\Customer\Plugins;
 
 use App\Enums\PluginStatus;
 use App\Features\AllowPaidPlugins;
-use App\Jobs\ReviewPluginRepository;
 use App\Models\Plugin;
-use App\Notifications\PluginSubmitted;
 use App\Services\GitHubUserService;
 use App\Services\PluginSyncService;
 use Illuminate\Support\Facades\Cache;
@@ -17,7 +15,7 @@ use Livewire\Attributes\Title;
 use Livewire\Component;
 
 #[Layout('components.layouts.dashboard')]
-#[Title('Submit Your Plugin')]
+#[Title('Create Your Plugin')]
 class Create extends Component
 {
     public string $pluginType = 'free';
@@ -25,10 +23,6 @@ class Create extends Component
     public string $selectedOwner = '';
 
     public string $repository = '';
-
-    public string $notes = '';
-
-    public string $supportChannel = '';
 
     /** @var array<int, array{id: int, full_name: string, name: string, owner: string, private: bool}> */
     public array $repositories = [];
@@ -113,12 +107,12 @@ class Create extends Component
         $this->loadingRepos = false;
     }
 
-    public function submitPlugin(PluginSyncService $syncService): void
+    public function createPlugin(PluginSyncService $syncService): void
     {
         $user = auth()->user();
 
         if (! $user->github_id) {
-            $this->addError('repository', 'You must connect your GitHub account to submit a plugin.');
+            $this->addError('repository', 'You must connect your GitHub account to create a plugin.');
 
             return;
         }
@@ -132,26 +126,14 @@ class Create extends Component
                 function ($attribute, $value, $fail): void {
                     $url = 'https://github.com/'.trim($value, '/');
                     if (Plugin::where('repository_url', $url)->exists()) {
-                        $fail('This repository has already been submitted.');
+                        $fail('A plugin for this repository already exists.');
                     }
                 },
             ],
             'pluginType' => ['required', 'string', 'in:free,paid'],
-            'notes' => ['nullable', 'string', 'max:5000'],
-            'supportChannel' => [
-                'required',
-                'string',
-                'max:255',
-                function (string $attribute, mixed $value, \Closure $fail) {
-                    if (! filter_var($value, FILTER_VALIDATE_EMAIL) && ! filter_var($value, FILTER_VALIDATE_URL)) {
-                        $fail('The support channel must be a valid email address or URL.');
-                    }
-                },
-            ],
         ], [
             'repository.required' => 'Please select a repository for your plugin.',
             'repository.regex' => 'Please enter a valid repository in the format vendor/repo-name.',
-            'supportChannel.required' => 'Please provide a support channel (email or URL) for your plugin.',
         ]);
 
         if ($this->pluginType === 'paid' && ! Feature::active(AllowPaidPlugins::class)) {
@@ -195,30 +177,11 @@ class Create extends Component
         $plugin = $user->plugins()->create([
             'repository_url' => $repositoryUrl,
             'type' => $this->pluginType,
-            'status' => PluginStatus::Pending,
+            'status' => PluginStatus::Draft,
             'developer_account_id' => $developerAccountId,
-            'notes' => $this->notes ?: null,
-            'support_channel' => $this->supportChannel ?: null,
         ]);
 
-        $webhookSecret = $plugin->generateWebhookSecret();
-
-        $webhookInstalled = false;
-        if ($user->hasGitHubToken()) {
-            $webhookResult = $githubService->createWebhook(
-                $owner,
-                $repo,
-                $plugin->getWebhookUrl(),
-                $webhookSecret
-            );
-            $webhookInstalled = $webhookResult['success'];
-        }
-
-        $plugin->update(['webhook_installed' => $webhookInstalled]);
-
         $syncService->sync($plugin);
-
-        (new ReviewPluginRepository($plugin))->handle();
 
         if (! $plugin->name) {
             $plugin->delete();
@@ -228,13 +191,6 @@ class Create extends Component
             return;
         }
 
-        $user->notify(new PluginSubmitted($plugin));
-
-        $successMessage = 'Your plugin has been submitted for review!';
-        if (! $webhookInstalled) {
-            $successMessage .= ' Please set up the webhook manually to enable automatic syncing.';
-        }
-
         [$vendor, $package] = explode('/', $plugin->name);
 
         $this->redirect(
@@ -242,7 +198,7 @@ class Create extends Component
             navigate: true
         );
 
-        session()->flash('success', $successMessage);
+        session()->flash('success', 'Your plugin has been created as a draft. You can edit it and submit for review when ready.');
     }
 
     public function render()

--- a/app/Livewire/Customer/Plugins/Index.php
+++ b/app/Livewire/Customer/Plugins/Index.php
@@ -16,7 +16,7 @@ use Livewire\Component;
 class Index extends Component
 {
     #[Url]
-    public string $status = 'pending';
+    public string $status = 'draft';
 
     #[Computed]
     public function plugins(): Collection
@@ -37,6 +37,7 @@ class Index extends Component
             ->toArray();
 
         return [
+            PluginStatus::Draft->value => $counts[PluginStatus::Draft->value] ?? 0,
             PluginStatus::Approved->value => $counts[PluginStatus::Approved->value] ?? 0,
             PluginStatus::Pending->value => $counts[PluginStatus::Pending->value] ?? 0,
             PluginStatus::Rejected->value => $counts[PluginStatus::Rejected->value] ?? 0,

--- a/app/Livewire/Customer/Plugins/Show.php
+++ b/app/Livewire/Customer/Plugins/Show.php
@@ -170,9 +170,16 @@ class Show extends Component
 
         if ($this->plugin->isDraft()) {
             $rules['notes'] = ['nullable', 'string', 'max:5000'];
+            $rules['pluginType'] = ['required', 'string', 'in:free,paid'];
+
+            if ($this->pluginType === 'paid') {
+                $rules['tier'] = ['required', 'string', 'in:bronze,silver,gold'];
+            }
         }
 
-        $this->validate($rules);
+        $this->validate($rules, [
+            'tier.required' => 'Please select a pricing tier for your paid plugin.',
+        ]);
 
         $data = [
             'display_name' => $this->displayName ?: null,

--- a/app/Livewire/Customer/Plugins/Show.php
+++ b/app/Livewire/Customer/Plugins/Show.php
@@ -2,7 +2,12 @@
 
 namespace App\Livewire\Customer\Plugins;
 
+use App\Enums\PluginTier;
+use App\Enums\PluginType;
+use App\Jobs\ReviewPluginRepository;
 use App\Models\Plugin;
+use App\Notifications\PluginSubmitted;
+use App\Services\GitHubUserService;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
@@ -11,7 +16,7 @@ use Livewire\Component;
 use Livewire\WithFileUploads;
 
 #[Layout('components.layouts.dashboard')]
-#[Title('Edit Plugin')]
+#[Title('Plugin')]
 class Show extends Component
 {
     use WithFileUploads;
@@ -31,7 +36,17 @@ class Show extends Component
     #[Validate('nullable|image|max:1024')]
     public $logo = null;
 
+    public ?string $displayName = null;
+
     public ?string $supportChannel = null;
+
+    public string $notes = '';
+
+    public string $activeTab = 'details';
+
+    public string $pluginType = 'free';
+
+    public ?string $tier = null;
 
     public function mount(string $vendor, string $package): void
     {
@@ -41,27 +56,152 @@ class Show extends Component
             abort(403);
         }
 
+        $this->displayName = $this->plugin->display_name;
         $this->description = $this->plugin->description;
         $this->iconName = $this->plugin->icon_name ?? 'cube';
         $this->iconGradient = $this->plugin->icon_gradient;
         $this->iconMode = $this->plugin->hasLogo() ? 'upload' : 'gradient';
         $this->supportChannel = $this->plugin->support_channel;
+        $this->notes = $this->plugin->notes ?? '';
+        $this->pluginType = $this->plugin->type->value;
+        $this->tier = $this->plugin->tier?->value;
     }
 
-    public function updateDescription(): void
+    public function submitForReview(): void
     {
-        $this->validate([
-            'description' => ['nullable', 'string', 'max:1000'],
-        ]);
+        if (! $this->plugin->isDraft()) {
+            session()->flash('error', 'Only draft plugins can be submitted for review.');
 
+            return;
+        }
+
+        if (! $this->plugin->support_channel) {
+            session()->flash('error', 'Please set a support channel before submitting for review.');
+
+            return;
+        }
+
+        if ($this->plugin->isPaid() && ! $this->plugin->tier) {
+            session()->flash('error', 'Please select a pricing tier for your paid plugin.');
+
+            return;
+        }
+
+        $user = auth()->user();
+
+        // Install webhook
+        $repoInfo = $this->plugin->getRepositoryOwnerAndName();
+
+        if ($repoInfo && $user->hasGitHubToken()) {
+            $webhookSecret = $this->plugin->webhook_secret ?? $this->plugin->generateWebhookSecret();
+            $githubService = GitHubUserService::for($user);
+            $webhookResult = $githubService->createWebhook(
+                $repoInfo['owner'],
+                $repoInfo['repo'],
+                $this->plugin->getWebhookUrl(),
+                $webhookSecret
+            );
+            $this->plugin->update(['webhook_installed' => $webhookResult['success']]);
+        }
+
+        // Run review checks
+        (new ReviewPluginRepository($this->plugin))->handle();
+
+        // Submit
+        $this->plugin->submit();
+        $this->plugin->refresh();
+
+        // Notify
+        $user->notify(new PluginSubmitted($this->plugin));
+
+        session()->flash('success', 'Your plugin has been submitted for review!');
+    }
+
+    public function withdrawFromReview(): void
+    {
+        if (! $this->plugin->isPending()) {
+            session()->flash('error', 'Only pending plugins can be withdrawn.');
+
+            return;
+        }
+
+        $this->plugin->withdraw();
+        $this->plugin->refresh();
+
+        session()->flash('success', 'Your plugin has been withdrawn from review and returned to draft.');
+    }
+
+    public function returnToDraft(): void
+    {
+        if (! $this->plugin->isRejected()) {
+            session()->flash('error', 'Only rejected plugins can be returned to draft.');
+
+            return;
+        }
+
+        $this->plugin->returnToDraft();
+        $this->plugin->refresh();
+
+        session()->flash('success', 'Your plugin has been returned to draft. You can make changes and resubmit.');
+    }
+
+    public function save(): void
+    {
+        if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
+            session()->flash('error', 'You can only edit draft or approved plugins.');
+
+            return;
+        }
+
+        $rules = [
+            'displayName' => ['nullable', 'string', 'max:250'],
+            'description' => ['required', 'string', 'max:1000'],
+            'supportChannel' => [
+                'required',
+                'string',
+                'max:255',
+                function (string $attribute, mixed $value, \Closure $fail) {
+                    if ($value && ! filter_var($value, FILTER_VALIDATE_EMAIL) && ! filter_var($value, FILTER_VALIDATE_URL)) {
+                        $fail('The support channel must be a valid email address or URL.');
+                    }
+                },
+            ],
+        ];
+
+        if ($this->plugin->isDraft()) {
+            $rules['notes'] = ['nullable', 'string', 'max:5000'];
+        }
+
+        $this->validate($rules);
+
+        $data = [
+            'display_name' => $this->displayName ?: null,
+            'support_channel' => $this->supportChannel,
+        ];
+
+        if ($this->plugin->isDraft()) {
+            $data['notes'] = $this->notes ?: null;
+
+            $pluginType = PluginType::from($this->pluginType);
+            $data['type'] = $pluginType;
+            $data['tier'] = $pluginType === PluginType::Paid && $this->tier ? PluginTier::from($this->tier) : null;
+        }
+
+        $this->plugin->update($data);
         $this->plugin->updateDescription($this->description, auth()->id());
         $this->plugin->refresh();
 
-        session()->flash('success', 'Plugin description updated successfully!');
+        session()->flash('success', 'Plugin details saved successfully!');
     }
 
     public function updateIcon(): void
     {
+        if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
+            session()->flash('error', 'You can only edit the icon for draft or approved plugins.');
+
+            return;
+        }
+
         $this->validate([
             'iconGradient' => ['required', 'string', 'in:'.implode(',', array_keys(Plugin::gradientPresets()))],
             'iconName' => ['required', 'string', 'max:100', 'regex:/^[a-z0-9-]+$/'],
@@ -84,6 +224,12 @@ class Show extends Component
 
     public function uploadLogo(): void
     {
+        if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
+            session()->flash('error', 'You can only upload a logo for draft or approved plugins.');
+
+            return;
+        }
+
         $this->validate([
             'logo' => ['required', 'image', 'max:1024', 'mimes:png,jpeg,jpg,svg,webp'],
         ]);
@@ -109,6 +255,12 @@ class Show extends Component
 
     public function deleteIcon(): void
     {
+        if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
+            session()->flash('error', 'You can only remove the icon for draft or approved plugins.');
+
+            return;
+        }
+
         if ($this->plugin->logo_path) {
             Storage::disk('public')->delete($this->plugin->logo_path);
         }
@@ -125,44 +277,22 @@ class Show extends Component
         session()->flash('success', 'Plugin icon removed successfully!');
     }
 
-    public function updateSupportChannel(): void
+    public function toggleListing(): void
     {
-        $this->validate([
-            'supportChannel' => [
-                'required',
-                'string',
-                'max:255',
-                function (string $attribute, mixed $value, \Closure $fail) {
-                    if (! filter_var($value, FILTER_VALIDATE_EMAIL) && ! filter_var($value, FILTER_VALIDATE_URL)) {
-                        $fail('The support channel must be a valid email address or URL.');
-                    }
-                },
-            ],
-        ], [
-            'supportChannel.required' => 'Please provide a support channel (email or URL) for your plugin.',
-        ]);
-
-        $this->plugin->update([
-            'support_channel' => $this->supportChannel,
-        ]);
-
-        $this->plugin->refresh();
-
-        session()->flash('success', 'Support channel updated successfully!');
-    }
-
-    public function resubmit(): void
-    {
-        if (! $this->plugin->isRejected()) {
-            session()->flash('error', 'Only rejected plugins can be resubmitted.');
+        if (! $this->plugin->isApproved()) {
+            session()->flash('error', 'Only approved plugins can be listed or de-listed.');
 
             return;
         }
 
-        $this->plugin->resubmit();
+        $this->plugin->update([
+            'is_active' => ! $this->plugin->is_active,
+        ]);
+
         $this->plugin->refresh();
 
-        session()->flash('success', 'Your plugin has been resubmitted for review!');
+        $action = $this->plugin->is_active ? 'listed' : 'de-listed';
+        session()->flash('success', "Your plugin has been {$action}.");
     }
 
     public function render()

--- a/app/Livewire/PluginDirectory.php
+++ b/app/Livewire/PluginDirectory.php
@@ -74,6 +74,7 @@ class PluginDirectory extends Component
 
         $plugins = Plugin::query()
             ->approved()
+            ->where('is_active', true)
             ->when($this->search, function ($query): void {
                 $query->where(function ($q): void {
                     $q->where('name', 'like', "%{$this->search}%")

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -71,16 +71,6 @@ class Plugin extends Model
             }
         });
 
-        static::created(function (Plugin $plugin): void {
-            $plugin->recordActivity(
-                PluginActivityType::Submitted,
-                null,
-                PluginStatus::Pending,
-                null,
-                $plugin->user_id
-            );
-        });
-
         static::updated(function (Plugin $plugin): void {
             // When tier is set or changed, create/update prices automatically
             if ($plugin->wasChanged('tier') && $plugin->tier !== null) {
@@ -266,6 +256,11 @@ class Plugin extends Model
     public function isApproved(): bool
     {
         return $this->status === PluginStatus::Approved;
+    }
+
+    public function isDraft(): bool
+    {
+        return $this->status === PluginStatus::Draft;
     }
 
     public function isRejected(): bool
@@ -616,6 +611,74 @@ class Plugin extends Model
             PluginActivityType::Resubmitted,
             $previousStatus,
             PluginStatus::Pending,
+            null,
+            $this->user_id
+        );
+    }
+
+    /**
+     * Submit a draft plugin for review (Draft → Pending).
+     * Logs Resubmitted if previously rejected, otherwise Submitted.
+     */
+    public function submit(): void
+    {
+        $previousStatus = $this->status;
+
+        $wasRejected = $this->activities()
+            ->where('type', PluginActivityType::Rejected)
+            ->exists();
+
+        $this->update([
+            'status' => PluginStatus::Pending,
+            'rejection_reason' => null,
+            'approved_at' => null,
+            'approved_by' => null,
+        ]);
+
+        $this->recordActivity(
+            $wasRejected ? PluginActivityType::Resubmitted : PluginActivityType::Submitted,
+            $previousStatus,
+            PluginStatus::Pending,
+            null,
+            $this->user_id
+        );
+    }
+
+    /**
+     * Withdraw a pending plugin back to draft (Pending → Draft).
+     */
+    public function withdraw(): void
+    {
+        $previousStatus = $this->status;
+
+        $this->update([
+            'status' => PluginStatus::Draft,
+        ]);
+
+        $this->recordActivity(
+            PluginActivityType::Withdrawn,
+            $previousStatus,
+            PluginStatus::Draft,
+            null,
+            $this->user_id
+        );
+    }
+
+    /**
+     * Return a rejected plugin to draft for editing (Rejected → Draft).
+     */
+    public function returnToDraft(): void
+    {
+        $previousStatus = $this->status;
+
+        $this->update([
+            'status' => PluginStatus::Draft,
+        ]);
+
+        $this->recordActivity(
+            PluginActivityType::ReturnedToDraft,
+            $previousStatus,
+            PluginStatus::Draft,
             null,
             $this->user_id
         );

--- a/app/Notifications/PluginSubmissionReminder.php
+++ b/app/Notifications/PluginSubmissionReminder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Plugin;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class PluginSubmissionReminder extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  Collection<int, Plugin>  $plugins
+     */
+    public function __construct(public Collection $plugins) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $message = (new MailMessage)
+            ->subject('Action Required: Finalize Your Plugin Submission')
+            ->greeting("Hi {$notifiable->name},")
+            ->line('We\'ve recently updated the plugin submission process with new requirements. Please review your pending plugin submissions to ensure they are configured correctly — particularly whether you intended to submit a **free** or **paid** plugin.')
+            ->line('The following plugins need your attention:');
+
+        foreach ($this->plugins as $plugin) {
+            $message->line("- **{$plugin->name}** ({$plugin->status->label()})");
+        }
+
+        $message->action('Review Your Plugins', route('customer.plugins.index'))
+            ->line('Please visit your plugin dashboard, review each submission, and re-submit when ready.')
+            ->salutation("Thanks,\n\nThe NativePHP Team");
+
+        return $message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Action Required: Finalize Your Plugin Submissions',
+            'body' => 'Please review your pending plugin submissions to ensure they are configured correctly.',
+            'plugin_names' => $this->plugins->pluck('name')->all(),
+        ];
+    }
+}

--- a/database/factories/PluginFactory.php
+++ b/database/factories/PluginFactory.php
@@ -121,6 +121,17 @@ class PluginFactory extends Factory
         ];
     }
 
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PluginStatus::Draft,
+            'approved_at' => null,
+            'approved_by' => null,
+            'rejection_reason' => null,
+            'webhook_secret' => null,
+        ]);
+    }
+
     public function pending(): static
     {
         return $this->state(fn (array $attributes) => [

--- a/database/migrations/2026_04_08_180326_change_plugins_default_status_to_draft.php
+++ b/database/migrations/2026_04_08_180326_change_plugins_default_status_to_draft.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            // SQLite doesn't support ALTER COLUMN DEFAULT directly,
+            // and Schema::change() fails when views reference the table.
+            // The default is only used for new inserts; we set status explicitly in code.
+            return;
+        }
+
+        DB::statement("ALTER TABLE plugins ALTER COLUMN status SET DEFAULT 'draft'");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            return;
+        }
+
+        DB::statement("ALTER TABLE plugins ALTER COLUMN status SET DEFAULT 'pending'");
+    }
+};

--- a/database/migrations/2026_04_09_091811_convert_existing_pending_plugins_to_draft.php
+++ b/database/migrations/2026_04_09_091811_convert_existing_pending_plugins_to_draft.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('plugins')
+            ->where('status', 'pending')
+            ->update(['status' => 'draft']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('plugins')
+            ->where('status', 'draft')
+            ->update(['status' => 'pending']);
+    }
+};

--- a/database/migrations/2026_04_09_101159_add_display_name_to_plugins_table.php
+++ b/database/migrations/2026_04_09_101159_add_display_name_to_plugins_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->string('display_name', 250)->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn('display_name');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "brave-lemur",
+    "name": "lazy-podenco",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/cart/show.blade.php
+++ b/resources/views/cart/show.blade.php
@@ -223,11 +223,12 @@
                                         <div class="flex flex-1 flex-col">
                                             <div class="flex justify-between">
                                                 <div>
-                                                    <h3 class="font-mono text-sm font-medium text-gray-900 dark:text-white">
+                                                    <h3 class="text-sm font-medium text-gray-900 dark:text-white">
                                                         <a href="{{ route('plugins.show', $item->plugin->routeParams()) }}" class="hover:text-indigo-600 dark:hover:text-indigo-400">
-                                                            {{ $item->plugin->name }}
+                                                            {{ $item->plugin->display_name ?? $item->plugin->name }}
                                                         </a>
                                                     </h3>
+                                                    <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
                                                     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                                                         by {{ $item->plugin->user->display_name }}
                                                     </p>

--- a/resources/views/cart/show.blade.php
+++ b/resources/views/cart/show.blade.php
@@ -228,7 +228,9 @@
                                                             {{ $item->plugin->display_name ?? $item->plugin->name }}
                                                         </a>
                                                     </h3>
-                                                    <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
+                                                    @if ($item->plugin->display_name)
+                                                        <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
+                                                    @endif
                                                     <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                                                         by {{ $item->plugin->user->display_name }}
                                                     </p>

--- a/resources/views/cart/success.blade.php
+++ b/resources/views/cart/success.blade.php
@@ -27,7 +27,9 @@
                                             </div>
                                             <div class="text-left">
                                                 <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $item->plugin->display_name ?? $item->plugin->name }}</span>
-                                                <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
+                                                @if ($item->plugin->display_name)
+                                                    <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
+                                                @endif
                                                 @if ($item->plugin->isOfficial() && auth()->user()?->hasUltraAccess())
                                                     <p class="text-xs text-green-600 dark:text-green-400">Included with Ultra</p>
                                                 @endif
@@ -47,7 +49,9 @@
                                                     <x-vaadin-plug class="size-5" />
                                                 </div>
                                                 <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->display_name ?? $plugin->name }}</span>
-                                                <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                                                @if ($plugin->display_name)
+                                                    <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                                                @endif
                                             </div>
                                         </div>
                                     @endforeach
@@ -213,7 +217,9 @@
                                                 </div>
                                                 <div class="text-left">
                                                     <span class="text-sm font-medium text-gray-900 dark:text-white" x-text="license.plugin_display_name || license.plugin_name"></span>
-                                                    <p class="font-mono text-xs text-gray-500 dark:text-gray-400" x-text="license.plugin_name"></p>
+                                                    <template x-if="license.plugin_display_name">
+                                                        <p class="font-mono text-xs text-gray-500 dark:text-gray-400" x-text="license.plugin_name"></p>
+                                                    </template>
                                                 </div>
                                             </div>
                                             <a :href="'/plugins/' + license.plugin_name" class="text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300">

--- a/resources/views/cart/success.blade.php
+++ b/resources/views/cart/success.blade.php
@@ -26,7 +26,8 @@
                                                 <x-vaadin-plug class="size-5" />
                                             </div>
                                             <div class="text-left">
-                                                <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $item->plugin->name }}</span>
+                                                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $item->plugin->display_name ?? $item->plugin->name }}</span>
+                                                <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $item->plugin->name }}</p>
                                                 @if ($item->plugin->isOfficial() && auth()->user()?->hasUltraAccess())
                                                     <p class="text-xs text-green-600 dark:text-green-400">Included with Ultra</p>
                                                 @endif
@@ -45,7 +46,8 @@
                                                 <div class="grid size-10 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
                                                     <x-vaadin-plug class="size-5" />
                                                 </div>
-                                                <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
+                                                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->display_name ?? $plugin->name }}</span>
+                                                <p class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
                                             </div>
                                         </div>
                                     @endforeach
@@ -209,7 +211,10 @@
                                                 <div class="grid size-10 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
                                                     <x-vaadin-plug class="size-5" />
                                                 </div>
-                                                <span class="font-mono text-sm font-medium text-gray-900 dark:text-white" x-text="license.plugin_name"></span>
+                                                <div class="text-left">
+                                                    <span class="text-sm font-medium text-gray-900 dark:text-white" x-text="license.plugin_display_name || license.plugin_name"></span>
+                                                    <p class="font-mono text-xs text-gray-500 dark:text-gray-400" x-text="license.plugin_name"></p>
+                                                </div>
                                             </div>
                                             <a :href="'/plugins/' + license.plugin_name" class="text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300">
                                                 View Plugin

--- a/resources/views/components/customer/status-badge.blade.php
+++ b/resources/views/components/customer/status-badge.blade.php
@@ -7,7 +7,7 @@ $color = match($status) {
     'Needs Renewal', 'In Progress' => 'blue',
     'Suspended', 'Rejected', 'Closed' => 'red',
     'Responded' => 'green',
-    'On Hold' => 'zinc',
+    'Draft', 'On Hold' => 'zinc',
     default => 'zinc',
 };
 @endphp

--- a/resources/views/components/plugin-card.blade.php
+++ b/resources/views/components/plugin-card.blade.php
@@ -39,7 +39,9 @@
         <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
             {{ $plugin->display_name ?? $plugin->name }}
         </h3>
-        <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+        @if ($plugin->display_name)
+            <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+        @endif
         @if ($plugin->description)
             <p class="mt-2 line-clamp-3 text-sm text-gray-600 dark:text-gray-400">
                 {{ $plugin->description }}

--- a/resources/views/components/plugin-card.blade.php
+++ b/resources/views/components/plugin-card.blade.php
@@ -36,9 +36,10 @@
     </div>
 
     <div class="mt-4 flex-1">
-        <h3 class="font-mono text-sm font-semibold text-gray-900 dark:text-white">
-            {{ $plugin->name }}
+        <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+            {{ $plugin->display_name ?? $plugin->name }}
         </h3>
+        <p class="mt-0.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
         @if ($plugin->description)
             <p class="mt-2 line-clamp-3 text-sm text-gray-600 dark:text-gray-400">
                 {{ $plugin->description }}

--- a/resources/views/customer/team/show.blade.php
+++ b/resources/views/customer/team/show.blade.php
@@ -53,8 +53,9 @@
                                         </div>
                                         <div>
                                             <a href="{{ route('plugins.show', $plugin->routeParams()) }}" class="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
-                                                {{ $plugin->name }}
+                                                {{ $plugin->display_name ?? $plugin->name }}
                                             </a>
+                                            <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
                                             @if($plugin->description)
                                                 <flux:text class="text-xs line-clamp-1">{{ $plugin->description }}</flux:text>
                                             @endif

--- a/resources/views/customer/team/show.blade.php
+++ b/resources/views/customer/team/show.blade.php
@@ -55,7 +55,9 @@
                                             <a href="{{ route('plugins.show', $plugin->routeParams()) }}" class="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
                                                 {{ $plugin->display_name ?? $plugin->name }}
                                             </a>
-                                            <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                            @if ($plugin->display_name)
+                                                <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                            @endif
                                             @if($plugin->description)
                                                 <flux:text class="text-xs line-clamp-1">{{ $plugin->description }}</flux:text>
                                             @endif

--- a/resources/views/customer/ultra/index.blade.php
+++ b/resources/views/customer/ultra/index.blade.php
@@ -153,7 +153,9 @@
                                                 <a href="{{ route('plugins.show', $plugin->routeParams()) }}" class="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
                                                     {{ $plugin->display_name ?? $plugin->name }}
                                                 </a>
-                                                <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                                @if ($plugin->display_name)
+                                                    <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                                @endif
                                                 @if($plugin->description)
                                                     <flux:text class="text-xs line-clamp-1">{{ $plugin->description }}</flux:text>
                                                 @endif

--- a/resources/views/customer/ultra/index.blade.php
+++ b/resources/views/customer/ultra/index.blade.php
@@ -151,8 +151,9 @@
                                             </div>
                                             <div class="min-w-0">
                                                 <a href="{{ route('plugins.show', $plugin->routeParams()) }}" class="font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">
-                                                    {{ $plugin->name }}
+                                                    {{ $plugin->display_name ?? $plugin->name }}
                                                 </a>
+                                                <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
                                                 @if($plugin->description)
                                                     <flux:text class="text-xs line-clamp-1">{{ $plugin->description }}</flux:text>
                                                 @endif

--- a/resources/views/livewire/customer/developer/dashboard.blade.php
+++ b/resources/views/livewire/customer/developer/dashboard.blade.php
@@ -68,7 +68,8 @@
                     <a href="{{ route('customer.plugins.show', $plugin->routeParams()) }}" class="block py-4 first:pt-0 last:pb-0 hover:bg-gray-50 dark:hover:bg-gray-700/50 -mx-2 px-2 rounded-lg" wire:key="plugin-{{ $plugin->id }}">
                         <div class="flex items-center justify-between">
                             <div class="min-w-0 flex-1">
-                                <p class="truncate font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</p>
+                                <p class="truncate font-medium text-gray-900 dark:text-white">{{ $plugin->display_name ?? $plugin->name }}</p>
+                                <p class="truncate font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
                             </div>
                             <div class="ml-4 text-right">
                                 <flux:text class="font-medium">{{ $plugin->licenses_count }} sales</flux:text>

--- a/resources/views/livewire/customer/developer/dashboard.blade.php
+++ b/resources/views/livewire/customer/developer/dashboard.blade.php
@@ -69,7 +69,9 @@
                         <div class="flex items-center justify-between">
                             <div class="min-w-0 flex-1">
                                 <p class="truncate font-medium text-gray-900 dark:text-white">{{ $plugin->display_name ?? $plugin->name }}</p>
-                                <p class="truncate font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                                @if ($plugin->display_name)
+                                    <p class="truncate font-mono text-xs text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                                @endif
                             </div>
                             <div class="ml-4 text-right">
                                 <flux:text class="font-medium">{{ $plugin->licenses_count }} sales</flux:text>

--- a/resources/views/livewire/customer/plugins/create.blade.php
+++ b/resources/views/livewire/customer/plugins/create.blade.php
@@ -11,11 +11,11 @@
                     <x-heroicon-s-chevron-right class="size-4 text-gray-400" />
                 </li>
                 <li>
-                    <span class="text-sm font-medium text-gray-900 dark:text-white">Submit Plugin</span>
+                    <span class="text-sm font-medium text-gray-900 dark:text-white">Create Plugin</span>
                 </li>
             </ol>
         </nav>
-        <flux:heading size="xl" class="mt-2">Submit Your Plugin</flux:heading>
+        <flux:heading size="xl" class="mt-2">Create Your Plugin</flux:heading>
         <flux:text>Add your plugin to the NativePHP Plugin Marketplace</flux:text>
     </div>
 
@@ -27,26 +27,12 @@
             </flux:callout>
         @endif
 
-        {{-- Validation Errors --}}
-        @if ($errors->any())
-            <flux:callout variant="danger" icon="x-circle">
-                <flux:callout.heading>Please fix the following errors:</flux:callout.heading>
-                <flux:callout.text>
-                    <ul class="list-disc space-y-1 pl-5">
-                        @foreach ($errors->all() as $error)
-                            <li>{{ $error }}</li>
-                        @endforeach
-                    </ul>
-                </flux:callout.text>
-            </flux:callout>
-        @endif
-
         {{-- GitHub Connection Required --}}
         @if (!auth()->user()->github_id)
             <flux:callout variant="warning" icon="exclamation-triangle">
                 <flux:callout.heading>GitHub Connection Required</flux:callout.heading>
                 <flux:callout.text>
-                    To submit a plugin, you need to connect your GitHub account so we can access your repository and automatically set up webhooks.
+                    To create a plugin, you need to connect your GitHub account so we can access your repository.
                 </flux:callout.text>
                 <x-slot name="actions">
                     <flux:button variant="filled" href="{{ route('github.redirect', ['return' => route('customer.plugins.create')]) }}">
@@ -56,7 +42,7 @@
                 </x-slot>
             </flux:callout>
         @else
-            <form wire:submit="submitPlugin" class="space-y-8">
+            <form wire:submit="createPlugin" class="space-y-8">
                 {{-- Plugin Type --}}
                 @feature(App\Features\AllowPaidPlugins::class)
                 <flux:card>
@@ -69,7 +55,7 @@
                             <input type="radio" wire:model="pluginType" value="free" class="sr-only" />
                             <span class="flex flex-1 flex-col">
                                 <span class="text-sm font-medium text-gray-900 dark:text-white">Free Plugin</span>
-                                <span class="mt-1 text-sm text-gray-500 dark:text-gray-400">Open source, hosted on Packagist/GitHub</span>
+                                <span class="mt-1 text-sm text-gray-500 dark:text-gray-400">Open source, hosted on Packagist</span>
                             </span>
                         </label>
 
@@ -102,7 +88,7 @@
 
                     <flux:heading size="lg">Select Repository</flux:heading>
                     <flux:text class="mt-1">
-                        Choose the repository containing your plugin. We'll automatically set up a webhook to keep your plugin in sync.
+                        Choose the repository containing your plugin.
                     </flux:text>
 
                     <div class="mt-6 space-y-4">
@@ -126,9 +112,6 @@
                                 </flux:select>
                             @endif
                         @endif
-                        @error('repository')
-                            <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                        @enderror
                     </div>
                 </flux:card>
 
@@ -159,36 +142,10 @@
                 @endif
                 @endfeature
 
-                @if($repository)
-                    {{-- Support Channel --}}
-                    <flux:card>
-                        <flux:heading size="lg">Support Channel</flux:heading>
-                        <flux:text class="mt-1">
-                            How can users get support for your plugin? Provide an email address or a URL. If you enter a URL, ensure that it clearly details how a visitor goes about getting support for this plugin.
-                        </flux:text>
-
-                        <div class="mt-6">
-                            <flux:input wire:model="supportChannel" label="Support Channel" placeholder="support@example.com or https://..." />
-                        </div>
-                    </flux:card>
-
-                    {{-- Notes --}}
-                    <flux:card>
-                        <flux:heading size="lg">Notes</flux:heading>
-                        <flux:text class="mt-1">
-                            Any notes for the review team? Feel free to share links to videos of the plugin working. These won't be displayed on your plugin listing.
-                        </flux:text>
-
-                        <div class="mt-6">
-                            <flux:textarea wire:model="notes" label="Notes" placeholder="Optional notes for the review team..." rows="4" />
-                        </div>
-                    </flux:card>
-                @endif
-
                 {{-- Submit Button --}}
                 <div class="flex items-center justify-end gap-4">
                     <flux:button variant="ghost" href="{{ route('customer.plugins.index') }}">Cancel</flux:button>
-                    <flux:button type="submit" variant="primary">Submit Plugin</flux:button>
+                    <flux:button type="submit" variant="primary">Create Plugin</flux:button>
                 </div>
             </form>
         @endif

--- a/resources/views/livewire/customer/plugins/index.blade.php
+++ b/resources/views/livewire/customer/plugins/index.blade.php
@@ -77,7 +77,6 @@
             <flux:table class="mt-4">
                 <flux:table.columns>
                     <flux:table.column>Plugin</flux:table.column>
-                    <flux:table.column>Status</flux:table.column>
                     <flux:table.column></flux:table.column>
                 </flux:table.columns>
 
@@ -91,8 +90,10 @@
                                             <div class="size-3 rounded-full bg-gray-400"></div>
                                         @elseif ($plugin->isPending())
                                             <div class="size-3 animate-pulse rounded-full bg-yellow-400"></div>
-                                        @elseif ($plugin->isApproved())
+                                        @elseif ($plugin->isApproved() && $plugin->is_active)
                                             <div class="size-3 rounded-full bg-green-400"></div>
+                                        @elseif ($plugin->isApproved() && ! $plugin->is_active)
+                                            <div class="size-3 rounded-full bg-gray-400"></div>
                                         @else
                                             <div class="size-3 rounded-full bg-red-400"></div>
                                         @endif
@@ -107,10 +108,6 @@
                                         </flux:text>
                                     </div>
                                 </div>
-                            </flux:table.cell>
-
-                            <flux:table.cell>
-                                <x-customer.status-badge :status="$plugin->status->label()" />
                             </flux:table.cell>
 
                             <flux:table.cell class="text-right">

--- a/resources/views/livewire/customer/plugins/index.blade.php
+++ b/resources/views/livewire/customer/plugins/index.blade.php
@@ -6,19 +6,19 @@
 
     {{-- Action Cards --}}
     <div class="grid gap-6 md:grid-cols-3">
-        {{-- Submit Plugin Card --}}
+        {{-- Create Plugin Card --}}
         <flux:card class="relative overflow-hidden border-2 border-indigo-500 dark:border-indigo-400">
             <div class="absolute -right-4 -top-4 size-24 rounded-full bg-indigo-500/10 dark:bg-indigo-400/10"></div>
             <div class="relative">
                 <div class="flex size-12 items-center justify-center rounded-lg bg-indigo-500 text-white dark:bg-indigo-600">
                     <x-heroicon-o-plus class="size-6" />
                 </div>
-                <flux:heading size="lg" class="mt-4">Submit Your Plugin</flux:heading>
+                <flux:heading size="lg" class="mt-4">Create Your Plugin</flux:heading>
                 <flux:text class="mt-2">
-                    Built a plugin? Submit it to the NativePHP Plugin Marketplace and share it with the community.
+                    Built a plugin? Add it to the NativePHP Plugin Marketplace and share it with the community.
                 </flux:text>
                 <flux:button variant="primary" href="{{ route('customer.plugins.create') }}" class="mt-4">
-                    Submit a Plugin
+                    Create a Plugin
                 </flux:button>
             </div>
         </flux:card>
@@ -61,12 +61,13 @@
         </flux:callout>
     @endif
 
-    {{-- Submitted Plugins List --}}
+    {{-- Plugins List --}}
     <div class="mt-8">
-        <flux:heading size="lg">Your Submitted Plugins</flux:heading>
-        <flux:text class="mt-1">Track the status of your plugin submissions.</flux:text>
+        <flux:heading size="lg">Your Plugins</flux:heading>
+        <flux:text class="mt-1">Track the status of your plugins.</flux:text>
 
         <flux:radio.group wire:model.live="status" variant="segmented" class="mt-4">
+            <flux:radio value="draft" label="Draft ({{ $this->pluginCounts['draft'] }})" />
             <flux:radio value="pending" label="Pending ({{ $this->pluginCounts['pending'] }})" />
             <flux:radio value="rejected" label="Rejected ({{ $this->pluginCounts['rejected'] }})" />
             <flux:radio value="approved" label="Approved ({{ $this->pluginCounts['approved'] }})" />
@@ -86,7 +87,9 @@
                             <flux:table.cell>
                                 <div class="flex items-center gap-3">
                                     <div class="shrink-0">
-                                        @if ($plugin->isPending())
+                                        @if ($plugin->isDraft())
+                                            <div class="size-3 rounded-full bg-gray-400"></div>
+                                        @elseif ($plugin->isPending())
                                             <div class="size-3 animate-pulse rounded-full bg-yellow-400"></div>
                                         @elseif ($plugin->isApproved())
                                             <div class="size-3 rounded-full bg-green-400"></div>
@@ -95,21 +98,30 @@
                                         @endif
                                     </div>
                                     <div>
-                                        <span class="font-mono text-sm font-medium">{{ $plugin->name }}</span>
+                                        <span class="text-sm font-medium">{{ $plugin->display_name ?? $plugin->name }}</span>
+                                        @if ($plugin->display_name)
+                                            <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                        @endif
                                         <flux:text class="text-xs">
-                                            {{ $plugin->type->label() }} plugin &bull; Submitted {{ $plugin->created_at->diffForHumans() }}
+                                            {{ $plugin->type->label() }} plugin &bull; Created {{ $plugin->created_at->diffForHumans() }}
                                         </flux:text>
                                     </div>
                                 </div>
                             </flux:table.cell>
 
                             <flux:table.cell>
-                                <x-customer.status-badge :status="$plugin->isPending() ? 'Pending Review' : ($plugin->isApproved() ? 'Approved' : 'Rejected')" />
+                                <x-customer.status-badge :status="$plugin->status->label()" />
                             </flux:table.cell>
 
                             <flux:table.cell class="text-right">
                                 <flux:button size="xs" variant="ghost" href="{{ route('customer.plugins.show', $plugin->routeParams()) }}">
-                                    Edit
+                                    @if ($plugin->isDraft())
+                                        Edit
+                                    @elseif ($plugin->isApproved())
+                                        Manage
+                                    @else
+                                        View
+                                    @endif
                                 </flux:button>
                             </flux:table.cell>
                         </flux:table.row>

--- a/resources/views/livewire/customer/plugins/show.blade.php
+++ b/resources/views/livewire/customer/plugins/show.blade.php
@@ -433,6 +433,30 @@
             </flux:tab.group>
         @elseif ($plugin->isApproved())
             {{-- Editable fields for Approved plugins (no tabs) --}}
+
+            {{-- Read-only Type & Tier --}}
+            <flux:card class="mb-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <flux:heading size="lg">Type</flux:heading>
+                        <flux:text class="mt-1">
+                            @if ($plugin->isPaid() && $plugin->tier)
+                                @php
+                                    $prices = $plugin->tier->getPrices();
+                                    $subscriberPrice = $prices[\App\Enums\PriceTier::Subscriber->value] / 100;
+                                    $regularPrice = $prices[\App\Enums\PriceTier::Regular->value] / 100;
+                                @endphp
+                                Paid &mdash; {{ $plugin->tier->label() }} (${{ number_format($subscriberPrice) }} – ${{ number_format($regularPrice) }})
+                            @elseif ($plugin->isPaid())
+                                Paid
+                            @else
+                                Free
+                            @endif
+                        </flux:text>
+                    </div>
+                </div>
+            </flux:card>
+
             <form wire:submit="save" class="space-y-6">
                 {{-- Display Name --}}
                 <flux:card>
@@ -446,22 +470,6 @@
                             maxlength="250"
                         />
                         <flux:text class="mt-2 text-xs">Maximum 250 characters</flux:text>
-                    </div>
-                </flux:card>
-
-                {{-- Support Channel --}}
-                <flux:card>
-                    <flux:heading size="lg">Support</flux:heading>
-                    <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
-
-                    <div class="mt-4">
-                        <flux:input
-                            wire:model="supportChannel"
-                            placeholder="support@example.com or https://..."
-                        />
-                        @error('supportChannel')
-                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                        @enderror
                     </div>
                 </flux:card>
 
@@ -571,6 +579,22 @@
                                 Or choose a gradient icon instead
                             </button>
                         </div>
+                    </div>
+                </flux:card>
+
+                {{-- Support Channel --}}
+                <flux:card>
+                    <flux:heading size="lg">Support</flux:heading>
+                    <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
+
+                    <div class="mt-4">
+                        <flux:input
+                            wire:model="supportChannel"
+                            placeholder="support@example.com or https://..."
+                        />
+                        @error('supportChannel')
+                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                        @enderror
                     </div>
                 </flux:card>
 

--- a/resources/views/livewire/customer/plugins/show.blade.php
+++ b/resources/views/livewire/customer/plugins/show.blade.php
@@ -78,21 +78,6 @@
             </flux:card>
         @endif
 
-        {{-- Plugin Status (hidden for Pending/Rejected — details card covers this) --}}
-        @if ($plugin->isDraft() || $plugin->isApproved())
-            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
-                <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3">
-                            <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
-                            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
-                        </div>
-                        <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
-                    </div>
-                </flux:card>
-            </a>
-        @endif
-
         {{-- Review Checks (show for Pending, Rejected, Approved — not Draft) --}}
         @if (! $plugin->isDraft() && $plugin->review_checks)
             <flux:card class="mb-6">
@@ -202,6 +187,19 @@
                 </flux:tabs>
 
                 <flux:tab.panel name="details">
+                    {{-- GitHub Repo --}}
+                    <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
+                        <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-3">
+                                    <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
+                                    <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
+                                </div>
+                                <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
+                            </div>
+                        </flux:card>
+                    </a>
+
                     <form wire:submit="save" class="space-y-6">
                         {{-- Plugin Type --}}
                         @feature(App\Features\AllowPaidPlugins::class)
@@ -232,7 +230,7 @@
 
                         {{-- Pricing Tier (only when paid) --}}
                         @if ($pluginType === 'paid')
-                            <flux:card>
+                            <flux:card :class="$errors->has('tier') ? '!border-red-500 dark:!border-red-400' : ''">
                                 <flux:heading size="lg">Pricing Tier</flux:heading>
                                 <flux:text class="mt-1">Choose a pricing tier for your plugin.</flux:text>
 
@@ -253,6 +251,10 @@
                                         </label>
                                     @endforeach
                                 </div>
+
+                                @error('tier')
+                                    <flux:text class="mt-4 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                @enderror
 
                                 <flux:text class="mt-4 text-xs text-gray-500 dark:text-gray-400">
                                     Actual sale price may vary due to discounts and offers. You keep 70% of the sale price. If a NativePHP Ultra subscriber purchases your plugin, you receive 100% of the sale price. Additional payment processing fees may apply.
@@ -410,6 +412,73 @@
 
                 <flux:tab.panel name="submit">
                     <div class="space-y-6">
+                        {{-- Plugin Summary --}}
+                        <flux:card>
+                            <div class="flex items-start justify-between">
+                                <div class="flex items-start gap-4">
+                                    @if ($plugin->hasLogo())
+                                        <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 shrink-0 rounded-lg object-cover shadow-sm" />
+                                    @elseif ($plugin->hasGradientIcon())
+                                        <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                            <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                        </div>
+                                    @else
+                                        <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-sm">
+                                            <x-vaadin-plug class="size-8" />
+                                        </div>
+                                    @endif
+                                    <div>
+                                        <flux:heading size="lg">{{ $plugin->display_name ?? $plugin->name }}</flux:heading>
+                                        @if ($plugin->display_name)
+                                            <flux:text class="font-mono text-xs">{{ $plugin->name }}</flux:text>
+                                        @endif
+                                        @if ($plugin->description)
+                                            <flux:text class="mt-2">{{ $plugin->description }}</flux:text>
+                                        @else
+                                            <flux:text class="mt-2 text-gray-400 dark:text-gray-500">No description provided</flux:text>
+                                        @endif
+                                    </div>
+                                </div>
+                                @if ($plugin->isPaid() && $plugin->tier)
+                                    @php
+                                        $regularPrice = $plugin->tier->getPrices()[\App\Enums\PriceTier::Regular->value] / 100;
+                                    @endphp
+                                    <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                                        {{ $plugin->tier->label() }}&nbsp;&mdash;&nbsp;${{ number_format($regularPrice) }}
+                                    </span>
+                                @elseif ($plugin->isPaid())
+                                    <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                                        Paid
+                                    </span>
+                                @else
+                                    <span class="inline-flex shrink-0 items-center text-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                                        Free
+                                    </span>
+                                @endif
+                            </div>
+
+                            <flux:separator class="my-4" />
+
+                            <div class="space-y-3">
+                                <div>
+                                    <flux:heading size="sm">Support Channel</flux:heading>
+                                    @if ($plugin->support_channel)
+                                        <flux:text class="mt-1">{{ $plugin->support_channel }}</flux:text>
+                                    @else
+                                        <flux:text class="mt-1 text-gray-400 dark:text-gray-500">No support channel set</flux:text>
+                                    @endif
+                                </div>
+
+                                <div>
+                                    <flux:heading size="sm">Repository</flux:heading>
+                                    <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="mt-1 inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                        {{ $plugin->repository_url }}
+                                        <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+                                    </a>
+                                </div>
+                            </div>
+                        </flux:card>
+
                         {{-- Notes --}}
                         <flux:card>
                             <flux:heading size="lg">Notes</flux:heading>
@@ -433,6 +502,19 @@
             </flux:tab.group>
         @elseif ($plugin->isApproved())
             {{-- Editable fields for Approved plugins (no tabs) --}}
+
+            {{-- GitHub Repo --}}
+            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
+                <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-3">
+                            <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
+                            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
+                        </div>
+                        <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
+                    </div>
+                </flux:card>
+            </a>
 
             {{-- Read-only Type & Tier --}}
             <flux:card class="mb-6">

--- a/resources/views/livewire/customer/plugins/show.blade.php
+++ b/resources/views/livewire/customer/plugins/show.blade.php
@@ -4,8 +4,24 @@
             <x-heroicon-s-arrow-left class="size-4" />
             <span class="font-medium">Plugins</span>
         </a>
-        <flux:heading size="xl" class="mt-4">Edit Plugin</flux:heading>
-        <flux:text class="font-mono">{{ $plugin->name }}</flux:text>
+        <flux:heading size="xl" class="mt-4">
+            @if ($plugin->isDraft())
+                Edit Draft Plugin
+            @elseif ($plugin->isPending())
+                Plugin Under Review
+            @elseif ($plugin->isRejected())
+                Plugin Rejected
+            @elseif ($plugin->isApproved())
+                Manage Plugin
+            @endif
+        </flux:heading>
+        <div class="mt-1 flex items-center gap-3">
+            <flux:text class="font-mono">{{ $plugin->display_name ?? $plugin->name }}</flux:text>
+            <a href="{{ route('plugins.show', $plugin->routeParams()) }}" target="_blank" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                Preview Listing
+                <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+            </a>
+        </div>
     </div>
 
     <div class="mx-auto max-w-3xl">
@@ -22,49 +38,63 @@
             </flux:callout>
         @endif
 
-        {{-- Rejection Reason --}}
-        @if ($plugin->isRejected() && $plugin->rejection_reason)
+        {{-- Status-specific banners --}}
+        @if ($plugin->isDraft())
+            <flux:callout variant="info" icon="information-circle" class="mb-6">
+                <flux:callout.heading>Draft Plugin</flux:callout.heading>
+                <flux:callout.text>This plugin is a draft. Edit the details below, then submit for review when ready.</flux:callout.text>
+            </flux:callout>
+        @elseif ($plugin->isPending())
+            <flux:callout variant="warning" icon="clock" class="mb-6">
+                <flux:callout.heading>Under Review</flux:callout.heading>
+                <flux:callout.text>Your plugin is currently being reviewed. You can withdraw it to make changes.</flux:callout.text>
+                <x-slot name="actions">
+                    <flux:button variant="ghost" wire:click="withdrawFromReview" wire:confirm="Are you sure you want to withdraw this plugin from review? It will return to draft status.">Withdraw from Review</flux:button>
+                </x-slot>
+            </flux:callout>
+        @elseif ($plugin->isRejected() && $plugin->rejection_reason)
             <flux:callout variant="danger" icon="x-circle" class="mb-6">
                 <flux:callout.heading>Rejection Reason</flux:callout.heading>
                 <flux:callout.text>{{ $plugin->rejection_reason }}</flux:callout.text>
                 <x-slot name="actions">
-                    <flux:button variant="danger" wire:click="resubmit">Resubmit for Review</flux:button>
+                    <flux:button variant="danger" wire:click="returnToDraft">Return to Draft</flux:button>
                 </x-slot>
             </flux:callout>
-        @endif
-
-        {{-- Plugin Status --}}
-        <flux:card class="mb-6">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center gap-3">
-                    @if ($plugin->hasLogo())
-                        <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-10 rounded-lg object-cover" />
-                    @elseif ($plugin->hasGradientIcon())
-                        <div class="grid size-10 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white">
-                            <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-5" />
-                        </div>
-                    @else
-                        <div class="grid size-10 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
-                            <x-vaadin-plug class="size-5" />
-                        </div>
-                    @endif
+        @elseif ($plugin->isApproved())
+            <flux:card class="mb-6">
+                <div class="flex items-center justify-between">
                     <div>
-                        <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
-                        <flux:text class="text-xs">
-                            {{ $plugin->type->label() }} plugin
-                            @if ($plugin->latest_version)
-                                <span class="text-gray-400 dark:text-gray-500">&bull;</span>
-                                v{{ $plugin->latest_version }}
+                        <flux:heading size="lg">Listing Status</flux:heading>
+                        <flux:text class="mt-1">
+                            @if ($plugin->is_active)
+                                Your plugin is publicly listed in the directory.
+                            @else
+                                Your plugin is de-listed and hidden from the directory.
                             @endif
                         </flux:text>
                     </div>
+                    <flux:switch wire:click="toggleListing" :checked="$plugin->is_active" />
                 </div>
-                <x-customer.status-badge :status="$plugin->isPending() ? 'Pending Review' : ($plugin->isApproved() ? 'Approved' : 'Rejected')" />
-            </div>
-        </flux:card>
+            </flux:card>
+        @endif
 
-        {{-- Review Checks --}}
-        @if ($plugin->review_checks)
+        {{-- Plugin Status (hidden for Pending/Rejected — details card covers this) --}}
+        @if ($plugin->isDraft() || $plugin->isApproved())
+            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
+                <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-3">
+                            <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
+                            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
+                        </div>
+                        <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
+                    </div>
+                </flux:card>
+            </a>
+        @endif
+
+        {{-- Review Checks (show for Pending, Rejected, Approved — not Draft) --}}
+        @if (! $plugin->isDraft() && $plugin->review_checks)
             <flux:card class="mb-6">
                 <flux:heading size="lg">Review Checks</flux:heading>
                 <flux:text class="mt-1">Automated checks run against your repository.</flux:text>
@@ -163,140 +193,464 @@
             </flux:card>
         @endif
 
-        {{-- Support Channel --}}
-        <flux:card class="mb-6">
-            <flux:heading size="lg">Support Channel</flux:heading>
-            <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
+        {{-- Editable fields for Draft plugins (with tabs) --}}
+        @if ($plugin->isDraft())
+            <flux:tab.group>
+                <flux:tabs wire:model="activeTab">
+                    <flux:tab name="details">Details</flux:tab>
+                    <flux:tab name="submit">Submit for Review</flux:tab>
+                </flux:tabs>
 
-            <form wire:submit="updateSupportChannel" class="mt-4">
-                <flux:input
-                    wire:model="supportChannel"
-                    placeholder="support@example.com or https://..."
-                />
-                @error('supportChannel')
-                    <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                @enderror
+                <flux:tab.panel name="details">
+                    <form wire:submit="save" class="space-y-6">
+                        {{-- Plugin Type --}}
+                        @feature(App\Features\AllowPaidPlugins::class)
+                        <flux:card>
+                            <flux:heading size="lg">Type</flux:heading>
+                            <flux:text class="mt-1">Is your plugin free or paid?</flux:text>
 
-                <div class="mt-4 flex justify-end">
-                    <flux:button type="submit" variant="primary">Save Support Channel</flux:button>
-                </div>
-            </form>
-        </flux:card>
+                            <div class="mt-6 space-y-4">
+                                <label class="relative flex cursor-pointer rounded-lg border p-4 transition focus:outline-none"
+                                    :class="$wire.pluginType === 'free' ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/30' : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50'">
+                                    <input type="radio" wire:model.live="pluginType" value="free" class="sr-only" />
+                                    <span class="flex flex-1 flex-col">
+                                        <span class="text-sm font-medium text-gray-900 dark:text-white">Free Plugin</span>
+                                        <span class="mt-1 text-sm text-gray-500 dark:text-gray-400">Open source, hosted on Packagist</span>
+                                    </span>
+                                </label>
 
-        {{-- Plugin Icon --}}
-        <flux:card class="mb-6" x-data="{ mode: @entangle('iconMode') }">
-            <flux:heading size="lg">Plugin Icon</flux:heading>
-            <flux:text class="mt-1">Choose a gradient and icon, or upload your own logo.</flux:text>
-
-            <div class="mt-4">
-                {{-- Current Icon Preview --}}
-                @if ($plugin->hasCustomIcon())
-                    <div class="mb-4 flex items-center gap-4">
-                        @if ($plugin->hasLogo())
-                            <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 rounded-lg object-cover shadow-sm" />
-                        @elseif ($plugin->hasGradientIcon())
-                            <div class="grid size-16 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
-                                <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                <label class="relative flex cursor-pointer rounded-lg border p-4 transition focus:outline-none"
+                                    :class="$wire.pluginType === 'paid' ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/30' : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50'">
+                                    <input type="radio" wire:model.live="pluginType" value="paid" class="sr-only" />
+                                    <span class="flex flex-1 flex-col">
+                                        <span class="text-sm font-medium text-gray-900 dark:text-white">Paid Plugin</span>
+                                        <span class="mt-1 text-sm text-gray-500 dark:text-gray-400">Commercial plugin, hosted on plugins.nativephp.com</span>
+                                    </span>
+                                </label>
                             </div>
-                        @endif
-                        <flux:button size="sm" variant="danger" icon="trash" wire:click="deleteIcon">Remove icon</flux:button>
-                    </div>
-                @endif
+                        </flux:card>
 
-                {{-- Gradient Icon Picker --}}
-                <div x-show="mode === 'gradient'" x-cloak>
-                    <form wire:submit="updateIcon">
-                        <div class="space-y-4">
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Choose a gradient</label>
-                                <div class="mt-2 grid grid-cols-4 gap-3 sm:grid-cols-8">
-                                    @foreach (\App\Models\Plugin::gradientPresets() as $key => $classes)
-                                        <label class="relative cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                wire:model="iconGradient"
-                                                value="{{ $key }}"
-                                                class="peer sr-only"
-                                            />
-                                            <div class="size-12 rounded-lg bg-gradient-to-br {{ $classes }} ring-2 ring-transparent ring-offset-2 transition-all peer-checked:ring-indigo-500 peer-focus:ring-indigo-500 hover:scale-105 dark:ring-offset-gray-800"></div>
+                        {{-- Pricing Tier (only when paid) --}}
+                        @if ($pluginType === 'paid')
+                            <flux:card>
+                                <flux:heading size="lg">Pricing Tier</flux:heading>
+                                <flux:text class="mt-1">Choose a pricing tier for your plugin.</flux:text>
+
+                                <div class="mt-6 space-y-4">
+                                    @foreach (\App\Enums\PluginTier::cases() as $pluginTier)
+                                        @php
+                                            $prices = $pluginTier->getPrices();
+                                            $subscriberPrice = $prices[\App\Enums\PriceTier::Subscriber->value] / 100;
+                                            $regularPrice = $prices[\App\Enums\PriceTier::Regular->value] / 100;
+                                        @endphp
+                                        <label class="relative flex cursor-pointer rounded-lg border p-4 transition focus:outline-none"
+                                            :class="$wire.tier === '{{ $pluginTier->value }}' ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/30' : 'border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50'">
+                                            <input type="radio" wire:model.live="tier" value="{{ $pluginTier->value }}" class="sr-only" />
+                                            <span class="flex flex-1 items-center justify-between">
+                                                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $pluginTier->label() }}</span>
+                                                <span class="text-lg font-semibold text-gray-900 dark:text-white">${{ number_format($subscriberPrice) }} – ${{ number_format($regularPrice) }}</span>
+                                            </span>
                                         </label>
                                     @endforeach
                                 </div>
-                                @error('iconGradient')
-                                    <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+
+                                <flux:text class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+                                    Actual sale price may vary due to discounts and offers. You keep 70% of the sale price. If a NativePHP Ultra subscriber purchases your plugin, you receive 100% of the sale price. Additional payment processing fees may apply.
+                                </flux:text>
+                            </flux:card>
+                        @endif
+                        @endfeature
+
+                        {{-- Display Name --}}
+                        <flux:card>
+                            <flux:heading size="lg">Name <span class="text-sm font-normal text-gray-400 dark:text-gray-500">(optional)</span></flux:heading>
+                            <flux:text class="mt-1">A display name for your plugin. If not set, your Composer package name will be used.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:input
+                                    wire:model="displayName"
+                                    placeholder="{{ $plugin->name }}"
+                                    maxlength="250"
+                                />
+                                <flux:text class="mt-2 text-xs">Maximum 250 characters</flux:text>
+                            </div>
+                        </flux:card>
+
+                        {{-- Description --}}
+                        <flux:card>
+                            <flux:heading size="lg">Description</flux:heading>
+                            <flux:text class="mt-1">Describe what your plugin does. This will be displayed in the plugin directory.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:textarea
+                                    wire:model="description"
+                                    rows="5"
+                                    placeholder="Describe what your plugin does, its key features, and how developers can use it..."
+                                />
+                                @error('description')
+                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                @enderror
+                                <flux:text class="mt-2 text-xs">Maximum 1000 characters</flux:text>
+                            </div>
+                        </flux:card>
+
+                        {{-- Icon --}}
+                        <flux:card x-data="{ mode: @entangle('iconMode') }">
+                            <flux:heading size="lg">Icon</flux:heading>
+                            <flux:text class="mt-1">Choose a gradient and icon, or upload your own logo.</flux:text>
+
+                            <div class="mt-4">
+                                {{-- Current Icon Preview --}}
+                                @if ($plugin->hasCustomIcon())
+                                    <div class="mb-4 flex items-center gap-4">
+                                        @if ($plugin->hasLogo())
+                                            <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 rounded-lg object-cover shadow-sm" />
+                                        @elseif ($plugin->hasGradientIcon())
+                                            <div class="grid size-16 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                                <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                            </div>
+                                        @endif
+                                        <flux:button size="sm" variant="danger" icon="trash" wire:click="deleteIcon" type="button">Remove icon</flux:button>
+                                    </div>
+                                @endif
+
+                                {{-- Gradient Icon Picker --}}
+                                <div x-show="mode === 'gradient'" x-cloak>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Choose a gradient</label>
+                                            <div class="mt-2 grid grid-cols-4 gap-3 sm:grid-cols-8">
+                                                @foreach (\App\Models\Plugin::gradientPresets() as $key => $classes)
+                                                    <label class="relative cursor-pointer">
+                                                        <input
+                                                            type="radio"
+                                                            wire:model="iconGradient"
+                                                            value="{{ $key }}"
+                                                            class="peer sr-only"
+                                                        />
+                                                        <div class="size-12 rounded-lg bg-gradient-to-br {{ $classes }} ring-2 ring-transparent ring-offset-2 transition-all peer-checked:ring-indigo-500 peer-focus:ring-indigo-500 hover:scale-105 dark:ring-offset-gray-800"></div>
+                                                    </label>
+                                                @endforeach
+                                            </div>
+                                            @error('iconGradient')
+                                                <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                            @enderror
+                                        </div>
+
+                                        <flux:input
+                                            wire:model="iconName"
+                                            label="Heroicon name"
+                                            placeholder="cube"
+                                            description="Enter a Heroicon outline name, e.g., cube, sparkles, bolt."
+                                        />
+                                        @error('iconName')
+                                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                        @enderror
+
+                                        <flux:button wire:click="updateIcon" variant="filled" type="button">Save Icon</flux:button>
+                                    </div>
+
+                                    <flux:separator class="my-4" />
+                                    <button type="button" @click="mode = 'upload'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                        Or upload your own logo instead
+                                    </button>
+                                </div>
+
+                                {{-- Custom Logo Upload --}}
+                                <div x-show="mode === 'upload'" x-cloak>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload a logo</label>
+                                            <div class="mt-2 flex items-center gap-4">
+                                                <input
+                                                    type="file"
+                                                    wire:model="logo"
+                                                    accept="image/png,image/jpeg,image/jpg,image/svg+xml,image/webp"
+                                                    class="block text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900/50 dark:file:text-indigo-300 dark:hover:file:bg-indigo-900/70"
+                                                />
+                                                <flux:button wire:click="uploadLogo" variant="filled" type="button">Upload</flux:button>
+                                            </div>
+                                            @error('logo')
+                                                <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                            @enderror
+                                            <flux:text class="mt-2 text-xs">PNG, JPG, SVG, or WebP. Max 1MB. Recommended: 256x256 pixels, square.</flux:text>
+                                        </div>
+                                    </div>
+
+                                    <flux:separator class="my-4" />
+                                    <button type="button" @click="mode = 'gradient'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                        Or choose a gradient icon instead
+                                    </button>
+                                </div>
+                            </div>
+                        </flux:card>
+
+                        {{-- Support Channel --}}
+                        <flux:card>
+                            <flux:heading size="lg">Support</flux:heading>
+                            <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:input
+                                    wire:model="supportChannel"
+                                    placeholder="support@example.com or https://..."
+                                />
+                                @error('supportChannel')
+                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
                                 @enderror
                             </div>
+                        </flux:card>
 
-                            <flux:input
-                                wire:model="iconName"
-                                label="Heroicon name"
-                                placeholder="cube"
-                                description="Enter a Heroicon outline name, e.g., cube, sparkles, bolt."
-                            />
-                            @error('iconName')
-                                <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                            @enderror
-
-                            <flux:button type="submit" variant="primary">Save Icon</flux:button>
+                        {{-- Save Button --}}
+                        <div class="flex items-center justify-end">
+                            <flux:button type="submit" variant="primary">Save Changes</flux:button>
                         </div>
                     </form>
+                </flux:tab.panel>
 
-                    <flux:separator class="my-4" />
-                    <button type="button" @click="mode = 'upload'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
-                        Or upload your own logo instead
-                    </button>
-                </div>
+                <flux:tab.panel name="submit">
+                    <div class="space-y-6">
+                        {{-- Notes --}}
+                        <flux:card>
+                            <flux:heading size="lg">Notes</flux:heading>
+                            <flux:text class="mt-1">Any notes for the review team? These won't be displayed on your plugin listing.</flux:text>
 
-                {{-- Custom Logo Upload --}}
-                <div x-show="mode === 'upload'" x-cloak>
-                    <form wire:submit="uploadLogo" class="space-y-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload a logo</label>
-                            <div class="mt-2 flex items-center gap-4">
-                                <input
-                                    type="file"
-                                    wire:model="logo"
-                                    accept="image/png,image/jpeg,image/jpg,image/svg+xml,image/webp"
-                                    class="block text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900/50 dark:file:text-indigo-300 dark:hover:file:bg-indigo-900/70"
+                            <div class="mt-4">
+                                <flux:textarea
+                                    wire:model="notes"
+                                    rows="4"
+                                    placeholder="Optional notes for the review team..."
                                 />
-                                <flux:button type="submit" variant="primary">Upload</flux:button>
                             </div>
-                            @error('logo')
-                                <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                            @enderror
-                            <flux:text class="mt-2 text-xs">PNG, JPG, SVG, or WebP. Max 1MB. Recommended: 256x256 pixels, square.</flux:text>
+                        </flux:card>
+
+                        {{-- Submit Button --}}
+                        <div class="flex items-center justify-end">
+                            <flux:button variant="primary" wire:click="submitForReview">Submit for Review</flux:button>
                         </div>
-                    </form>
+                    </div>
+                </flux:tab.panel>
+            </flux:tab.group>
+        @elseif ($plugin->isApproved())
+            {{-- Editable fields for Approved plugins (no tabs) --}}
+            <form wire:submit="save" class="space-y-6">
+                {{-- Display Name --}}
+                <flux:card>
+                    <flux:heading size="lg">Name <span class="text-sm font-normal text-gray-400 dark:text-gray-500">(optional)</span></flux:heading>
+                    <flux:text class="mt-1">A display name for your plugin. If not set, your Composer package name will be used.</flux:text>
 
-                    <flux:separator class="my-4" />
-                    <button type="button" @click="mode = 'gradient'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
-                        Or choose a gradient icon instead
-                    </button>
-                </div>
-            </div>
-        </flux:card>
+                    <div class="mt-4">
+                        <flux:input
+                            wire:model="displayName"
+                            placeholder="{{ $plugin->name }}"
+                            maxlength="250"
+                        />
+                        <flux:text class="mt-2 text-xs">Maximum 250 characters</flux:text>
+                    </div>
+                </flux:card>
 
-        {{-- Description Form --}}
-        <flux:card class="mb-6">
-            <flux:heading size="lg">Plugin Description</flux:heading>
-            <flux:text class="mt-1">Describe what your plugin does. This will be displayed in the plugin directory.</flux:text>
+                {{-- Support Channel --}}
+                <flux:card>
+                    <flux:heading size="lg">Support</flux:heading>
+                    <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
 
-            <form wire:submit="updateDescription" class="mt-4">
-                <flux:textarea
-                    wire:model="description"
-                    rows="5"
-                    placeholder="Describe what your plugin does, its key features, and how developers can use it..."
-                />
-                @error('description')
-                    <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                @enderror
-                <flux:text class="mt-2 text-xs">Maximum 1000 characters</flux:text>
+                    <div class="mt-4">
+                        <flux:input
+                            wire:model="supportChannel"
+                            placeholder="support@example.com or https://..."
+                        />
+                        @error('supportChannel')
+                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                        @enderror
+                    </div>
+                </flux:card>
 
-                <div class="mt-4 flex justify-end">
-                    <flux:button type="submit" variant="primary">Save Description</flux:button>
+                {{-- Description --}}
+                <flux:card>
+                    <flux:heading size="lg">Description</flux:heading>
+                    <flux:text class="mt-1">Describe what your plugin does. This will be displayed in the plugin directory.</flux:text>
+
+                    <div class="mt-4">
+                        <flux:textarea
+                            wire:model="description"
+                            rows="5"
+                            placeholder="Describe what your plugin does, its key features, and how developers can use it..."
+                        />
+                        @error('description')
+                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                        @enderror
+                        <flux:text class="mt-2 text-xs">Maximum 1000 characters</flux:text>
+                    </div>
+                </flux:card>
+
+                {{-- Icon --}}
+                <flux:card x-data="{ mode: @entangle('iconMode') }">
+                    <flux:heading size="lg">Icon</flux:heading>
+                    <flux:text class="mt-1">Choose a gradient and icon, or upload your own logo.</flux:text>
+
+                    <div class="mt-4">
+                        {{-- Current Icon Preview --}}
+                        @if ($plugin->hasCustomIcon())
+                            <div class="mb-4 flex items-center gap-4">
+                                @if ($plugin->hasLogo())
+                                    <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 rounded-lg object-cover shadow-sm" />
+                                @elseif ($plugin->hasGradientIcon())
+                                    <div class="grid size-16 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                        <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                    </div>
+                                @endif
+                                <flux:button size="sm" variant="danger" icon="trash" wire:click="deleteIcon" type="button">Remove icon</flux:button>
+                            </div>
+                        @endif
+
+                        {{-- Gradient Icon Picker --}}
+                        <div x-show="mode === 'gradient'" x-cloak>
+                            <div class="space-y-4">
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Choose a gradient</label>
+                                    <div class="mt-2 grid grid-cols-4 gap-3 sm:grid-cols-8">
+                                        @foreach (\App\Models\Plugin::gradientPresets() as $key => $classes)
+                                            <label class="relative cursor-pointer">
+                                                <input
+                                                    type="radio"
+                                                    wire:model="iconGradient"
+                                                    value="{{ $key }}"
+                                                    class="peer sr-only"
+                                                />
+                                                <div class="size-12 rounded-lg bg-gradient-to-br {{ $classes }} ring-2 ring-transparent ring-offset-2 transition-all peer-checked:ring-indigo-500 peer-focus:ring-indigo-500 hover:scale-105 dark:ring-offset-gray-800"></div>
+                                            </label>
+                                        @endforeach
+                                    </div>
+                                    @error('iconGradient')
+                                        <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                    @enderror
+                                </div>
+
+                                <flux:input
+                                    wire:model="iconName"
+                                    label="Heroicon name"
+                                    placeholder="cube"
+                                    description="Enter a Heroicon outline name, e.g., cube, sparkles, bolt."
+                                />
+                                @error('iconName')
+                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                @enderror
+
+                                <flux:button wire:click="updateIcon" variant="filled" type="button">Save Icon</flux:button>
+                            </div>
+
+                            <flux:separator class="my-4" />
+                            <button type="button" @click="mode = 'upload'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                Or upload your own logo instead
+                            </button>
+                        </div>
+
+                        {{-- Custom Logo Upload --}}
+                        <div x-show="mode === 'upload'" x-cloak>
+                            <div class="space-y-4">
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload a logo</label>
+                                    <div class="mt-2 flex items-center gap-4">
+                                        <input
+                                            type="file"
+                                            wire:model="logo"
+                                            accept="image/png,image/jpeg,image/jpg,image/svg+xml,image/webp"
+                                            class="block text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900/50 dark:file:text-indigo-300 dark:hover:file:bg-indigo-900/70"
+                                        />
+                                        <flux:button wire:click="uploadLogo" variant="filled" type="button">Upload</flux:button>
+                                    </div>
+                                    @error('logo')
+                                        <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                    @enderror
+                                    <flux:text class="mt-2 text-xs">PNG, JPG, SVG, or WebP. Max 1MB. Recommended: 256x256 pixels, square.</flux:text>
+                                </div>
+                            </div>
+
+                            <flux:separator class="my-4" />
+                            <button type="button" @click="mode = 'gradient'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                Or choose a gradient icon instead
+                            </button>
+                        </div>
+                    </div>
+                </flux:card>
+
+                {{-- Save Button --}}
+                <div class="flex items-center justify-end">
+                    <flux:button type="submit" variant="primary">Save Changes</flux:button>
                 </div>
             </form>
-        </flux:card>
+        @else
+            {{-- Read-only display for Pending/Rejected --}}
+            <flux:card class="mb-6">
+                <div class="flex items-start justify-between">
+                    <div class="flex items-start gap-4">
+                        @if ($plugin->hasLogo())
+                            <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 shrink-0 rounded-lg object-cover shadow-sm" />
+                        @elseif ($plugin->hasGradientIcon())
+                            <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                            </div>
+                        @else
+                            <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-sm">
+                                <x-vaadin-plug class="size-8" />
+                            </div>
+                        @endif
+                        <div>
+                            <flux:heading size="lg">{{ $plugin->display_name ?? $plugin->name }}</flux:heading>
+                            @if ($plugin->description)
+                                <flux:text class="mt-2">{{ $plugin->description }}</flux:text>
+                            @else
+                                <flux:text class="mt-2 text-gray-400 dark:text-gray-500">No description provided</flux:text>
+                            @endif
+                        </div>
+                    </div>
+                    @if ($plugin->isPaid() && $plugin->tier)
+                        @php
+                            $regularPrice = $plugin->tier->getPrices()[\App\Enums\PriceTier::Regular->value] / 100;
+                        @endphp
+                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                            {{ $plugin->tier->label() }}&nbsp;&mdash;&nbsp;${{ number_format($regularPrice) }}
+                        </span>
+                    @elseif ($plugin->isPaid())
+                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                            Paid
+                        </span>
+                    @else
+                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                            Free
+                        </span>
+                    @endif
+                </div>
+
+                <flux:separator class="my-4" />
+
+                <div class="space-y-3">
+                    <div>
+                        <flux:heading size="sm">Support Channel</flux:heading>
+                        @if ($plugin->support_channel)
+                            <flux:text class="mt-1">{{ $plugin->support_channel }}</flux:text>
+                        @else
+                            <flux:text class="mt-1 text-gray-400 dark:text-gray-500">No support channel set</flux:text>
+                        @endif
+                    </div>
+
+                    <div>
+                        <flux:heading size="sm">Repository</flux:heading>
+                        <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="mt-1 inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                            {{ $plugin->repository_url }}
+                            <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+                        </a>
+                    </div>
+                </div>
+            </flux:card>
+
+            @if ($plugin->notes)
+                <flux:card class="mb-6">
+                    <flux:heading size="lg">Submission Notes</flux:heading>
+                    <flux:text class="mt-2">{{ $plugin->notes }}</flux:text>
+                </flux:card>
+            @endif
+        @endif
 
     </div>
 </div>

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -87,7 +87,9 @@
                     >
                         {{ $plugin->display_name ?? $plugin->name }}
                     </h1>
-                    <p class="mt-1 font-mono text-sm text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                    @if ($plugin->display_name)
+                        <p class="mt-1 font-mono text-sm text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
+                    @endif
                     @if ($plugin->description)
                         <p class="mt-1 text-gray-600 dark:text-gray-400">
                             {{ $plugin->description }}

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -1,4 +1,4 @@
-<x-layout title="{{ $plugin->name }} - Plugin">
+<x-layout title="{{ $plugin->display_name ?? $plugin->name }} - Plugin">
     <section
         class="mx-auto mt-10 w-full max-w-7xl"
         aria-labelledby="plugin-title"
@@ -6,7 +6,12 @@
         @if ($isAdminPreview ?? false)
             <div class="mb-6 rounded-xl border border-amber-300 bg-amber-50 p-4 text-center dark:border-amber-600 dark:bg-amber-950/50">
                 <p class="text-sm font-medium text-amber-800 dark:text-amber-200">
-                    Admin Preview &mdash; This plugin is not yet published. Status: {{ $plugin->status->label() }}
+                    Preview &mdash; This plugin is not publicly visible.
+                    @if ($plugin->isApproved() && ! $plugin->is_active)
+                        It has been de-listed.
+                    @else
+                        Status: {{ $plugin->status->label() }}
+                    @endif
                 </p>
             </div>
         @endif
@@ -78,10 +83,11 @@
                 <div>
                     <h1
                         id="plugin-title"
-                        class="font-mono text-2xl font-bold sm:text-3xl"
+                        class="text-2xl font-bold sm:text-3xl"
                     >
-                        {{ $plugin->name }}
+                        {{ $plugin->display_name ?? $plugin->name }}
                     </h1>
+                    <p class="mt-1 font-mono text-sm text-gray-500 dark:text-gray-400">{{ $plugin->name }}</p>
                     @if ($plugin->description)
                         <p class="mt-1 text-gray-600 dark:text-gray-400">
                             {{ $plugin->description }}
@@ -269,6 +275,35 @@
                                 {{ $plugin->android_version ?? '—' }}
                             </dd>
                         </div>
+
+                        {{-- Support --}}
+                        @if ($plugin->support_channel)
+                            <div class="col-span-2 rounded-xl bg-gray-50 p-3 dark:bg-slate-700/30">
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Support</dt>
+                                <dd class="mt-1">
+                                    @if (filter_var($plugin->support_channel, FILTER_VALIDATE_URL))
+                                        <a
+                                            href="{{ $plugin->support_channel }}"
+                                            target="_blank"
+                                            class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                        >
+                                            {{ $plugin->support_channel }}
+                                            <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                        </a>
+                                    @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
+                                        <a
+                                            href="mailto:{{ $plugin->support_channel }}"
+                                            class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                        >
+                                            {{ $plugin->support_channel }}
+                                            <x-heroicon-o-envelope class="size-3" />
+                                        </a>
+                                    @else
+                                        <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
+                                    @endif
+                                </dd>
+                            </div>
+                        @endif
 
                     </dl>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -454,7 +454,7 @@ Route::middleware(['auth', EnsureFeaturesAreActive::using(ShowAuthButtons::class
     // Plugin management (keeps customer.plugins.* route names)
     Route::name('customer.')->group(function (): void {
         Route::livewire('plugins', App\Livewire\Customer\Plugins\Index::class)->name('plugins.index');
-        Route::livewire('plugins/submit', App\Livewire\Customer\Plugins\Create::class)->name('plugins.create');
+        Route::livewire('plugins/create', App\Livewire\Customer\Plugins\Create::class)->name('plugins.create');
         Route::livewire('plugins/{vendor}/{package}', App\Livewire\Customer\Plugins\Show::class)->name('plugins.show');
     });
 });

--- a/tests/Feature/AdminPluginPreviewTest.php
+++ b/tests/Feature/AdminPluginPreviewTest.php
@@ -59,7 +59,7 @@ class AdminPluginPreviewTest extends TestCase
 
         $this->actingAs($admin)
             ->get(route('plugins.show', $plugin->routeParams()))
-            ->assertSee('Admin Preview')
+            ->assertSee('Preview')
             ->assertSee('Pending Review');
     }
 
@@ -68,7 +68,7 @@ class AdminPluginPreviewTest extends TestCase
         $plugin = Plugin::factory()->approved()->create();
 
         $this->get(route('plugins.show', $plugin->routeParams()))
-            ->assertDontSee('Admin Preview');
+            ->assertDontSee('This plugin is not publicly visible');
     }
 
     public function test_admin_can_view_approved_plugin_without_preview_banner(): void
@@ -81,6 +81,6 @@ class AdminPluginPreviewTest extends TestCase
         $this->actingAs($admin)
             ->get(route('plugins.show', $plugin->routeParams()))
             ->assertStatus(200)
-            ->assertDontSee('Admin Preview');
+            ->assertDontSee('This plugin is not publicly visible');
     }
 }

--- a/tests/Feature/CustomerPluginReviewChecksTest.php
+++ b/tests/Feature/CustomerPluginReviewChecksTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Livewire\Customer\Plugins\Create;
+use App\Livewire\Customer\Plugins\Show;
 use App\Models\DeveloperAccount;
 use App\Models\User;
 use App\Notifications\PluginSubmitted;
@@ -16,23 +17,11 @@ class CustomerPluginReviewChecksTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function submitting_a_plugin_runs_review_checks(): void
+    private function fakeGitHubForCreateAndSubmit(string $repoSlug): void
     {
-        Notification::fake();
-
-        $user = User::factory()->create([
-            'github_id' => '12345',
-            'github_token' => encrypt('fake-token'),
-        ]);
-        DeveloperAccount::factory()->withAcceptedTerms()->create([
-            'user_id' => $user->id,
-        ]);
-
-        $repoSlug = 'acme/test-plugin';
         $base = "https://api.github.com/repos/{$repoSlug}";
         $composerJson = json_encode([
-            'name' => 'acme/test-plugin',
+            'name' => $repoSlug,
             'description' => 'A test plugin',
             'require' => [
                 'php' => '^8.1',
@@ -75,18 +64,51 @@ class CustomerPluginReviewChecksTest extends TestCase
                 'encoding' => 'base64',
             ]),
         ]);
+    }
 
+    /** @test */
+    public function submitting_a_plugin_for_review_runs_review_checks(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'github_id' => '12345',
+            'github_token' => encrypt('fake-token'),
+        ]);
+        DeveloperAccount::factory()->withAcceptedTerms()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $repoSlug = 'acme/test-plugin';
+        $this->fakeGitHubForCreateAndSubmit($repoSlug);
+
+        // Step 1: Create the draft
         Livewire::actingAs($user)
             ->test(Create::class)
             ->set('repository', $repoSlug)
             ->set('pluginType', 'free')
-            ->set('supportChannel', 'dev@testplugin.io')
-            ->call('submitPlugin')
+            ->call('createPlugin')
             ->assertRedirect();
 
         $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
+        $this->assertNotNull($plugin, 'Plugin should exist after creation');
+        $this->assertEquals('draft', $plugin->status->value);
 
-        $this->assertNotNull($plugin, 'Plugin should exist after submission');
+        // Set support channel (required before submission)
+        $plugin->update(['support_channel' => 'dev@testplugin.io']);
+
+        // Re-fake HTTP for the submission step
+        $this->fakeGitHubForCreateAndSubmit($repoSlug);
+
+        // Step 2: Submit for review from the Show page
+        [$vendor, $package] = explode('/', $plugin->name);
+        Livewire::actingAs($user)
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
+            ->call('submitForReview');
+
+        $plugin->refresh();
+
+        $this->assertEquals('pending', $plugin->status->value);
         $this->assertNotNull($plugin->review_checks, 'review_checks should be populated');
         $this->assertTrue($plugin->review_checks['has_license_file']);
         $this->assertTrue($plugin->review_checks['has_release_version']);
@@ -138,10 +160,7 @@ class CustomerPluginReviewChecksTest extends TestCase
             "{$base}/releases/latest" => Http::response([], 404),
             "{$base}/tags*" => Http::response([]),
             "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
-
-            // Webhook creation (fails)
             "{$base}/hooks" => Http::response([], 422),
-
             $base => Http::response(['default_branch' => 'main']),
             "{$base}/git/trees/main*" => Http::response([
                 'tree' => [
@@ -154,14 +173,53 @@ class CustomerPluginReviewChecksTest extends TestCase
             ]),
         ]);
 
+        // Step 1: Create the draft
         Livewire::actingAs($user)
             ->test(Create::class)
             ->set('repository', $repoSlug)
             ->set('pluginType', 'free')
-            ->set('supportChannel', 'support@bare-plugin.io')
-            ->call('submitPlugin');
+            ->call('createPlugin');
 
         $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
+
+        // Set support channel (required before submission)
+        $plugin->update(['support_channel' => 'support@bare-plugin.io']);
+
+        // Re-fake HTTP for submission
+        Http::fake([
+            "{$base}/contents/composer.json*" => Http::response([
+                'content' => base64_encode($composerJson),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/README.md" => Http::response([
+                'content' => base64_encode('# Bare Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/nativephp.json" => Http::response([], 404),
+            "{$base}/contents/LICENSE*" => Http::response([], 404),
+            "{$base}/releases/latest" => Http::response([], 404),
+            "{$base}/tags*" => Http::response([]),
+            "{$base}/hooks" => Http::response([], 422),
+            $base => Http::response(['default_branch' => 'main']),
+            "{$base}/git/trees/main*" => Http::response([
+                'tree' => [
+                    ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                ],
+            ]),
+            "{$base}/readme" => Http::response([
+                'content' => base64_encode('# Bare Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
+        ]);
+
+        // Step 2: Submit for review
+        [$vendor, $package] = explode('/', $plugin->name);
+        Livewire::actingAs($user)
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
+            ->call('submitForReview');
+
+        $plugin->refresh();
 
         Notification::assertSentTo($user, PluginSubmitted::class, function (PluginSubmitted $notification) use ($plugin) {
             $mail = $notification->toMail($plugin->user);

--- a/tests/Feature/DeveloperTermsTest.php
+++ b/tests/Feature/DeveloperTermsTest.php
@@ -230,7 +230,7 @@ class DeveloperTermsTest extends TestCase
         Livewire::actingAs($user)
             ->test(Create::class)
             ->assertStatus(200)
-            ->assertSee('Submit Your Plugin')
+            ->assertSee('Create Your Plugin')
             ->assertSee('Select Repository');
     }
 

--- a/tests/Feature/Livewire/Customer/PluginCreateTest.php
+++ b/tests/Feature/Livewire/Customer/PluginCreateTest.php
@@ -136,7 +136,7 @@ class PluginCreateTest extends TestCase
     // Namespace Validation Tests
     // ========================================
 
-    public function test_submission_blocked_when_namespace_claimed_by_another_user(): void
+    public function test_creation_blocked_when_namespace_claimed_by_another_user(): void
     {
         $existingUser = User::factory()->create();
         Plugin::factory()->for($existingUser)->create(['name' => 'acme/existing-plugin']);
@@ -148,7 +148,7 @@ class PluginCreateTest extends TestCase
         Livewire::actingAs($user)->test(Create::class)
             ->set('repository', 'acme/new-plugin')
             ->set('pluginType', 'free')
-            ->call('submitPlugin')
+            ->call('createPlugin')
             ->assertNoRedirect();
 
         $this->assertDatabaseMissing('plugins', [
@@ -156,7 +156,7 @@ class PluginCreateTest extends TestCase
         ]);
     }
 
-    public function test_submission_blocked_for_reserved_namespace(): void
+    public function test_creation_blocked_for_reserved_namespace(): void
     {
         $user = $this->createGitHubUser();
 
@@ -165,7 +165,7 @@ class PluginCreateTest extends TestCase
         Livewire::actingAs($user)->test(Create::class)
             ->set('repository', 'nativephp/my-plugin')
             ->set('pluginType', 'free')
-            ->call('submitPlugin')
+            ->call('createPlugin')
             ->assertNoRedirect();
 
         $this->assertDatabaseMissing('plugins', [
@@ -173,7 +173,7 @@ class PluginCreateTest extends TestCase
         ]);
     }
 
-    public function test_submission_allowed_for_own_namespace(): void
+    public function test_creation_allowed_for_own_namespace(): void
     {
         $user = $this->createGitHubUser();
         Plugin::factory()->for($user)->create(['name' => 'myvendor/first-plugin']);
@@ -184,23 +184,22 @@ class PluginCreateTest extends TestCase
             'api.github.com/repos/myvendor/second-plugin/contents/composer.json*' => Http::response([
                 'content' => $composerJson,
             ]),
-            'api.github.com/repos/myvendor/second-plugin/hooks' => Http::response(['id' => 1]),
             'api.github.com/*' => Http::response([], 404),
         ]);
 
         Livewire::actingAs($user)->test(Create::class)
             ->set('repository', 'myvendor/second-plugin')
             ->set('pluginType', 'free')
-            ->set('supportChannel', 'support@myvendor.io')
-            ->call('submitPlugin');
+            ->call('createPlugin');
 
         $this->assertDatabaseHas('plugins', [
             'repository_url' => 'https://github.com/myvendor/second-plugin',
             'user_id' => $user->id,
+            'status' => 'draft',
         ]);
     }
 
-    public function test_submission_blocked_when_composer_json_missing(): void
+    public function test_creation_blocked_when_composer_json_missing(): void
     {
         $user = $this->createGitHubUser();
 
@@ -211,11 +210,39 @@ class PluginCreateTest extends TestCase
         Livewire::actingAs($user)->test(Create::class)
             ->set('repository', 'testuser/no-composer')
             ->set('pluginType', 'free')
-            ->call('submitPlugin')
+            ->call('createPlugin')
             ->assertNoRedirect();
 
         $this->assertDatabaseMissing('plugins', [
             'repository_url' => 'https://github.com/testuser/no-composer',
         ]);
+    }
+
+    public function test_plugin_created_as_draft(): void
+    {
+        $user = $this->createGitHubUser();
+
+        $composerJson = base64_encode(json_encode(['name' => 'testuser/draft-plugin']));
+
+        Http::fake([
+            'api.github.com/repos/testuser/draft-plugin/contents/composer.json*' => Http::response([
+                'content' => $composerJson,
+            ]),
+            'api.github.com/*' => Http::response([], 404),
+        ]);
+
+        Livewire::actingAs($user)->test(Create::class)
+            ->set('repository', 'testuser/draft-plugin')
+            ->set('pluginType', 'free')
+            ->call('createPlugin');
+
+        $this->assertDatabaseHas('plugins', [
+            'repository_url' => 'https://github.com/testuser/draft-plugin',
+            'status' => 'draft',
+        ]);
+
+        // No webhook should be installed for drafts
+        $plugin = Plugin::where('repository_url', 'https://github.com/testuser/draft-plugin')->first();
+        $this->assertNull($plugin->webhook_secret);
     }
 }

--- a/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
+++ b/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
@@ -369,7 +369,7 @@ class PluginStatusTransitionsTest extends TestCase
         $this->assertEquals(PluginStatus::Pending, $plugin->status);
     }
 
-    public function test_submit_paid_plugin_requires_tier(): void
+    public function test_save_paid_plugin_requires_tier(): void
     {
         Feature::define(AllowPaidPlugins::class, true);
 
@@ -378,16 +378,13 @@ class PluginStatusTransitionsTest extends TestCase
 
         $this->mountShowComponent($user, $plugin)
             ->set('description', 'A test plugin')
+            ->set('supportChannel', 'support@example.com')
             ->set('pluginType', 'paid')
-            ->call('save');
+            ->call('save')
+            ->assertHasErrors(['tier']);
 
         $plugin->refresh();
-
-        $this->mountShowComponent($user, $plugin)
-            ->call('submitForReview');
-
-        $plugin->refresh();
-        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+        $this->assertNull($plugin->tier);
     }
 
     public function test_submit_paid_plugin_with_tier_saves_type_and_tier(): void

--- a/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
+++ b/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
@@ -1,0 +1,442 @@
+<?php
+
+namespace Tests\Feature\Livewire\Customer;
+
+use App\Enums\PluginActivityType;
+use App\Enums\PluginStatus;
+use App\Enums\PluginTier;
+use App\Enums\PluginType;
+use App\Features\AllowPaidPlugins;
+use App\Livewire\Customer\Plugins\Show;
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\PluginSubmitted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Pennant\Feature;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginStatusTransitionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createGitHubUser(): User
+    {
+        return User::factory()->create([
+            'github_id' => '12345',
+            'github_username' => 'testuser',
+            'github_token' => encrypt('fake-token'),
+        ]);
+    }
+
+    private function createDraftPlugin(User $user, ?string $supportChannel = 'support@test.io'): Plugin
+    {
+        return Plugin::factory()->draft()->for($user)->create([
+            'name' => 'testuser/my-plugin-'.fake()->unique()->numberBetween(100, 999999),
+            'repository_url' => 'https://github.com/testuser/my-plugin-'.fake()->unique()->numberBetween(100, 999999),
+            'support_channel' => $supportChannel,
+        ]);
+    }
+
+    private function fakeGitHubForSubmission(Plugin $plugin): void
+    {
+        $repoInfo = $plugin->getRepositoryOwnerAndName();
+        $base = "https://api.github.com/repos/{$repoInfo['owner']}/{$repoInfo['repo']}";
+
+        Http::fake([
+            "{$base}/hooks" => Http::response(['id' => 1], 201),
+            $base => Http::response(['default_branch' => 'main']),
+            "{$base}/git/trees/main*" => Http::response([
+                'tree' => [
+                    ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                ],
+            ]),
+            "{$base}/contents/composer.json*" => Http::response([
+                'content' => base64_encode(json_encode(['name' => $plugin->name])),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/LICENSE*" => Http::response([], 404),
+            "{$base}/releases/latest" => Http::response([], 404),
+            "{$base}/tags*" => Http::response([]),
+            "{$base}/readme" => Http::response([
+                'content' => base64_encode('# Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/README.md*" => Http::response([
+                'content' => base64_encode('# Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/nativephp.json*" => Http::response([], 404),
+            'https://raw.githubusercontent.com/*' => Http::response('', 404),
+        ]);
+    }
+
+    private function mountShowComponent(User $user, Plugin $plugin): Testable
+    {
+        [$vendor, $package] = explode('/', $plugin->name);
+
+        return Livewire::actingAs($user)->test(Show::class, [
+            'vendor' => $vendor,
+            'package' => $package,
+        ]);
+    }
+
+    // ========================================
+    // Submit for Review (Draft → Pending)
+    // ========================================
+
+    public function test_submit_draft_for_review(): void
+    {
+        Notification::fake();
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+        $this->assertNotNull($plugin->reviewed_at);
+
+        Notification::assertSentTo($user, PluginSubmitted::class);
+    }
+
+    public function test_submit_requires_support_channel(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user, supportChannel: null);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+    }
+
+    public function test_cannot_submit_non_draft_plugin(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/pending-plugin',
+            'support_channel' => 'support@test.io',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+
+    public function test_resubmit_after_rejection_logs_resubmitted_activity(): void
+    {
+        Notification::fake();
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+
+        // Simulate a rejection in the activity history
+        $plugin->activities()->create([
+            'type' => PluginActivityType::Rejected,
+            'from_status' => 'pending',
+            'to_status' => 'rejected',
+            'note' => 'Test rejection',
+            'causer_id' => $user->id,
+        ]);
+
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+
+        // Should log Resubmitted, not Submitted
+        $latestActivity = $plugin->activities()->latest()->first();
+        $this->assertEquals(PluginActivityType::Resubmitted, $latestActivity->type);
+    }
+
+    // ========================================
+    // Withdraw from Review (Pending → Draft)
+    // ========================================
+
+    public function test_withdraw_from_review(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/withdraw-plugin',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('withdrawFromReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+
+        $latestActivity = $plugin->activities()->latest()->first();
+        $this->assertEquals(PluginActivityType::Withdrawn, $latestActivity->type);
+    }
+
+    public function test_cannot_withdraw_non_pending_plugin(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->draft()->for($user)->create([
+            'name' => 'testuser/draft-plugin',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('withdrawFromReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+        $this->assertCount(0, $plugin->activities);
+    }
+
+    // ========================================
+    // Return to Draft (Rejected → Draft)
+    // ========================================
+
+    public function test_return_rejected_to_draft(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->rejected()->for($user)->create([
+            'name' => 'testuser/rejected-plugin',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('returnToDraft');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+
+        $latestActivity = $plugin->activities()->latest()->first();
+        $this->assertEquals(PluginActivityType::ReturnedToDraft, $latestActivity->type);
+    }
+
+    public function test_cannot_return_non_rejected_to_draft(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/pending-for-return',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('returnToDraft');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+
+    // ========================================
+    // Edit Guards
+    // ========================================
+
+    public function test_draft_plugin_details_editable(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->draft()->for($user)->create([
+            'name' => 'testuser/details-draft',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('displayName', 'My Awesome Plugin')
+            ->set('description', 'New description')
+            ->set('supportChannel', 'new@support.io')
+            ->set('notes', 'Updated notes')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals('My Awesome Plugin', $plugin->display_name);
+        $this->assertEquals('New description', $plugin->description);
+        $this->assertEquals('new@support.io', $plugin->support_channel);
+        $this->assertEquals('Updated notes', $plugin->notes);
+    }
+
+    public function test_pending_plugin_details_not_editable(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/details-pending',
+            'display_name' => 'Original Name',
+            'description' => 'Original',
+            'support_channel' => 'original@support.io',
+            'notes' => 'Original notes',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('displayName', 'Changed Name')
+            ->set('description', 'Changed')
+            ->set('supportChannel', 'changed@support.io')
+            ->set('notes', 'Changed notes')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals('Original Name', $plugin->display_name);
+        $this->assertEquals('Original', $plugin->description);
+        $this->assertEquals('original@support.io', $plugin->support_channel);
+        $this->assertEquals('Original notes', $plugin->notes);
+    }
+
+    public function test_approved_plugin_details_editable(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->approved()->for($user)->create([
+            'name' => 'testuser/details-approved',
+            'notes' => 'Old notes',
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('description', 'Updated approved description')
+            ->set('supportChannel', 'updated@support.io')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals('Updated approved description', $plugin->description);
+        $this->assertEquals('updated@support.io', $plugin->support_channel);
+        // Notes should not change for approved plugins
+        $this->assertEquals('Old notes', $plugin->notes);
+    }
+
+    // ========================================
+    // Toggle Listing (Approved only)
+    // ========================================
+
+    public function test_toggle_listing_on_approved_plugin(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->approved()->for($user)->create([
+            'name' => 'testuser/toggle-approved',
+            'is_active' => true,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('toggleListing');
+
+        $plugin->refresh();
+        $this->assertFalse($plugin->is_active);
+
+        // Toggle back
+        $this->mountShowComponent($user, $plugin)
+            ->call('toggleListing');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->is_active);
+    }
+
+    public function test_cannot_toggle_listing_on_non_approved_plugin(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = Plugin::factory()->draft()->for($user)->create([
+            'name' => 'testuser/toggle-draft',
+            'is_active' => true,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('toggleListing');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->is_active);
+    }
+
+    // ========================================
+    // Plugin Type & Tier on Submission
+    // ========================================
+
+    public function test_submit_free_plugin_does_not_require_tier(): void
+    {
+        Notification::fake();
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('description', 'A test plugin')
+            ->set('pluginType', 'free')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginType::Free, $plugin->type);
+        $this->assertNull($plugin->tier);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+
+    public function test_submit_paid_plugin_requires_tier(): void
+    {
+        Feature::define(AllowPaidPlugins::class, true);
+
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('description', 'A test plugin')
+            ->set('pluginType', 'paid')
+            ->call('save');
+
+        $plugin->refresh();
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+    }
+
+    public function test_submit_paid_plugin_with_tier_saves_type_and_tier(): void
+    {
+        Notification::fake();
+        Feature::define(AllowPaidPlugins::class, true);
+
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('description', 'A test plugin')
+            ->set('pluginType', 'paid')
+            ->set('tier', 'gold')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginType::Paid, $plugin->type);
+        $this->assertEquals(PluginTier::Gold, $plugin->tier);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+
+    public function test_submit_free_plugin_clears_tier(): void
+    {
+        Notification::fake();
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $plugin->update(['tier' => PluginTier::Silver]);
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->mountShowComponent($user, $plugin)
+            ->set('description', 'A test plugin')
+            ->set('pluginType', 'free')
+            ->call('save');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginType::Free, $plugin->type);
+        $this->assertNull($plugin->tier);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+}

--- a/tests/Feature/PluginShowMobileVersionTest.php
+++ b/tests/Feature/PluginShowMobileVersionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Features\ShowPlugins;
 use App\Models\Plugin;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Pennant\Feature;
 use Tests\TestCase;
@@ -40,5 +41,54 @@ class PluginShowMobileVersionTest extends TestCase
         $this->get(route('plugins.show', $plugin->routeParams()))
             ->assertStatus(200)
             ->assertSee('NativePHP Mobile');
+    }
+
+    public function test_owner_can_preview_draft_plugin_listing(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->draft()->for($user)->create();
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Preview');
+    }
+
+    public function test_non_owner_cannot_view_draft_plugin_listing(): void
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $plugin = Plugin::factory()->draft()->for($owner)->create();
+
+        $this->actingAs($otherUser)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(404);
+    }
+
+    public function test_guest_cannot_view_draft_plugin_listing(): void
+    {
+        $plugin = Plugin::factory()->draft()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(404);
+    }
+
+    public function test_delisted_plugin_is_not_visible_to_public(): void
+    {
+        $plugin = Plugin::factory()->approved()->create(['is_active' => false]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(404);
+    }
+
+    public function test_owner_can_preview_delisted_plugin(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->approved()->for($user)->create(['is_active' => false]);
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('de-listed');
     }
 }

--- a/tests/Feature/PluginSubmissionNotesTest.php
+++ b/tests/Feature/PluginSubmissionNotesTest.php
@@ -3,61 +3,17 @@
 namespace Tests\Feature;
 
 use App\Livewire\Customer\Plugins\Create;
+use App\Livewire\Customer\Plugins\Show;
 use App\Models\DeveloperAccount;
 use App\Models\Plugin;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 use Tests\TestCase;
 
 class PluginSubmissionNotesTest extends TestCase
 {
     use RefreshDatabase;
-
-    /**
-     * @param  array<string, mixed>  $extraComposerData
-     */
-    private function fakeGitHubForPlugin(string $repoSlug, array $extraComposerData = []): void
-    {
-        $base = "https://api.github.com/repos/{$repoSlug}";
-        $composerJson = json_encode(array_merge([
-            'name' => $repoSlug,
-            'description' => "A test plugin: {$repoSlug}",
-            'require' => [
-                'php' => '^8.1',
-                'nativephp/mobile' => '^3.0.0',
-            ],
-        ], $extraComposerData));
-
-        Http::fake([
-            "{$base}/contents/README.md*" => Http::response([
-                'content' => base64_encode("# {$repoSlug}"),
-                'encoding' => 'base64',
-            ]),
-            "{$base}/contents/composer.json*" => Http::response([
-                'content' => base64_encode($composerJson),
-                'encoding' => 'base64',
-            ]),
-            "{$base}/contents/nativephp.json*" => Http::response([], 404),
-            "{$base}/contents/LICENSE*" => Http::response([], 404),
-            "{$base}/releases/latest" => Http::response([], 404),
-            "{$base}/tags*" => Http::response([]),
-            "{$base}/hooks" => Http::response(['id' => 1]),
-            "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
-            $base => Http::response(['default_branch' => 'main']),
-            "{$base}/git/trees/main*" => Http::response([
-                'tree' => [
-                    ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
-                ],
-            ]),
-            "{$base}/readme" => Http::response([
-                'content' => base64_encode("# {$repoSlug}"),
-                'encoding' => 'base64',
-            ]),
-        ]);
-    }
 
     private function createUserWithGitHub(): User
     {
@@ -73,149 +29,121 @@ class PluginSubmissionNotesTest extends TestCase
     }
 
     /** @test */
-    public function submitting_a_plugin_saves_notes(): void
+    public function creating_a_plugin_does_not_accept_notes(): void
     {
-        Notification::fake();
         $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/notes-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
 
         Livewire::actingAs($user)
             ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
-            ->set('supportChannel', 'help@example.com')
+            ->assertDontSee('Any notes for the review team');
+    }
+
+    /** @test */
+    public function creating_a_plugin_does_not_accept_support_channel(): void
+    {
+        $user = $this->createUserWithGitHub();
+
+        Livewire::actingAs($user)
+            ->test(Create::class)
+            ->assertDontSee('Support Channel');
+    }
+
+    /** @test */
+    public function draft_plugin_notes_can_be_updated_via_show_page(): void
+    {
+        $user = $this->createUserWithGitHub();
+        $plugin = Plugin::factory()->draft()->for($user)->create([
+            'support_channel' => 'support@example.com',
+        ]);
+
+        [$vendor, $package] = explode('/', $plugin->name);
+
+        Livewire::actingAs($user)
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
             ->set('notes', 'Please review this quickly, we have a launch deadline.')
-            ->call('submitPlugin')
-            ->assertRedirect();
+            ->call('save');
 
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNotNull($plugin);
+        $plugin->refresh();
         $this->assertEquals('Please review this quickly, we have a launch deadline.', $plugin->notes);
     }
 
     /** @test */
-    public function submitting_a_plugin_without_notes_stores_null(): void
+    public function draft_plugin_support_channel_email_can_be_updated_via_show_page(): void
     {
-        Notification::fake();
         $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/no-notes-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
+        $plugin = Plugin::factory()->draft()->for($user)->create();
+
+        [$vendor, $package] = explode('/', $plugin->name);
 
         Livewire::actingAs($user)
-            ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
             ->set('supportChannel', 'help@example.com')
-            ->call('submitPlugin')
-            ->assertRedirect();
+            ->call('save');
 
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNotNull($plugin);
-        $this->assertNull($plugin->notes);
-    }
-
-    /** @test */
-    public function submitting_a_plugin_saves_support_channel_email(): void
-    {
-        Notification::fake();
-        $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/support-email-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
-
-        Livewire::actingAs($user)
-            ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
-            ->set('supportChannel', 'help@example.com')
-            ->call('submitPlugin')
-            ->assertRedirect();
-
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNotNull($plugin);
+        $plugin->refresh();
         $this->assertEquals('help@example.com', $plugin->support_channel);
     }
 
     /** @test */
-    public function submitting_a_plugin_saves_support_channel_url(): void
+    public function draft_plugin_support_channel_url_can_be_updated_via_show_page(): void
     {
-        Notification::fake();
         $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/support-url-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
+        $plugin = Plugin::factory()->draft()->for($user)->create();
+
+        [$vendor, $package] = explode('/', $plugin->name);
 
         Livewire::actingAs($user)
-            ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
             ->set('supportChannel', 'https://example.com/support')
-            ->call('submitPlugin')
-            ->assertRedirect();
+            ->call('save');
 
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNotNull($plugin);
+        $plugin->refresh();
         $this->assertEquals('https://example.com/support', $plugin->support_channel);
     }
 
     /** @test */
-    public function submitting_a_plugin_without_support_channel_fails_validation(): void
+    public function draft_plugin_rejects_invalid_support_channel(): void
     {
-        Notification::fake();
         $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/no-support-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
+        $plugin = Plugin::factory()->draft()->for($user)->create();
+
+        [$vendor, $package] = explode('/', $plugin->name);
 
         Livewire::actingAs($user)
-            ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
-            ->call('submitPlugin')
-            ->assertHasErrors(['supportChannel' => 'required']);
-
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNull($plugin);
-    }
-
-    /** @test */
-    public function submitting_a_plugin_with_invalid_support_channel_fails_validation(): void
-    {
-        Notification::fake();
-        $user = $this->createUserWithGitHub();
-        $repoSlug = 'acme/invalid-support-plugin';
-        $this->fakeGitHubForPlugin($repoSlug);
-
-        Livewire::actingAs($user)
-            ->test(Create::class)
-            ->set('repository', $repoSlug)
-            ->set('pluginType', 'free')
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
             ->set('supportChannel', 'not-an-email-or-url')
-            ->call('submitPlugin')
+            ->call('save')
             ->assertHasErrors('supportChannel');
-
-        $plugin = $user->plugins()->where('repository_url', "https://github.com/{$repoSlug}")->first();
-
-        $this->assertNull($plugin);
     }
 
     /** @test */
-    public function notes_and_support_channel_fields_are_hidden_until_repository_selected(): void
+    public function draft_plugin_rejects_empty_support_channel_on_save(): void
     {
-        $user = User::factory()->create([
-            'github_id' => '12345',
-        ]);
+        $user = $this->createUserWithGitHub();
+        $plugin = Plugin::factory()->draft()->for($user)->create(['support_channel' => 'old@example.com']);
+
+        [$vendor, $package] = explode('/', $plugin->name);
 
         Livewire::actingAs($user)
-            ->test(Create::class)
-            ->assertDontSee('Support Channel')
-            ->assertDontSee('Any notes for the review team')
-            ->set('repository', 'acme/my-plugin')
-            ->assertSee('Support Channel')
-            ->assertSee('Notes');
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
+            ->set('supportChannel', '')
+            ->call('save')
+            ->assertHasErrors('supportChannel');
+    }
+
+    /** @test */
+    public function draft_plugin_rejects_empty_description_on_save(): void
+    {
+        $user = $this->createUserWithGitHub();
+        $plugin = Plugin::factory()->draft()->for($user)->create(['support_channel' => 'support@example.com']);
+
+        [$vendor, $package] = explode('/', $plugin->name);
+
+        Livewire::actingAs($user)
+            ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
+            ->set('description', '')
+            ->call('save')
+            ->assertHasErrors('description');
     }
 
     /** @test */

--- a/tests/Feature/SendPluginSubmissionRemindersTest.php
+++ b/tests/Feature/SendPluginSubmissionRemindersTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\PluginSubmissionReminder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SendPluginSubmissionRemindersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_notification_to_user_with_draft_plugin(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->draft()->for($user)->create();
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class);
+    }
+
+    public function test_sends_notification_to_user_with_pending_plugin(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->pending()->for($user)->create();
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class);
+    }
+
+    public function test_sends_notification_to_user_with_rejected_plugin(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->rejected()->for($user)->create();
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class);
+    }
+
+    public function test_does_not_send_to_user_with_only_approved_plugins(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->approved()->for($user)->create();
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_sends_one_notification_per_user_with_multiple_plugins(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->draft()->for($user)->create(['name' => 'acme/plugin-one']);
+        Plugin::factory()->pending()->for($user)->create(['name' => 'acme/plugin-two']);
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentToTimes($user, PluginSubmissionReminder::class, 1);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class, function ($notification) {
+            return $notification->plugins->count() === 2;
+        });
+    }
+
+    public function test_notification_includes_plugin_names(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->draft()->for($user)->create(['name' => 'acme/my-plugin']);
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class, function ($notification) {
+            return $notification->plugins->first()->name === 'acme/my-plugin';
+        });
+    }
+
+    public function test_excludes_approved_plugins_from_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->draft()->for($user)->create(['name' => 'acme/draft-one']);
+        Plugin::factory()->approved()->for($user)->create(['name' => 'acme/approved-one']);
+
+        $this->artisan('plugins:send-submission-reminders')
+            ->assertExitCode(0);
+
+        Notification::assertSentTo($user, PluginSubmissionReminder::class, function ($notification) {
+            return $notification->plugins->count() === 1
+                && $notification->plugins->first()->name === 'acme/draft-one';
+        });
+    }
+
+    public function test_dry_run_does_not_send_notifications(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        Plugin::factory()->draft()->for($user)->create();
+
+        $this->artisan('plugins:send-submission-reminders', ['--dry-run' => true])
+            ->assertExitCode(0);
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_notification_email_contains_expected_content(): void
+    {
+        $user = User::factory()->create(['name' => 'Jane']);
+        $plugin = Plugin::factory()->draft()->for($user)->create(['name' => 'acme/test-plugin']);
+
+        $notification = new PluginSubmissionReminder(collect([$plugin]));
+        $mail = $notification->toMail($user);
+
+        $this->assertStringContainsString('Action Required', $mail->subject);
+        $this->assertStringContainsString('acme/test-plugin', implode(' ', array_map(fn ($line) => (string) $line, $mail->introLines)));
+    }
+
+    public function test_notification_database_array_contains_plugin_names(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->draft()->for($user)->create(['name' => 'acme/test-plugin']);
+
+        $notification = new PluginSubmissionReminder(collect([$plugin]));
+        $data = $notification->toArray($user);
+
+        $this->assertArrayHasKey('plugin_names', $data);
+        $this->assertContains('acme/test-plugin', $data['plugin_names']);
+    }
+}


### PR DESCRIPTION
## Summary

- **Draft plugin status**: Plugins now start as "Draft" instead of "Pending", allowing authors to save work-in-progress before submitting for review. New migrations change the default status and convert existing pending plugins to draft.
- **Display name support**: Added optional `display_name` field to plugins. Used as the primary name across marketplace, cart, checkout, Ultra benefits, team, and developer dashboard pages, with the Composer package name shown as a monospace subheading.
- **Plugin edit/submit UX improvements**: Moved Type and Pricing Tier selection to the Details tab. Simplified the Submit tab to just notes and a submit button. Added inline validation errors. Removed "Plugin" prefix from card headings. Marked Name as optional. Updated pricing tier display to show price ranges. URL changed from `/plugins/submit` to `/plugins/create`.
- **Listing preview for authors**: Plugin owners can now preview their listing page (even for unpublished/de-listed plugins) via a "Preview Listing" link on the edit page.
- **De-listed plugin visibility**: De-listed plugins (`is_active = false`) are now hidden from the public directory while remaining accessible to owners and admins for preview.
- **Filament admin updates**: Added Draft status filter to plugin list and updated status badge styling.

## Test plan

- [x] Existing tests updated for new save/submit flow
- [x] New `PluginStatusTransitionsTest` covering draft → pending → approved/rejected transitions
- [x] New tests for owner preview of draft and de-listed plugins
- [x] New tests for public 404 on draft and de-listed plugins
- [x] All 36 related tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)