### PR TITLE
Allow webhook ping events for unapproved plugins

### DIFF
--- a/app/Http/Controllers/PluginWebhookController.php
+++ b/app/Http/Controllers/PluginWebhookController.php
@@ -18,11 +18,15 @@ class PluginWebhookController extends Controller
             return response()->json(['error' => 'Invalid webhook secret'], 404);
         }
 
+        $event = $request->header('X-GitHub-Event');
+
+        if ($event === 'ping') {
+            return response()->json(['success' => true, 'message' => 'pong']);
+        }
+
         if (! $plugin->isApproved()) {
             return response()->json(['error' => 'Plugin is not approved'], 403);
         }
-
-        $event = $request->header('X-GitHub-Event');
 
         if ($event === 'release') {
             // Sync plugin metadata to update latest_version

--- a/tests/Feature/PluginWebhookTest.php
+++ b/tests/Feature/PluginWebhookTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plugin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class PluginWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function ping_event_succeeds_for_unapproved_plugin(): void
+    {
+        $plugin = Plugin::factory()->create();
+
+        $response = $this->postJson(
+            route('webhooks.plugins', $plugin->webhook_secret),
+            [],
+            ['X-GitHub-Event' => 'ping']
+        );
+
+        $response->assertOk()
+            ->assertJson(['success' => true, 'message' => 'pong']);
+    }
+
+    #[Test]
+    public function ping_event_succeeds_for_approved_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        $response = $this->postJson(
+            route('webhooks.plugins', $plugin->webhook_secret),
+            [],
+            ['X-GitHub-Event' => 'ping']
+        );
+
+        $response->assertOk()
+            ->assertJson(['success' => true, 'message' => 'pong']);
+    }
+
+    #[Test]
+    public function non_ping_event_returns_403_for_unapproved_plugin(): void
+    {
+        $plugin = Plugin::factory()->create();
+
+        $response = $this->postJson(
+            route('webhooks.plugins', $plugin->webhook_secret),
+            [],
+            ['X-GitHub-Event' => 'push']
+        );
+
+        $response->assertForbidden()
+            ->assertJson(['error' => 'Plugin is not approved']);
+    }
+
+    #[Test]
+    public function invalid_secret_returns_404(): void
+    {
+        $response = $this->postJson(
+            route('webhooks.plugins', 'invalid-secret'),
+            [],
+            ['X-GitHub-Event' => 'ping']
+        );
+
+        $response->assertNotFound();
+    }
+}


### PR DESCRIPTION
## Summary

- Moves the `X-GitHub-Event` header check before the plugin approval gate in `PluginWebhookController`
- Returns a `200` response for `ping` events regardless of plugin approval status
- Non-ping events (push, release, etc.) still require the plugin to be approved

This fixes an issue where developers setting up webhooks manually would get a 403 on GitHub's test ping because their plugin wasn't yet approved, making it look like the webhook was misconfigured.

## Test plan

- [x] Ping event returns 200 for unapproved plugins
- [x] Ping event returns 200 for approved plugins
- [x] Non-ping events still return 403 for unapproved plugins
- [x] Invalid webhook secret still returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)