### PR TITLE
Add webhook self-certification and preflight submission checks

### DIFF
--- a/app/Jobs/ReviewPluginRepository.php
+++ b/app/Jobs/ReviewPluginRepository.php
@@ -25,12 +25,29 @@ class ReviewPluginRepository implements ShouldQueue
     {
         $repo = $this->plugin->getRepositoryOwnerAndName();
 
+        $failedChecks = [
+            'has_license_file' => false,
+            'has_release_version' => false,
+            'release_version' => null,
+            'supports_ios' => false,
+            'supports_android' => false,
+            'supports_js' => false,
+            'requires_mobile_sdk' => false,
+            'mobile_sdk_constraint' => null,
+            'has_ios_min_version' => false,
+            'ios_min_version' => null,
+            'has_android_min_version' => false,
+            'android_min_version' => null,
+        ];
+
         if (! $repo) {
             Log::warning('[ReviewPluginRepository] No valid repository URL', [
                 'plugin_id' => $this->plugin->id,
             ]);
 
-            return [];
+            $this->plugin->update(['review_checks' => $failedChecks, 'reviewed_at' => now()]);
+
+            return $failedChecks;
         }
 
         $token = $this->getGitHubToken();
@@ -44,7 +61,9 @@ class ReviewPluginRepository implements ShouldQueue
                 'plugin_id' => $this->plugin->id,
             ]);
 
-            return [];
+            $this->plugin->update(['review_checks' => $failedChecks, 'reviewed_at' => now()]);
+
+            return $failedChecks;
         }
 
         $tree = $this->fetchRepoTree($owner, $repoName, $defaultBranch, $token);

--- a/app/Livewire/Customer/Plugins/Show.php
+++ b/app/Livewire/Customer/Plugins/Show.php
@@ -8,7 +8,9 @@ use App\Jobs\ReviewPluginRepository;
 use App\Models\Plugin;
 use App\Notifications\PluginSubmitted;
 use App\Services\GitHubUserService;
+use Flux\Flux;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
@@ -74,45 +76,86 @@ class Show extends Component
         $this->tier = $this->plugin->tier?->value;
     }
 
+    public function runPreflightChecks(): void
+    {
+        if (! $this->plugin->isDraft()) {
+            return;
+        }
+
+        $user = auth()->user();
+        $repoInfo = $this->plugin->getRepositoryOwnerAndName();
+
+        // Ensure a webhook secret exists so we can always show setup instructions
+        if (! $this->plugin->webhook_secret) {
+            $this->plugin->generateWebhookSecret();
+        }
+
+        // Verify or install webhook
+        if ($repoInfo && $user->hasGitHubToken()) {
+            $githubService = GitHubUserService::for($user);
+            $webhookUrl = $this->plugin->getWebhookUrl();
+
+            // Check if our webhook already exists on the repo
+            if ($webhookUrl && $githubService->webhookExists($repoInfo['owner'], $repoInfo['repo'], $webhookUrl)) {
+                if (! $this->plugin->webhook_installed) {
+                    $this->plugin->update(['webhook_installed' => true]);
+                }
+            } else {
+                // Webhook not found on GitHub — try to create it
+                $webhookSecret = $this->plugin->webhook_secret ?? $this->plugin->generateWebhookSecret();
+                $webhookResult = $githubService->createWebhook(
+                    $repoInfo['owner'],
+                    $repoInfo['repo'],
+                    $this->plugin->getWebhookUrl(),
+                    $webhookSecret
+                );
+                $this->plugin->update(['webhook_installed' => $webhookResult['success']]);
+            }
+        }
+
+        // Run review checks
+        (new ReviewPluginRepository($this->plugin))->handle();
+
+        $this->plugin->refresh();
+    }
+
     public function submitForReview(): void
     {
         if (! $this->plugin->isDraft()) {
-            session()->flash('error', 'Only draft plugins can be submitted for review.');
+            Flux::toast(variant: 'danger', text: 'Only draft plugins can be submitted for review.');
+
+            return;
+        }
+
+        if (! $this->plugin->description) {
+            Flux::toast(variant: 'danger', text: 'Please add a description before submitting for review.');
 
             return;
         }
 
         if (! $this->plugin->support_channel) {
-            session()->flash('error', 'Please set a support channel before submitting for review.');
+            Flux::toast(variant: 'danger', text: 'Please set a support channel before submitting for review.');
 
             return;
         }
 
         if ($this->plugin->isPaid() && ! $this->plugin->tier) {
-            session()->flash('error', 'Please select a pricing tier for your paid plugin.');
+            Flux::toast(variant: 'danger', text: 'Please select a pricing tier for your paid plugin.');
+
+            return;
+        }
+
+        // Run preflight checks
+        $this->runPreflightChecks();
+
+        // Only submit if required checks pass
+        if (! $this->plugin->passesRequiredReviewChecks()) {
+            Flux::toast(variant: 'danger', text: 'Your plugin doesn\'t pass all required checks yet. Please resolve the failing checks and try again.');
 
             return;
         }
 
         $user = auth()->user();
-
-        // Install webhook
-        $repoInfo = $this->plugin->getRepositoryOwnerAndName();
-
-        if ($repoInfo && $user->hasGitHubToken()) {
-            $webhookSecret = $this->plugin->webhook_secret ?? $this->plugin->generateWebhookSecret();
-            $githubService = GitHubUserService::for($user);
-            $webhookResult = $githubService->createWebhook(
-                $repoInfo['owner'],
-                $repoInfo['repo'],
-                $this->plugin->getWebhookUrl(),
-                $webhookSecret
-            );
-            $this->plugin->update(['webhook_installed' => $webhookResult['success']]);
-        }
-
-        // Run review checks
-        (new ReviewPluginRepository($this->plugin))->handle();
 
         // Submit
         $this->plugin->submit();
@@ -121,13 +164,61 @@ class Show extends Component
         // Notify
         $user->notify(new PluginSubmitted($this->plugin));
 
-        session()->flash('success', 'Your plugin has been submitted for review!');
+        Flux::toast(variant: 'success', text: 'Your plugin has been submitted for review!');
+    }
+
+    public function certifyWebhook(): void
+    {
+        if ($this->plugin->webhook_installed) {
+            return;
+        }
+
+        if (! $this->plugin->webhook_secret) {
+            $this->plugin->generateWebhookSecret();
+        }
+
+        $this->plugin->update(['webhook_installed' => true]);
+        $this->plugin->refresh();
+
+        $this->modal('certify-webhook')->close();
+
+        Flux::toast(variant: 'success', text: 'Webhook marked as installed.');
+    }
+
+    public function retryWebhook(): void
+    {
+        $user = auth()->user();
+        $repoInfo = $this->plugin->getRepositoryOwnerAndName();
+
+        if (! $repoInfo || ! $user->hasGitHubToken()) {
+            Flux::toast(variant: 'danger', text: 'Unable to register webhook automatically. Please ensure your GitHub account is connected and the repository URL is valid.');
+
+            return;
+        }
+
+        $webhookSecret = $this->plugin->webhook_secret ?? $this->plugin->generateWebhookSecret();
+        $githubService = GitHubUserService::for($user);
+        $webhookResult = $githubService->createWebhook(
+            $repoInfo['owner'],
+            $repoInfo['repo'],
+            $this->plugin->getWebhookUrl(),
+            $webhookSecret
+        );
+
+        $this->plugin->update(['webhook_installed' => $webhookResult['success']]);
+        $this->plugin->refresh();
+
+        if ($webhookResult['success']) {
+            Flux::toast(variant: 'success', text: 'Webhook installed successfully.');
+        } else {
+            Flux::toast(variant: 'danger', text: 'Failed to install webhook: '.($webhookResult['error'] ?? 'Unknown error'));
+        }
     }
 
     public function withdrawFromReview(): void
     {
         if (! $this->plugin->isPending()) {
-            session()->flash('error', 'Only pending plugins can be withdrawn.');
+            Flux::toast(variant: 'danger', text: 'Only pending plugins can be withdrawn.');
 
             return;
         }
@@ -135,13 +226,13 @@ class Show extends Component
         $this->plugin->withdraw();
         $this->plugin->refresh();
 
-        session()->flash('success', 'Your plugin has been withdrawn from review and returned to draft.');
+        Flux::toast(variant: 'success', text: 'Your plugin has been withdrawn from review and returned to draft.');
     }
 
     public function returnToDraft(): void
     {
         if (! $this->plugin->isRejected()) {
-            session()->flash('error', 'Only rejected plugins can be returned to draft.');
+            Flux::toast(variant: 'danger', text: 'Only rejected plugins can be returned to draft.');
 
             return;
         }
@@ -149,13 +240,13 @@ class Show extends Component
         $this->plugin->returnToDraft();
         $this->plugin->refresh();
 
-        session()->flash('success', 'Your plugin has been returned to draft. You can make changes and resubmit.');
+        Flux::toast(variant: 'success', text: 'Your plugin has been returned to draft. You can make changes and resubmit.');
     }
 
     public function save(): void
     {
         if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
-            session()->flash('error', 'You can only edit draft or approved plugins.');
+            Flux::toast(variant: 'danger', text: 'You can only edit draft or approved plugins.');
 
             return;
         }
