### PR TITLE
Add developer account info and plugins tab to admin user view

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\StripeConnectStatus;
 use App\Filament\Resources\UserResource\Pages;
 use App\Filament\Resources\UserResource\RelationManagers;
 use App\Models\User;
@@ -12,6 +13,7 @@ use Filament\Schemas;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 use STS\FilamentImpersonate\Actions\Impersonate;
 
 class UserResource extends Resource
@@ -62,6 +64,46 @@ class UserResource extends Resource
                             ->maxLength(255)
                             ->disabled(),
                     ]),
+                Schemas\Components\Section::make('Developer Account')
+                    ->inlineLabel()
+                    ->columns(1)
+                    ->visible(fn (?User $record) => $record?->developerAccount !== null)
+                    ->schema([
+                        Forms\Components\Select::make('developerAccount.stripe_connect_status')
+                            ->label('Stripe Connect Status')
+                            ->options(StripeConnectStatus::class)
+                            ->disabled(),
+                        Forms\Components\Placeholder::make('developerAccount.stripe_connect_account_id')
+                            ->label('Stripe Connect Account')
+                            ->content(fn (User $record) => new HtmlString(
+                                '<a href="https://dashboard.stripe.com/connect/accounts/'
+                                .e($record->developerAccount->stripe_connect_account_id)
+                                .'" target="_blank" class="text-primary-600 hover:underline">'
+                                .e($record->developerAccount->stripe_connect_account_id)
+                                .' &#8599;</a>'
+                            )),
+                        Forms\Components\Placeholder::make('developerAccount.country')
+                            ->label('Country')
+                            ->content(fn (User $record) => $record->developerAccount->country ?? '—'),
+                        Forms\Components\Placeholder::make('developerAccount.payout_currency')
+                            ->label('Payout Currency')
+                            ->content(fn (User $record) => strtoupper($record->developerAccount->payout_currency ?? '—')),
+                        Forms\Components\Placeholder::make('developerAccount.payouts_enabled')
+                            ->label('Payouts Enabled')
+                            ->content(fn (User $record) => $record->developerAccount->payouts_enabled ? 'Yes' : 'No'),
+                        Forms\Components\Placeholder::make('developerAccount.charges_enabled')
+                            ->label('Charges Enabled')
+                            ->content(fn (User $record) => $record->developerAccount->charges_enabled ? 'Yes' : 'No'),
+                        Forms\Components\Placeholder::make('developerAccount.onboarding_completed_at')
+                            ->label('Onboarding Completed')
+                            ->content(fn (User $record) => $record->developerAccount->onboarding_completed_at?->format('M j, Y g:i A') ?? '—'),
+                        Forms\Components\Placeholder::make('developerAccount.accepted_plugin_terms_at')
+                            ->label('Plugin Terms Accepted')
+                            ->content(fn (User $record) => $record->developerAccount->accepted_plugin_terms_at?->format('M j, Y g:i A') ?? '—'),
+                        Forms\Components\Placeholder::make('developerAccount.plugin_terms_version')
+                            ->label('Terms Version')
+                            ->content(fn (User $record) => $record->developerAccount->plugin_terms_version ?? '—'),
+                    ]),
             ]);
     }
 
@@ -85,6 +127,10 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('anystack_contact_id')
                     ->hidden()
                     ->searchable(),
+                Tables\Columns\IconColumn::make('developerAccount.id')
+                    ->label('Developer')
+                    ->boolean()
+                    ->getStateUsing(fn (User $record) => $record->developerAccount !== null),
                 Tables\Columns\TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable(),
@@ -128,6 +174,7 @@ class UserResource extends Resource
     public static function getRelations(): array
     {
         return [
+            RelationManagers\DeveloperPluginsRelationManager::class,
             RelationManagers\PluginLicensesRelationManager::class,
             RelationManagers\ProductLicensesRelationManager::class,
             RelationManagers\LicensesRelationManager::class,

--- a/app/Filament/Resources/UserResource/RelationManagers/DeveloperPluginsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/DeveloperPluginsRelationManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\RelationManagers;
+
+use App\Enums\PluginStatus;
+use App\Enums\PluginType;
+use App\Filament\Resources\PluginResource;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class DeveloperPluginsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'plugins';
+
+    protected static ?string $title = 'Developer Plugins';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Package')
+                    ->searchable()
+                    ->sortable()
+                    ->fontFamily('mono'),
+                Tables\Columns\TextColumn::make('type')
+                    ->badge()
+                    ->color(fn (PluginType $state): string => match ($state) {
+                        PluginType::Free => 'gray',
+                        PluginType::Paid => 'success',
+                    }),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (PluginStatus $state): string => $state->color()),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Submitted')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->recordUrl(fn ($record) => PluginResource::getUrl('edit', ['record' => $record]));
+    }
+}

