### PR TITLE
Remove GitHub/Packagist links and hide grant action for free plugins

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -371,6 +371,7 @@ class PluginResource extends Resource
                         ->label('Grant to User')
                         ->icon('heroicon-o-gift')
                         ->color('success')
+                        ->visible(fn (Plugin $record): bool => ! $record->isFree())
                         ->form([
                             Forms\Components\Select::make('user_id')
                                 ->label('User')

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -115,6 +115,11 @@ class PluginResource extends Resource
                         Forms\Components\Toggle::make('is_official')
                             ->label('Official (First-Party)')
                             ->helperText('Official plugins are free for Ultra subscribers'),
+
+                        Forms\Components\Toggle::make('featured'),
+
+                        Forms\Components\Toggle::make('is_active')
+                            ->label('Active'),
                     ]),
 
                 Schemas\Components\Section::make('Review Checks')

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -59,6 +59,17 @@ class PluginResource extends Resource
                         Forms\Components\TextInput::make('display_name')
                             ->label('Display Name'),
 
+                        Forms\Components\Textarea::make('description')
+                            ->label('Description'),
+
+                        Forms\Components\Select::make('type')
+                            ->options(PluginType::class),
+
+                        Forms\Components\Select::make('tier')
+                            ->options(PluginTier::class)
+                            ->placeholder('No tier')
+                            ->helperText('Set pricing tier for paid plugins'),
+
                         Forms\Components\Placeholder::make('name')
                             ->label('Composer Package Name')
                             ->content(function (?Plugin $record) {
@@ -72,14 +83,6 @@ class PluginResource extends Resource
 
                                 return $record->name;
                             }),
-
-                        Forms\Components\Select::make('type')
-                            ->options(PluginType::class),
-
-                        Forms\Components\Select::make('tier')
-                            ->options(PluginTier::class)
-                            ->placeholder('No tier')
-                            ->helperText('Set pricing tier for paid plugins'),
 
                         Forms\Components\Placeholder::make('repository_url')
                             ->label('Repository URL')
@@ -109,22 +112,9 @@ class PluginResource extends Resource
                             })
                             ->visible(fn (?Plugin $record) => $record !== null),
 
-                        Forms\Components\Select::make('status')
-                            ->options(PluginStatus::class)
-                            ->disabled()
-                            ->helperText('Use the Approve/Reject actions to change status'),
-
                         Forms\Components\Toggle::make('is_official')
                             ->label('Official (First-Party)')
                             ->helperText('Official plugins are free for Ultra subscribers'),
-
-                        Forms\Components\Textarea::make('description')
-                            ->label('Description'),
-
-                        Forms\Components\Textarea::make('rejection_reason')
-                            ->label('Rejection Reason')
-
-                            ->visible(fn (?Plugin $record) => $record?->isRejected()),
                     ]),
 
                 Schemas\Components\Section::make('Review Checks')

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PluginResource\Pages;
 
+use App\Enums\PluginStatus;
 use App\Enums\PluginTier;
 use App\Enums\PluginType;
 use App\Filament\Resources\PluginResource;