@@ -189,7 +280,7 @@ class Show extends Component
         ]);
 
         if ($this->plugin->isDraft() && $this->pluginType === 'paid' && ! $this->hasCompletedDeveloperOnboarding) {
-            session()->flash('error', 'You must complete developer onboarding before setting a plugin as paid.');
+            Flux::toast(variant: 'danger', text: 'You must complete developer onboarding before setting a plugin as paid.');
 
             return;
         }
@@ -211,13 +302,13 @@ class Show extends Component
         $this->plugin->updateDescription($this->description, auth()->id());
         $this->plugin->refresh();
 
-        session()->flash('success', 'Plugin details saved successfully!');
+        Flux::toast(variant: 'success', text: 'Plugin details saved successfully!');
     }
 
     public function updateIcon(): void
     {
         if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
-            session()->flash('error', 'You can only edit the icon for draft or approved plugins.');
+            Flux::toast(variant: 'danger', text: 'You can only edit the icon for draft or approved plugins.');
 
             return;
         }
@@ -239,13 +330,13 @@ class Show extends Component
 
         $this->plugin->refresh();
 
-        session()->flash('success', 'Plugin icon updated successfully!');
+        Flux::toast(variant: 'success', text: 'Plugin icon updated successfully!');
     }
 
     public function uploadLogo(): void
     {
         if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
-            session()->flash('error', 'You can only upload a logo for draft or approved plugins.');
+            Flux::toast(variant: 'danger', text: 'You can only upload a logo for draft or approved plugins.');
 
             return;
         }
@@ -270,13 +361,13 @@ class Show extends Component
         $this->logo = null;
         $this->iconMode = 'upload';
 
-        session()->flash('success', 'Plugin logo updated successfully!');
+        Flux::toast(variant: 'success', text: 'Plugin logo updated successfully!');
     }
 
     public function deleteIcon(): void
     {
         if (! $this->plugin->isDraft() && ! $this->plugin->isApproved()) {
-            session()->flash('error', 'You can only remove the icon for draft or approved plugins.');
+            Flux::toast(variant: 'danger', text: 'You can only remove the icon for draft or approved plugins.');
 
             return;
         }
@@ -294,13 +385,13 @@ class Show extends Component
         $this->plugin->refresh();
         $this->iconMode = 'gradient';
 
-        session()->flash('success', 'Plugin icon removed successfully!');
+        Flux::toast(variant: 'success', text: 'Plugin icon removed successfully!');
     }
 
     public function toggleListing(): void
     {
         if (! $this->plugin->isApproved()) {
-            session()->flash('error', 'Only approved plugins can be listed or de-listed.');
+            Flux::toast(variant: 'danger', text: 'Only approved plugins can be listed or de-listed.');
 
             return;
         }
@@ -312,7 +403,18 @@ class Show extends Component
         $this->plugin->refresh();
 
         $action = $this->plugin->is_active ? 'listed' : 'de-listed';
-        session()->flash('success', "Your plugin has been {$action}.");
+        Flux::toast(variant: 'success', text: "Your plugin has been {$action}.");
+    }
+
+    public function validate($rules = [], $messages = [], $attributes = []): array
+    {
+        try {
+            return parent::validate($rules, $messages, $attributes);
+        } catch (ValidationException $e) {
+            $this->dispatch('scroll-to-first-error');
+
+            throw $e;
+        }
     }
 
     public function render()

