### PR TITLE
Link notification preferences in email to settings page

### DIFF
--- a/app/Notifications/NewPluginAvailable.php
+++ b/app/Notifications/NewPluginAvailable.php
@@ -35,7 +35,7 @@ class NewPluginAvailable extends Notification implements ShouldQueue
             ->greeting('A new plugin is available!')
             ->line("**{$this->plugin->name}** has just been added to the NativePHP Plugin Marketplace.")
             ->action('View Plugin', route('plugins.show', $this->plugin->routeParams()))
-            ->line('You can manage your notification preferences in your account settings.');
+            ->line('[Manage your notification preferences]('.route('customer.settings', ['tab' => 'notifications']).').');
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "zappy-ox",
+    "name": "lazy-eagle",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/Notifications/NewPluginAvailableTest.php
+++ b/tests/Feature/Notifications/NewPluginAvailableTest.php
@@ -115,6 +115,22 @@ class NewPluginAvailableTest extends TestCase
         $this->assertEquals('View Plugin', $data['action_label']);
     }
 
+    public function test_mail_contains_notification_preferences_link(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->for($user)->create();
+
+        $notification = new NewPluginAvailable($plugin);
+        $mail = $notification->toMail($user);
+
+        $expectedUrl = route('customer.settings', ['tab' => 'notifications']);
+        $found = collect($mail->introLines)->concat($mail->outroLines)->contains(function ($line) use ($expectedUrl) {
+            return str_contains($line, $expectedUrl);
+        });
+
+        $this->assertTrue($found, 'Mail should contain a link to the notification preferences page.');
+    }
+
     public function test_new_users_receive_new_plugin_notifications_by_default(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- Updated the `NewPluginAvailable` email notification to include a direct link to the notification preferences settings page (`/dashboard/settings?tab=notifications`) instead of plain text mentioning account settings
- Added test coverage to verify the email contains the correct link

## Test plan
- [x] Existing `NewPluginAvailableTest` tests pass (9 tests, 15 assertions)
- [x] New `test_mail_contains_notification_preferences_link` test verifies the link is present in the email body

🤖 Generated with [Claude Code](https://claude.com/claude-code)