### PR TITLE
Constrain admin plugin logo size to recommended dimensions

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -52,7 +52,7 @@ class PluginResource extends Resource
                         Forms\Components\Placeholder::make('logo_preview')
                             ->label('Logo')
                             ->content(fn (?Plugin $record) => $record?->hasLogo()
-                                ? new HtmlString('<img src="'.e($record->getLogoUrl()).'" alt="Logo" class="w-16 h-16 rounded-lg object-cover" />')
+                                ? new HtmlString('<img src="'.e($record->getLogoUrl()).'" alt="Logo" style="max-width: 256px; max-height: 256px; border-radius: 0.5rem; object-fit: cover;" />')
                                 : 'No logo')
                             ->visible(fn (?Plugin $record) => $record !== null),
 


### PR DESCRIPTION
## Summary
- Fixes oversized logo images on the admin plugin edit screen by using inline styles instead of Tailwind classes
- Constrains the logo preview to 256x256px max, matching the dimensions recommended to developers in the plugin edit form ("Recommended: 256x256 pixels, square")
- Tailwind classes (`w-16 h-16`) weren't being applied because Filament's CSS build doesn't scan inline HTML strings in PHP files

## Test plan
- [x] Open a plugin with a custom logo in the admin edit screen
- [x] Verify the logo is constrained to a reasonable size (max 256x256) instead of filling the entire space
- [x] Verify plugins without logos still show "No logo" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)