--- a/app/Services/GitHubUserService.php
+++ b/app/Services/GitHubUserService.php
@@ -145,6 +145,33 @@ class GitHubUserService
     }
 
     /**
+     * Check if a webhook with the given URL exists on a GitHub repository.
+     */
+    public function webhookExists(string $owner, string $repo, string $webhookUrl): bool
+    {
+        $token = $this->user->getGitHubToken();
+
+        if (! $token) {
+            return false;
+        }
+
+        $response = Http::withToken($token)
+            ->get("https://api.github.com/repos/{$owner}/{$repo}/hooks");
+
+        if ($response->failed()) {
+            return false;
+        }
+
+        foreach ($response->json() as $hook) {
+            if (($hook['config']['url'] ?? null) === $webhookUrl) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Create a webhook on a GitHub repository.
      *
      * @return array{success: bool, error?: string, webhook_id?: int}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "cosmic-wasp",
+    "name": "agile-sloth",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/components/layouts/dashboard.blade.php
+++ b/resources/views/components/layouts/dashboard.blade.php
@@ -250,6 +250,8 @@
             {{ $slot }}
         </flux:main>
 
+        <flux:toast />
+
         <x-impersonate::banner/>
 
         @livewireScriptConfig

--- a/resources/views/livewire/customer/plugins/show.blade.php
+++ b/resources/views/livewire/customer/plugins/show.blade.php
@@ -25,19 +25,6 @@
     </div>
 
     <div class="mx-auto max-w-3xl">
-        {{-- Success/Error Messages --}}
-        @if (session('success'))
-            <flux:callout variant="success" icon="check-circle" class="mb-6">
-                <flux:callout.text>{{ session('success') }}</flux:callout.text>
-            </flux:callout>
-        @endif
-
-        @if (session('error'))
-            <flux:callout variant="danger" icon="x-circle" class="mb-6">
-                <flux:callout.text>{{ session('error') }}</flux:callout.text>
-            </flux:callout>
-        @endif
-
         {{-- Status-specific banners --}}
         @if ($plugin->isDraft())
             <flux:callout variant="info" icon="information-circle" class="mb-6">
@@ -49,9 +36,30 @@
                 <flux:callout.heading>Under Review</flux:callout.heading>
                 <flux:callout.text>Your plugin is currently being reviewed. You can withdraw it to make changes.</flux:callout.text>
                 <x-slot name="actions">
-                    <flux:button variant="ghost" wire:click="withdrawFromReview" wire:confirm="Are you sure you want to withdraw this plugin from review? It will return to draft status.">Withdraw from Review</flux:button>
+                    <flux:modal.trigger name="withdraw-from-review">
+                        <flux:button variant="ghost">Withdraw from Review</flux:button>
+                    </flux:modal.trigger>
                 </x-slot>
             </flux:callout>
+
+            <flux:modal name="withdraw-from-review" class="md:w-96">
+                <div class="space-y-6">
+                    <div>
+                        <flux:heading size="lg">Withdraw from Review</flux:heading>
+                        <flux:text class="mt-2">
+                            Are you sure you want to withdraw this plugin from review? It will return to draft status.
+                        </flux:text>
+                    </div>
+
+                    <div class="flex gap-2">
+                        <flux:spacer />
+                        <flux:modal.close>
+                            <flux:button variant="ghost">Cancel</flux:button>
+                        </flux:modal.close>
+                        <flux:button variant="danger" wire:click="withdrawFromReview">Withdraw</flux:button>
+                    </div>
+                </div>
+            </flux:modal>
         @elseif ($plugin->isRejected() && $plugin->rejection_reason)
             <flux:callout variant="danger" icon="x-circle" class="mb-6">
                 <flux:callout.heading>Rejection Reason</flux:callout.heading>
@@ -78,8 +86,8 @@
             </flux:card>
         @endif
 
-        {{-- Review Checks (show for Pending, Rejected, Approved — not Draft) --}}
-        @if (! $plugin->isDraft() && $plugin->review_checks)
+        {{-- Review Checks (show when review checks have been run) --}}
+        @if ($plugin->review_checks)
             <flux:card class="mb-6">
                 <flux:heading size="lg">Review Checks</flux:heading>
                 <flux:text class="mt-1">Automated checks run against your repository.</flux:text>
@@ -122,29 +130,68 @@
                                 @endif
                             </div>
 
-                            @if ($check['key'] === 'webhook_configured' && ! $isPassing && $plugin->webhook_secret)
-                                <div class="ml-7 mt-2 rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-900/20">
-                                    <p class="text-sm text-amber-800 dark:text-amber-200">
-                                        We couldn't automatically install the webhook. Please set it up manually:
-                                    </p>
-                                    <div class="mt-2">
-                                        <label class="text-xs font-medium text-amber-900 dark:text-amber-100">Webhook URL</label>
-                                        <div class="mt-1 flex items-center gap-2">
-                                            <code class="block flex-1 overflow-x-auto rounded-md bg-white px-3 py-2 font-mono text-xs dark:bg-gray-800">{{ $plugin->getWebhookUrl() }}</code>
-                                            <flux:button size="xs" variant="ghost" x-on:click="navigator.clipboard.writeText('{{ $plugin->getWebhookUrl() }}')">
-                                                <x-heroicon-o-clipboard class="size-3" />
+                            @if ($check['key'] === 'webhook_configured')
+                                @if (! $isPassing)
+                                    <div class="ml-7 mt-2 rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-900/20">
+                                        <p class="text-sm text-amber-800 dark:text-amber-200">
+                                            We couldn't automatically install the webhook. Please set it up manually:
+                                        </p>
+                                        <div class="mt-2">
+                                            <label class="text-xs font-medium text-amber-900 dark:text-amber-100">Webhook URL</label>
+                                            <div class="mt-1 flex items-center gap-2">
+                                                <code class="block flex-1 overflow-x-auto rounded-md bg-white px-3 py-2 font-mono text-xs dark:bg-gray-800">{{ $plugin->getWebhookUrl() }}</code>
+                                                <flux:button size="xs" variant="ghost" x-on:click="navigator.clipboard.writeText('{{ $plugin->getWebhookUrl() }}')">
+                                                    <x-heroicon-o-clipboard class="size-3" />
+                                                </flux:button>
+                                            </div>
+                                        </div>
+                                        <ol class="mt-3 list-inside list-decimal space-y-1 text-xs text-amber-700 dark:text-amber-300">
+                                            <li>Go to your repository's <a href="{{ $plugin->repository_url }}/settings/hooks" target="_blank" rel="noopener noreferrer" class="font-medium underline hover:no-underline"><strong>Settings &rarr; Webhooks</strong></a></li>
+                                            <li>Click <strong>Add webhook</strong></li>
+                                            <li>Paste the URL above into the <strong>Payload URL</strong> field</li>
+                                            <li>Set <strong>Content type</strong> to <code class="rounded bg-amber-100 px-1 dark:bg-amber-800">application/json</code></li>
+                                            <li>Select events: <strong>Pushes</strong> and <strong>Releases</strong></li>
+                                            <li>Click <strong>Add webhook</strong></li>
+                                        </ol>
+
+                                        <div class="mt-3 flex items-center gap-2">
+                                            <flux:button size="sm" wire:click="retryWebhook">
+                                                Retry automatic setup
                                             </flux:button>
+                                            <flux:modal.trigger name="certify-webhook">
+                                                <flux:button size="sm" variant="ghost">
+                                                    I've installed it manually
+                                                </flux:button>
+                                            </flux:modal.trigger>
                                         </div>
                                     </div>
-                                    <ol class="mt-3 list-inside list-decimal space-y-1 text-xs text-amber-700 dark:text-amber-300">
-                                        <li>Go to your repository's <strong>Settings &rarr; Webhooks</strong></li>
-                                        <li>Click <strong>Add webhook</strong></li>
-                                        <li>Paste the URL above into the <strong>Payload URL</strong> field</li>
-                                        <li>Set <strong>Content type</strong> to <code class="rounded bg-amber-100 px-1 dark:bg-amber-800">application/json</code></li>
-                                        <li>Select events: <strong>Pushes</strong> and <strong>Releases</strong></li>
-                                        <li>Click <strong>Add webhook</strong></li>
-                                    </ol>
-                                </div>
+                                @elseif ($plugin->webhook_secret)
+                                    <div class="ml-7 mt-1" x-data="{ open: false }">
+                                        <button type="button" @click="open = !open" class="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
+                                            <x-heroicon-o-chevron-right class="size-3 transition-transform" ::class="open && 'rotate-90'" />
+                                            View setup instructions
+                                        </button>
+                                        <div x-show="open" x-cloak class="mt-2 rounded-md border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+                                            <div>
+                                                <label class="text-xs font-medium text-gray-700 dark:text-gray-300">Webhook URL</label>
+                                                <div class="mt-1 flex items-center gap-2">
+                                                    <code class="block flex-1 overflow-x-auto rounded-md bg-white px-3 py-2 font-mono text-xs dark:bg-gray-800">{{ $plugin->getWebhookUrl() }}</code>
+                                                    <flux:button size="xs" variant="ghost" x-on:click="navigator.clipboard.writeText('{{ $plugin->getWebhookUrl() }}')">
+                                                        <x-heroicon-o-clipboard class="size-3" />
+                                                    </flux:button>
+                                                </div>
+                                            </div>
+                                            <ol class="mt-3 list-inside list-decimal space-y-1 text-xs text-gray-600 dark:text-gray-400">
+                                                <li>Go to your repository's <a href="{{ $plugin->repository_url }}/settings/hooks" target="_blank" rel="noopener noreferrer" class="font-medium underline hover:no-underline"><strong>Settings &rarr; Webhooks</strong></a></li>
+                                                <li>Click <strong>Add webhook</strong></li>
+                                                <li>Paste the URL above into the <strong>Payload URL</strong> field</li>
+                                                <li>Set <strong>Content type</strong> to <code class="rounded bg-gray-200 px-1 dark:bg-gray-700">application/json</code></li>
+                                                <li>Select events: <strong>Pushes</strong> and <strong>Releases</strong></li>
+                                                <li>Click <strong>Add webhook</strong></li>
+                                            </ol>
+                                        </div>
+                                    </div>
+                                @endif
                             @endif
                         </li>
                     @endforeach
@@ -175,6 +222,31 @@
                         Last checked {{ $plugin->reviewed_at->diffForHumans() }}
                     </flux:text>
                 @endif
+
+                <flux:modal name="certify-webhook" class="md:w-96">
+                    <div class="space-y-6">
+                        <div>
+                            <flux:heading size="lg">Confirm Webhook Installation</flux:heading>
+                            <flux:text class="mt-2">
+                                Please confirm that you have manually installed the webhook on your GitHub repository.
+                            </flux:text>
+                        </div>
+
+                        <flux:callout variant="warning" icon="exclamation-triangle">
+                            <flux:callout.text>
+                                If the webhook is not correctly installed, we won't be able to sync your plugin's releases and metadata automatically.
+                            </flux:callout.text>
+                        </flux:callout>
+
+                        <div class="flex gap-2">
+                            <flux:spacer />
+                            <flux:modal.close>
+                                <flux:button variant="ghost">Cancel</flux:button>
+                            </flux:modal.close>
+                            <flux:button variant="primary" wire:click="certifyWebhook">Confirm</flux:button>
+                        </div>
+                    </div>
+                </flux:modal>
             </flux:card>
         @endif
 
@@ -459,30 +531,110 @@
 
                             <flux:separator class="my-4" />
 
-                            <div class="space-y-3">
-                                <div>
-                                    <flux:heading size="sm">Support Channel</flux:heading>
-                                    @if ($plugin->support_channel)
-                                        <flux:text class="mt-1">{{ $plugin->support_channel }}</flux:text>
-                                    @else
-                                        <flux:text class="mt-1 text-gray-400 dark:text-gray-500">No support channel set</flux:text>
-                                    @endif
+                            <dl class="grid grid-cols-2 gap-3">
+                                {{-- Author --}}
+                                <div class="col-span-2">
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Author</dt>
+                                    <dd class="mt-1">
+                                        <a href="{{ route('customer.developer.settings') }}" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                            {{ $plugin->user->display_name }}
+                                            <x-heroicon-o-pencil-square class="size-3" />
+                                        </a>
+                                    </dd>
                                 </div>
 
+                                {{-- Version --}}
                                 <div>
-                                    <flux:heading size="sm">Repository</flux:heading>
-                                    <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="mt-1 inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                        {{ $plugin->repository_url }}
-                                        <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
-                                    </a>
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Version</dt>
+                                    <dd class="mt-1">
+                                        @if ($plugin->latest_version)
+                                            <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                {{ $plugin->latest_version }}
+                                                <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                            </a>
+                                        @elseif ($plugin->review_checks['release_version'] ?? null)
+                                            <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                {{ $plugin->review_checks['release_version'] }}
+                                                <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                            </a>
+                                        @else
+                                            <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                                        @endif
+                                    </dd>
                                 </div>
-                            </div>
+
+                                {{-- License --}}
+                                <div>
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">License</dt>
+                                    <dd class="mt-1">
+                                        @if ($plugin->getLicense())
+                                            <a href="{{ $plugin->getLicenseUrl() }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                {{ $plugin->getLicense() }}
+                                                <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                            </a>
+                                        @else
+                                            <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                                        @endif
+                                    </dd>
+                                </div>
+
+                                {{-- iOS Version --}}
+                                <div>
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min iOS</dt>
+                                    <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                                        {{ $plugin->ios_version ?? ($plugin->review_checks['ios_min_version'] ?? '—') }}
+                                    </dd>
+                                </div>
+
+                                {{-- Android Version --}}
+                                <div>
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min Android</dt>
+                                    <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                                        {{ $plugin->android_version ?? ($plugin->review_checks['android_min_version'] ?? '—') }}
+                                    </dd>
+                                </div>
+
+                                {{-- Support Channel --}}
+                                <div class="col-span-2">
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Support Channel</dt>
+                                    <dd class="mt-1">
+                                        @if ($plugin->support_channel)
+                                            @if (filter_var($plugin->support_channel, FILTER_VALIDATE_URL))
+                                                <a href="{{ $plugin->support_channel }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                    {{ $plugin->support_channel }}
+                                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                                </a>
+                                            @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
+                                                <a href="mailto:{{ $plugin->support_channel }}" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                    {{ $plugin->support_channel }}
+                                                    <x-heroicon-o-envelope class="size-3" />
+                                                </a>
+                                            @else
+                                                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
+                                            @endif
+                                        @else
+                                            <span class="text-sm text-gray-400 dark:text-gray-500">Not set</span>
+                                        @endif
+                                    </dd>
+                                </div>
+
+                                {{-- Repository --}}
+                                <div class="col-span-2">
+                                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Repository</dt>
+                                    <dd class="mt-1">
+                                        <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                            {{ $plugin->repository_url }}
+                                            <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+                                        </a>
+                                    </dd>
+                                </div>
+                            </dl>
                         </flux:card>
 
                         {{-- Notes --}}
                         <flux:card>
                             <flux:heading size="lg">Notes</flux:heading>
-                            <flux:text class="mt-1">Any notes for the review team? These won't be displayed on your plugin listing.</flux:text>
+                            <flux:text class="mt-1">Share links to videos demonstrating the plugin in use or applications already available on the app stores using this plugin. Provide as much extra context for the review team so they can review your plugin more easily. <em>These notes will not be displayed on your plugin listing.</em></flux:text>
 
                             <div class="mt-4">
                                 <flux:textarea
@@ -493,9 +645,12 @@
                             </div>
                         </flux:card>
 
-                        {{-- Submit Button --}}
-                        <div class="flex items-center justify-end">
-                            <flux:button variant="primary" wire:click="submitForReview">Submit for Review</flux:button>
+                        {{-- Preflight Checks & Submit --}}
+                        <div class="flex items-center justify-end gap-3">
+                            @if ($plugin->review_checks)
+                                <flux:button variant="ghost" wire:click="runPreflightChecks">Re-run Checks</flux:button>
+                            @endif
+                            <flux:button variant="primary" wire:click="submitForReview">{{ $plugin->review_checks ? 'Submit for Review' : 'Submit' }}</flux:button>
                         </div>
                     </div>
                 </flux:tab.panel>
@@ -722,24 +877,101 @@
 
                 <flux:separator class="my-4" />
 
-                <div class="space-y-3">
-                    <div>
-                        <flux:heading size="sm">Support Channel</flux:heading>
-                        @if ($plugin->support_channel)
-                            <flux:text class="mt-1">{{ $plugin->support_channel }}</flux:text>
-                        @else
-                            <flux:text class="mt-1 text-gray-400 dark:text-gray-500">No support channel set</flux:text>
-                        @endif
+                <dl class="grid grid-cols-2 gap-3">
+                    {{-- Author --}}
+                    <div class="col-span-2">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Author</dt>
+                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                            {{ $plugin->user->display_name }}
+                        </dd>
                     </div>
 
+                    {{-- Version --}}
                     <div>
-                        <flux:heading size="sm">Repository</flux:heading>
-                        <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="mt-1 inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                            {{ $plugin->repository_url }}
-                            <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
-                        </a>
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Version</dt>
+                        <dd class="mt-1">
+                            @if ($plugin->latest_version)
+                                <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                    {{ $plugin->latest_version }}
+                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                </a>
+                            @elseif ($plugin->review_checks['release_version'] ?? null)
+                                <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                    {{ $plugin->review_checks['release_version'] }}
+                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                </a>
+                            @else
+                                <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                            @endif
+                        </dd>
                     </div>
-                </div>
+
+                    {{-- License --}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">License</dt>
+                        <dd class="mt-1">
+                            @if ($plugin->getLicense())
+                                <a href="{{ $plugin->getLicenseUrl() }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                    {{ $plugin->getLicense() }}
+                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                </a>
+                            @else
+                                <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                            @endif
+                        </dd>
+                    </div>
+
+                    {{-- iOS Version --}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min iOS</dt>
+                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                            {{ $plugin->ios_version ?? ($plugin->review_checks['ios_min_version'] ?? '—') }}
+                        </dd>
+                    </div>
+
+                    {{-- Android Version --}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min Android</dt>
+                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                            {{ $plugin->android_version ?? ($plugin->review_checks['android_min_version'] ?? '—') }}
+                        </dd>
+                    </div>
+
+                    {{-- Support Channel --}}
+                    <div class="col-span-2">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Support Channel</dt>
+                        <dd class="mt-1">
+                            @if ($plugin->support_channel)
+                                @if (filter_var($plugin->support_channel, FILTER_VALIDATE_URL))
+                                    <a href="{{ $plugin->support_channel }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                        {{ $plugin->support_channel }}
+                                        <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                    </a>
+                                @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
+                                    <a href="mailto:{{ $plugin->support_channel }}" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                        {{ $plugin->support_channel }}
+                                        <x-heroicon-o-envelope class="size-3" />
+                                    </a>
+                                @else
+                                    <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
+                                @endif
+                            @else
+                                <span class="text-sm text-gray-400 dark:text-gray-500">Not set</span>
+                            @endif
+                        </dd>
+                    </div>
+
+                    {{-- Repository --}}
+                    <div class="col-span-2">
+                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Repository</dt>
+                        <dd class="mt-1">
+                            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                {{ $plugin->repository_url }}
+                                <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+                            </a>
+                        </dd>
+                    </div>
+                </dl>
             </flux:card>
 
             @if ($plugin->notes)
@@ -751,4 +983,17 @@
         @endif
 
     </div>
+
+    @script
+    <script>
+        $wire.on('scroll-to-first-error', () => {
+            setTimeout(() => {
+                const firstError = document.querySelector('.text-red-600, .text-red-500, [data-flux-error]:not(.hidden)');
+                if (firstError) {
+                    firstError.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+            }, 100);
+        });
+    </script>
+    @endscript
 </div>

--- a/tests/Feature/CustomerPluginReviewChecksTest.php
+++ b/tests/Feature/CustomerPluginReviewChecksTest.php
@@ -46,7 +46,13 @@ class CustomerPluginReviewChecksTest extends TestCase
             "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
 
             // Webhook creation
-            "{$base}/hooks" => Http::response(['id' => 1], 201),
+            "{$base}/hooks" => function ($request) {
+                if ($request->method() === 'GET') {
+                    return Http::response([], 200);
+                }
+
+                return Http::response(['id' => 1], 201);
+            },
 
             // ReviewPluginRepository calls
             $base => Http::response(['default_branch' => 'main']),
@@ -126,7 +132,7 @@ class CustomerPluginReviewChecksTest extends TestCase
     }
 
     /** @test */
-    public function plugin_submitted_email_includes_failing_checks(): void
+    public function plugin_submitted_email_includes_failing_optional_checks(): void
     {
         Notification::fake();
 
@@ -157,14 +163,21 @@ class CustomerPluginReviewChecksTest extends TestCase
             ]),
             "{$base}/contents/nativephp.json" => Http::response([], 404),
             "{$base}/contents/LICENSE*" => Http::response([], 404),
-            "{$base}/releases/latest" => Http::response([], 404),
-            "{$base}/tags*" => Http::response([]),
+            "{$base}/releases/latest" => Http::response(['tag_name' => 'v1.0.0']),
+            "{$base}/tags*" => Http::response([['name' => 'v1.0.0']]),
             "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
-            "{$base}/hooks" => Http::response([], 422),
+            "{$base}/hooks" => function ($request) {
+                if ($request->method() === 'GET') {
+                    return Http::response([], 200);
+                }
+
+                return Http::response(['id' => 1], 201);
+            },
             $base => Http::response(['default_branch' => 'main']),
             "{$base}/git/trees/main*" => Http::response([
                 'tree' => [
                     ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                    ['path' => 'LICENSE', 'type' => 'blob'],
                 ],
             ]),
             "{$base}/readme" => Http::response([
@@ -197,13 +210,20 @@ class CustomerPluginReviewChecksTest extends TestCase
             ]),
             "{$base}/contents/nativephp.json" => Http::response([], 404),
             "{$base}/contents/LICENSE*" => Http::response([], 404),
-            "{$base}/releases/latest" => Http::response([], 404),
-            "{$base}/tags*" => Http::response([]),
-            "{$base}/hooks" => Http::response([], 422),
+            "{$base}/releases/latest" => Http::response(['tag_name' => 'v1.0.0']),
+            "{$base}/tags*" => Http::response([['name' => 'v1.0.0']]),
+            "{$base}/hooks" => function ($request) {
+                if ($request->method() === 'GET') {
+                    return Http::response([], 200);
+                }
+
+                return Http::response(['id' => 1], 201);
+            },
             $base => Http::response(['default_branch' => 'main']),
             "{$base}/git/trees/main*" => Http::response([
                 'tree' => [
                     ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                    ['path' => 'LICENSE', 'type' => 'blob'],
                 ],
             ]),
             "{$base}/readme" => Http::response([
@@ -213,7 +233,7 @@ class CustomerPluginReviewChecksTest extends TestCase
             "https://raw.githubusercontent.com/{$repoSlug}/*" => Http::response('', 404),
         ]);
 
-        // Step 2: Submit for review
+        // Step 2: Submit for review (required checks pass, optional ones don't)
         [$vendor, $package] = explode('/', $plugin->name);
         Livewire::actingAs($user)
             ->test(Show::class, ['vendor' => $vendor, 'package' => $package])
@@ -221,14 +241,11 @@ class CustomerPluginReviewChecksTest extends TestCase
 
         $plugin->refresh();
 
+        $this->assertEquals('pending', $plugin->status->value);
+
         Notification::assertSentTo($user, PluginSubmitted::class, function (PluginSubmitted $notification) use ($plugin) {
             $mail = $notification->toMail($plugin->user);
             $rendered = $mail->render()->toHtml();
-
-            // Should mention failing required checks
-            $this->assertStringContainsString('LICENSE', $rendered);
-            $this->assertStringContainsString('release version', $rendered);
-            $this->assertStringContainsString('webhook', $rendered);
 
             // Should mention failing optional checks
             $this->assertStringContainsString('Add iOS support', $rendered);

--- a/tests/Feature/Jobs/ReviewPluginRepositoryTest.php
+++ b/tests/Feature/Jobs/ReviewPluginRepositoryTest.php
@@ -221,7 +221,7 @@ class ReviewPluginRepositoryTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_empty_array_when_no_repository_url(): void
+    public function it_returns_failed_checks_when_no_repository_url(): void
     {
         $plugin = Plugin::factory()->create([
             'repository_url' => null,
@@ -229,8 +229,10 @@ class ReviewPluginRepositoryTest extends TestCase
 
         $checks = (new ReviewPluginRepository($plugin))->handle();
 
-        $this->assertEmpty($checks);
-        $this->assertNull($plugin->fresh()->reviewed_at);
+        $this->assertFalse($checks['has_license_file']);
+        $this->assertFalse($checks['has_release_version']);
+        $this->assertNotNull($plugin->fresh()->reviewed_at);
+        $this->assertNotNull($plugin->fresh()->review_checks);
     }
 
     /** @test */

--- a/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
+++ b/tests/Feature/Livewire/Customer/PluginStatusTransitionsTest.php
@@ -42,26 +42,43 @@ class PluginStatusTransitionsTest extends TestCase
         ]);
     }
 
-    private function fakeGitHubForSubmission(Plugin $plugin): void
+    private function fakeGitHubForSubmission(Plugin $plugin, bool $passingChecks = true): void
     {
         $repoInfo = $plugin->getRepositoryOwnerAndName();
         $base = "https://api.github.com/repos/{$repoInfo['owner']}/{$repoInfo['repo']}";
 
         Http::fake([
-            "{$base}/hooks" => Http::response(['id' => 1], 201),
+            "{$base}/hooks" => function ($request) {
+                if ($request->method() === 'GET') {
+                    return Http::response([], 200);
+                }
+
+                return Http::response(['id' => 1], 201);
+            },
             $base => Http::response(['default_branch' => 'main']),
             "{$base}/git/trees/main*" => Http::response([
-                'tree' => [
-                    ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
-                ],
+                'tree' => $passingChecks
+                    ? [
+                        ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                        ['path' => 'LICENSE', 'type' => 'blob'],
+                    ]
+                    : [
+                        ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                    ],
             ]),
             "{$base}/contents/composer.json*" => Http::response([
                 'content' => base64_encode(json_encode(['name' => $plugin->name])),
                 'encoding' => 'base64',
             ]),
-            "{$base}/contents/LICENSE*" => Http::response([], 404),
-            "{$base}/releases/latest" => Http::response([], 404),
-            "{$base}/tags*" => Http::response([]),
+            "{$base}/contents/LICENSE*" => $passingChecks
+                ? Http::response(['name' => 'LICENSE', 'type' => 'file'], 200)
+                : Http::response([], 404),
+            "{$base}/releases/latest" => $passingChecks
+                ? Http::response(['tag_name' => 'v1.0.0'], 200)
+                : Http::response([], 404),
+            "{$base}/tags*" => $passingChecks
+                ? Http::response([['name' => 'v1.0.0']])
+                : Http::response([]),
             "{$base}/readme" => Http::response([
                 'content' => base64_encode('# Plugin'),
                 'encoding' => 'base64',
@@ -104,6 +121,19 @@ class PluginStatusTransitionsTest extends TestCase
         $this->assertNotNull($plugin->reviewed_at);
 
         Notification::assertSentTo($user, PluginSubmitted::class);
+    }
+
+    public function test_submit_requires_description(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $plugin->update(['description' => null]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
     }
 
     public function test_submit_requires_support_channel(): void
@@ -438,5 +468,122 @@ class PluginStatusTransitionsTest extends TestCase
 
         $plugin->refresh();
         $this->assertEquals(PluginStatus::Pending, $plugin->status);
+    }
+
+    // ========================================
+    // Preflight Checks Gate Submission
+    // ========================================
+
+    public function test_submit_blocked_when_required_checks_fail(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin, passingChecks: false);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Draft, $plugin->status);
+        $this->assertNotNull($plugin->review_checks);
+        $this->assertFalse($plugin->passesRequiredReviewChecks());
+    }
+
+    public function test_run_preflight_checks_populates_review_checks(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin);
+
+        $this->assertNull($plugin->review_checks);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('runPreflightChecks');
+
+        $plugin->refresh();
+        $this->assertNotNull($plugin->review_checks);
+        $this->assertTrue($plugin->review_checks['has_license_file']);
+        $this->assertTrue($plugin->review_checks['has_release_version']);
+        $this->assertTrue($plugin->webhook_installed);
+    }
+
+    public function test_submit_succeeds_after_preflight_checks_pass(): void
+    {
+        Notification::fake();
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+        $this->fakeGitHubForSubmission($plugin);
+
+        // Run checks first
+        $this->mountShowComponent($user, $plugin)
+            ->call('runPreflightChecks');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->passesRequiredReviewChecks());
+
+        // Now submit
+        $this->mountShowComponent($user, $plugin)
+            ->call('submitForReview');
+
+        $plugin->refresh();
+        $this->assertEquals(PluginStatus::Pending, $plugin->status);
+        Notification::assertSentTo($user, PluginSubmitted::class);
+    }
+
+    public function test_preflight_detects_manually_installed_webhook(): void
+    {
+        $user = $this->createGitHubUser();
+        $plugin = $this->createDraftPlugin($user);
+
+        // Simulate a webhook secret existing but not marked as installed
+        $plugin->generateWebhookSecret();
+        $plugin->update(['webhook_installed' => false]);
+
+        $repoInfo = $plugin->getRepositoryOwnerAndName();
+        $base = "https://api.github.com/repos/{$repoInfo['owner']}/{$repoInfo['repo']}";
+        $webhookUrl = $plugin->getWebhookUrl();
+
+        Http::fake([
+            // GET /hooks returns our webhook in the list
+            "{$base}/hooks" => function ($request) use ($webhookUrl) {
+                if ($request->method() === 'GET') {
+                    return Http::response([
+                        ['id' => 42, 'config' => ['url' => $webhookUrl]],
+                    ], 200);
+                }
+
+                return Http::response(['id' => 1], 201);
+            },
+            $base => Http::response(['default_branch' => 'main']),
+            "{$base}/git/trees/main*" => Http::response([
+                'tree' => [
+                    ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
+                    ['path' => 'LICENSE', 'type' => 'blob'],
+                ],
+            ]),
+            "{$base}/contents/composer.json*" => Http::response([
+                'content' => base64_encode(json_encode(['name' => $plugin->name])),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/LICENSE*" => Http::response(['name' => 'LICENSE', 'type' => 'file'], 200),
+            "{$base}/releases/latest" => Http::response(['tag_name' => 'v1.0.0'], 200),
+            "{$base}/tags*" => Http::response([['name' => 'v1.0.0']]),
+            "{$base}/readme" => Http::response([
+                'content' => base64_encode('# Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/README.md*" => Http::response([
+                'content' => base64_encode('# Plugin'),
+                'encoding' => 'base64',
+            ]),
+            "{$base}/contents/nativephp.json*" => Http::response([], 404),
+            'https://raw.githubusercontent.com/*' => Http::response('', 404),
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('runPreflightChecks');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->webhook_installed);
     }
 }

--- a/tests/Feature/Livewire/Customer/PluginWebhookCertificationTest.php
+++ b/tests/Feature/Livewire/Customer/PluginWebhookCertificationTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Livewire\Customer;
+
+use App\Livewire\Customer\Plugins\Show;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginWebhookCertificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createUser(): User
+    {
+        return User::factory()->create([
+            'github_id' => '12345',
+            'github_username' => 'testuser',
+            'github_token' => encrypt('fake-token'),
+        ]);
+    }
+
+    private function mountShowComponent(User $user, Plugin $plugin)
+    {
+        [$vendor, $package] = explode('/', $plugin->name);
+
+        return Livewire::actingAs($user)->test(Show::class, [
+            'vendor' => $vendor,
+            'package' => $package,
+        ]);
+    }
+
+    public function test_certify_webhook_marks_plugin_as_webhook_installed(): void
+    {
+        $user = $this->createUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/certify-plugin',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+            'webhook_installed' => false,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('certifyWebhook');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->webhook_installed);
+    }
+
+    public function test_certify_webhook_generates_secret_if_missing(): void
+    {
+        $user = $this->createUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/no-secret-plugin',
+            'webhook_secret' => null,
+            'webhook_installed' => false,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('certifyWebhook');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->webhook_installed);
+        $this->assertNotNull($plugin->webhook_secret);
+    }
+
+    public function test_certify_webhook_is_idempotent(): void
+    {
+        $user = $this->createUser();
+        $secret = bin2hex(random_bytes(32));
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/already-installed',
+            'webhook_secret' => $secret,
+            'webhook_installed' => true,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('certifyWebhook');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->webhook_installed);
+        $this->assertEquals($secret, $plugin->webhook_secret);
+    }
+
+    public function test_certify_webhook_makes_plugin_pass_webhook_check(): void
+    {
+        $user = $this->createUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/check-plugin',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+            'webhook_installed' => false,
+            'review_checks' => [
+                'has_license_file' => true,
+                'has_release_version' => true,
+            ],
+        ]);
+
+        $this->assertFalse($plugin->passesRequiredReviewChecks());
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('certifyWebhook');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->passesRequiredReviewChecks());
+    }
+
+    public function test_retry_webhook_installs_successfully(): void
+    {
+        $user = $this->createUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/retry-plugin',
+            'repository_url' => 'https://github.com/testuser/retry-plugin',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+            'webhook_installed' => false,
+        ]);
+
+        Http::fake([
+            'https://api.github.com/repos/testuser/retry-plugin/hooks' => Http::response(['id' => 1], 201),
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('retryWebhook');
+
+        $plugin->refresh();
+        $this->assertTrue($plugin->webhook_installed);
+    }
+
+    public function test_retry_webhook_handles_failure(): void
+    {
+        $user = $this->createUser();
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/retry-fail-plugin',
+            'repository_url' => 'https://github.com/testuser/retry-fail-plugin',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+            'webhook_installed' => false,
+        ]);
+
+        Http::fake([
+            'https://api.github.com/repos/testuser/retry-fail-plugin/hooks' => Http::response(['message' => 'Not Found'], 404),
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('retryWebhook');
+
+        $plugin->refresh();
+        $this->assertFalse($plugin->webhook_installed);
+    }
+
+    public function test_retry_webhook_without_github_token_shows_error(): void
+    {
+        $user = User::factory()->create([
+            'github_id' => null,
+            'github_token' => null,
+        ]);
+        $plugin = Plugin::factory()->pending()->for($user)->create([
+            'name' => 'testuser/no-token-plugin',
+            'repository_url' => 'https://github.com/testuser/no-token-plugin',
+            'webhook_secret' => bin2hex(random_bytes(32)),
+            'webhook_installed' => false,
+        ]);
+
+        $this->mountShowComponent($user, $plugin)
+            ->call('retryWebhook');
+
+        $plugin->refresh();
+        $this->assertFalse($plugin->webhook_installed);
+    }
+}


### PR DESCRIPTION
## Summary

- Developers can self-certify webhook installation when automatic registration fails, with manual setup instructions always visible
- Adds "Retry automatic setup" button alongside self-certification
- Preflight checks (license file, release version, webhook) now gate plugin submission — plugins stay in draft until all required checks pass
- Verifies webhook existence via GitHub API during preflight checks, correcting stale `webhook_installed` flags
- Adds description validation to submission flow
- Enhances plugin summary card with author name, version, license, min iOS/Android versions, and support channel with appropriate links
- Replaces session flash banners with Flux toasts and adds `<flux:toast />` to the dashboard layout
- Scrolls to first validation error on form submission failures
- `ReviewPluginRepository` now always populates `review_checks` even when GitHub API calls fail, ensuring the checks panel always renders

## Test plan

- [x] 31 tests passing across `PluginStatusTransitionsTest`, `PluginWebhookCertificationTest`, and `CustomerPluginReviewChecksTest`
- [x] Verify webhook self-certification flow works end-to-end
- [x] Verify preflight checks block submission when license/release/webhook missing
- [x] Verify Flux toasts appear correctly for success and error states
- [x] Verify scroll-to-error works on form validation failures
- [x] Verify plugin summary card shows all details with correct links

🤖 Generated with [Claude Code](https://claude.com/claude-code)