### PR TITLE
Queue new plugin notifications via a dedicated job

### DIFF
--- a/app/Jobs/SendNewPluginNotifications.php
+++ b/app/Jobs/SendNewPluginNotifications.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginAvailable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Notification;
+
+class SendNewPluginNotifications implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Plugin $plugin) {}
+
+    public function handle(): void
+    {
+        $recipients = User::query()
+            ->where('receives_new_plugin_notifications', true)
+            ->where('id', '!=', $this->plugin->user_id)
+            ->get();
+
+        Notification::send($recipients, new NewPluginAvailable($this->plugin));
+    }
+}

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -7,7 +7,7 @@ use App\Enums\PluginStatus;
 use App\Enums\PluginTier;
 use App\Enums\PluginType;
 use App\Enums\PriceTier;
-use App\Notifications\NewPluginAvailable;
+use App\Jobs\SendNewPluginNotifications;
 use App\Notifications\PluginApproved;
 use App\Notifications\PluginRejected;
 use App\Services\PluginSyncService;
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Support\Facades\Notification;
 
 class Plugin extends Model
 {
@@ -568,12 +567,7 @@ class Plugin extends Model
         $this->user->notify(new PluginApproved($this));
 
         if ($isFirstApproval) {
-            $recipients = User::query()
-                ->where('receives_new_plugin_notifications', true)
-                ->where('id', '!=', $this->user_id)
-                ->get();
-
-            Notification::send($recipients, new NewPluginAvailable($this));
+            SendNewPluginNotifications::dispatch($this);
         }
 
         resolve(PluginSyncService::class)->sync($this);

--- a/tests/Feature/Jobs/SendNewPluginNotificationsTest.php
+++ b/tests/Feature/Jobs/SendNewPluginNotificationsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\SendNewPluginNotifications;
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginAvailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SendNewPluginNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_sends_notification_to_opted_in_users(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $optedIn = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $optedOut = User::factory()->create(['receives_new_plugin_notifications' => false]);
+
+        $plugin = Plugin::factory()->approved()->for($author)->create();
+
+        (new SendNewPluginNotifications($plugin))->handle();
+
+        Notification::assertSentTo($optedIn, NewPluginAvailable::class);
+        Notification::assertNotSentTo($optedOut, NewPluginAvailable::class);
+    }
+
+    public function test_job_does_not_notify_plugin_author(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin = Plugin::factory()->approved()->for($author)->create();
+
+        (new SendNewPluginNotifications($plugin))->handle();
+
+        Notification::assertNotSentTo($author, NewPluginAvailable::class);
+    }
+}

--- a/tests/Feature/Notifications/NewPluginAvailableTest.php
+++ b/tests/Feature/Notifications/NewPluginAvailableTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Feature\Notifications;
 
+use App\Jobs\SendNewPluginNotifications;
 use App\Models\Plugin;
 use App\Models\User;
 use App\Notifications\NewPluginAvailable;
 use App\Services\PluginSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Bus;
 use Tests\TestCase;
 
 class NewPluginAvailableTest extends TestCase
@@ -23,31 +24,26 @@ class NewPluginAvailableTest extends TestCase
         });
     }
 
-    public function test_notification_is_sent_to_opted_in_users_on_first_approval(): void
+    public function test_notification_job_is_dispatched_on_first_approval(): void
     {
-        Notification::fake();
+        Bus::fake(SendNewPluginNotifications::class);
 
         $author = User::factory()->create();
-        $optedIn = User::factory()->create(['receives_new_plugin_notifications' => true]);
-        $optedOut = User::factory()->create(['receives_new_plugin_notifications' => false]);
-
         $plugin = Plugin::factory()->pending()->for($author)->create();
         $admin = User::factory()->create();
 
         $plugin->approve($admin->id);
 
-        Notification::assertSentTo($optedIn, NewPluginAvailable::class);
-        Notification::assertNotSentTo($optedOut, NewPluginAvailable::class);
-        Notification::assertNotSentTo($author, NewPluginAvailable::class);
+        Bus::assertDispatched(SendNewPluginNotifications::class, function ($job) use ($plugin) {
+            return $job->plugin->id === $plugin->id;
+        });
     }
 
-    public function test_notification_is_not_sent_on_re_approval(): void
+    public function test_notification_job_is_not_dispatched_on_re_approval(): void
     {
-        Notification::fake();
+        Bus::fake(SendNewPluginNotifications::class);
 
         $author = User::factory()->create();
-        $optedIn = User::factory()->create(['receives_new_plugin_notifications' => true]);
-
         $plugin = Plugin::factory()->pending()->for($author)->create([
             'approved_at' => now()->subDay(),
         ]);
@@ -55,7 +51,7 @@ class NewPluginAvailableTest extends TestCase
 
         $plugin->approve($admin->id);
 
-        Notification::assertNotSentTo($optedIn, NewPluginAvailable::class);
+        Bus::assertNotDispatched(SendNewPluginNotifications::class);
     }
 
     public function test_via_returns_empty_array_when_user_opted_out(): void


### PR DESCRIPTION
## Summary
- Moves the `NewPluginAvailable` notification fan-out from `Plugin::approve()` into a new `SendNewPluginNotifications` queued job
- Previously, approving a plugin iterated through all opted-in users synchronously during the HTTP request, queuing individual notifications one-by-one — this blocked the admin UI
- Now a single job is dispatched, and the fan-out happens on the queue worker

## Changes
- **New:** `app/Jobs/SendNewPluginNotifications.php` — queued job that queries opted-in users and sends `NewPluginAvailable` notifications
- **Updated:** `Plugin::approve()` — dispatches the job instead of inline `Notification::send()`
- **Updated:** `NewPluginAvailableTest` — integration tests now assert the job is dispatched via `Bus::fake()`
- **New:** `SendNewPluginNotificationsTest` — dedicated tests for the job's notification logic

## Test plan
- [x] Job sends notifications to opted-in users
- [x] Job excludes the plugin author
- [x] Job is dispatched on first approval
- [x] Job is not dispatched on re-approval
- [x] All existing notification tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)