@@ -15,11 +16,29 @@ use Filament\Actions;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 
 class EditPlugin extends EditRecord
 {
     protected static string $resource = PluginResource::class;
+
+    public function getSubheading(): string|HtmlString|null
+    {
+        $color = match ($this->record->status) {
+            PluginStatus::Draft => 'gray',
+            PluginStatus::Pending => 'warning',
+            PluginStatus::Approved => 'success',
+            PluginStatus::Rejected => 'danger',
+        };
+
+        return new HtmlString(
+            Blade::render('<x-filament::badge :color="$color">{{ $label }}</x-filament::badge>', [
+                'color' => $color,
+                'label' => $this->record->status->label(),
+            ])
+        );
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -106,7 +106,7 @@ class EditPlugin extends EditRecord
                     ->label('Grant to User')
                     ->icon('heroicon-o-gift')
                     ->color('success')
-                    ->visible(fn () => $this->record->isApproved())
+                    ->visible(fn () => $this->record->isApproved() && ! $this->record->isFree())
                     ->form([
                         Forms\Components\Select::make('user_id')
                             ->label('User')
@@ -158,14 +158,6 @@ class EditPlugin extends EditRecord
                     ->modalHeading('Grant Plugin to User')
                     ->modalDescription(fn () => "Grant '{$this->record->name}' to a user for free.")
                     ->modalSubmitActionLabel('Grant'),
-
-                Actions\Action::make('viewPackagist')
-                    ->label('View on Packagist')
-                    ->icon('heroicon-o-arrow-top-right-on-square')
-                    ->color('gray')
-                    ->url(fn () => $this->record->getPackagistUrl())
-                    ->openUrlInNewTab()
-                    ->visible(fn () => $this->record->isFree()),
 
                 Actions\Action::make('runReviewChecks')
                     ->label('Run Review Checks')
@@ -244,14 +236,6 @@ class EditPlugin extends EditRecord
                             ->success()
                             ->send();
                     }),
-
-                Actions\Action::make('viewGithub')
-                    ->label('View on GitHub')
-                    ->icon('heroicon-o-arrow-top-right-on-square')
-                    ->color('gray')
-                    ->visible(fn () => $this->record->repository_url !== null)
-                    ->url(fn () => $this->record->getGithubUrl())
-                    ->openUrlInNewTab(),
 
                 Actions\Action::make('viewListing')
                     ->label('View Listing Page')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tender-duck",
+    "name": "eager-ferret",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/Filament/GrantPluginToUserActionTest.php
+++ b/tests/Feature/Filament/GrantPluginToUserActionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\PluginResource\Pages\EditPlugin;
+use App\Filament\Resources\PluginResource\Pages\ListPlugins;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class GrantPluginToUserActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_grant_to_user_action_is_hidden_for_free_plugins_on_list(): void
+    {
+        $plugin = Plugin::factory()->free()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertTableActionHidden('grantToUser', $plugin);
+    }
+
+    public function test_grant_to_user_action_is_visible_for_paid_plugins_on_list(): void
+    {
+        $plugin = Plugin::factory()->paid()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertTableActionVisible('grantToUser', $plugin);
+    }
+
+    public function test_grant_to_user_action_is_hidden_for_free_plugins_on_edit(): void
+    {
+        $plugin = Plugin::factory()->free()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertActionHidden('grantToUser');
+    }
+
+    public function test_grant_to_user_action_is_visible_for_paid_plugins_on_edit(): void
+    {
+        $plugin = Plugin::factory()->paid()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertActionVisible('grantToUser');
+    }
+}

--- a/tests/Feature/Filament/PluginEditFormTest.php
+++ b/tests/Feature/Filament/PluginEditFormTest.php
@@ -105,4 +105,33 @@ class PluginEditFormTest extends TestCase
             ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
             ->assertActionHidden('approve');
     }
+
+    public function test_status_is_shown_as_badge_in_subheading(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertSee('Approved');
+    }
+
+    public function test_status_field_is_not_in_form(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertFormFieldDoesNotExist('status');
+    }
+
+    public function test_rejection_reason_field_is_not_in_form(): void
+    {
+        $plugin = Plugin::factory()->rejected()->create([
+            'rejection_reason' => 'Missing license',
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertFormFieldDoesNotExist('rejection_reason');
+    }
 }

--- a/tests/Feature/Filament/ResyncPluginActionTest.php
+++ b/tests/Feature/Filament/ResyncPluginActionTest.php
@@ -64,27 +64,4 @@ class ResyncPluginActionTest extends TestCase
             ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
             ->assertActionHidden('resync');
     }
-
-    public function test_view_github_action_uses_repository_url(): void
-    {
-        $plugin = Plugin::factory()->free()->approved()->create([
-            'repository_url' => 'https://github.com/acme/test-plugin',
-        ]);
-
-        Livewire::actingAs($this->admin)
-            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
-            ->assertActionVisible('viewGithub')
-            ->assertActionHasUrl('viewGithub', 'https://github.com/acme/test-plugin');
-    }
-
-    public function test_view_github_action_hidden_when_no_repository_url(): void
-    {
-        $plugin = Plugin::factory()->free()->approved()->create([
-            'repository_url' => null,
-        ]);
-
-        Livewire::actingAs($this->admin)
-            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
-            ->assertActionHidden('viewGithub');
-    }
 }


### PR DESCRIPTION
## Summary
- Removed "View on GitHub" and "View on Packagist" actions from the admin plugin edit page menu
- Hidden the "Grant to User" action for free plugins on both the list and edit pages (granting a license to a free plugin doesn't make sense)

## Test plan
- [x] Added tests verifying grant action is hidden for free plugins and visible for paid plugins on both list and edit pages
- [x] Existing plugin resource tests still pass