--- a/tests/Feature/Filament/UserResourceDeveloperTest.php
+++ b/tests/Feature/Filament/UserResourceDeveloperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\UserResource;
+use App\Filament\Resources\UserResource\Pages\EditUser;
+use App\Filament\Resources\UserResource\RelationManagers\DeveloperPluginsRelationManager;
+use App\Models\DeveloperAccount;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UserResourceDeveloperTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $this->user = User::factory()->create();
+    }
+
+    public function test_developer_account_section_is_visible_when_user_has_developer_account(): void
+    {
+        DeveloperAccount::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(EditUser::getUrl(['record' => $this->user]))
+            ->assertSee('Developer Account')
+            ->assertSee($this->user->developerAccount->stripe_connect_account_id);
+    }
+
+    public function test_developer_account_section_is_hidden_when_user_has_no_developer_account(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(EditUser::getUrl(['record' => $this->user]))
+            ->assertDontSee('Developer Account');
+    }
+
+    public function test_developer_account_section_shows_stripe_connect_link(): void
+    {
+        $developerAccount = DeveloperAccount::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(EditUser::getUrl(['record' => $this->user]))
+            ->assertSee('https://dashboard.stripe.com/connect/accounts/'.$developerAccount->stripe_connect_account_id);
+    }
+
+    public function test_developer_plugins_relation_manager_lists_plugins(): void
+    {
+        $plugins = Plugin::factory()->count(3)->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(DeveloperPluginsRelationManager::class, [
+                'ownerRecord' => $this->user,
+                'pageClass' => EditUser::class,
+            ])
+            ->assertCanSeeTableRecords($plugins)
+            ->assertCountTableRecords(3);
+    }
+
+    public function test_developer_plugins_relation_manager_does_not_show_other_users_plugins(): void
+    {
+        $otherUser = User::factory()->create();
+
+        Plugin::factory()->create(['user_id' => $this->user->id]);
+        Plugin::factory()->create(['user_id' => $otherUser->id]);
+
+        Livewire::actingAs($this->admin)
+            ->test(DeveloperPluginsRelationManager::class, [
+                'ownerRecord' => $this->user,
+                'pageClass' => EditUser::class,
+            ])
+            ->assertCountTableRecords(1);
+    }
+
+    public function test_developer_plugins_relation_manager_renders_successfully(): void
+    {
+        Livewire::actingAs($this->admin)
+            ->test(DeveloperPluginsRelationManager::class, [
+                'ownerRecord' => $this->user,
+                'pageClass' => EditUser::class,
+            ])
+            ->assertOk()
+            ->assertCountTableRecords(0);
+    }
+
+    public function test_users_index_shows_developer_column(): void
+    {
+        DeveloperAccount::factory()->create([
+            'user_id' => $this->user->id,
+        ]);
+
+        $nonDeveloper = User::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(UserResource\Pages\ListUsers::class)
+            ->assertCanRenderTableColumn('developerAccount.id');
+    }
+}


### PR DESCRIPTION
## Summary
- Show a **Developer Account** section on the user edit page when the user has a developer profile, displaying Stripe Connect status, account link, country, payout currency, payouts/charges enabled, onboarding completion, and plugin terms acceptance
- Add a **Developer Plugins** relation manager tab listing all plugins created by the user, with links to each plugin's edit page
- Add a **Developer** boolean column to the users index table indicating whether a user has a developer account

## Test plan
- [x] Developer Account section visible only for users with a developer account
- [x] Stripe Connect account ID links to Stripe dashboard
- [x] Developer Plugins tab lists only the user's plugins
- [x] Developer column renders on users index
- [x] All 7 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)