### PR TITLE
Fix plugin listing page showing stale version

### DIFF
--- a/app/Jobs/SyncPluginReleases.php
+++ b/app/Jobs/SyncPluginReleases.php
@@ -78,7 +78,17 @@ class SyncPluginReleases implements ShouldQueue
             }
         }
 
-        $this->plugin->update(['last_synced_at' => now()]);
+        $updateData = ['last_synced_at' => now()];
+
+        if ($this->hasNewReleases) {
+            $latestVersion = $this->plugin->versions()->latest('published_at')->first();
+
+            if ($latestVersion) {
+                $updateData['latest_version'] = $latestVersion->version;
+            }
+        }
+
+        $this->plugin->update($updateData);
 
         Log::info('[SyncPluginReleases] Processing complete', [
             'plugin_id' => $this->plugin->id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "eager-ferret",
+    "name": "proud-mole",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/Jobs/SyncPluginReleasesTest.php
+++ b/tests/Feature/Jobs/SyncPluginReleasesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\SyncPluginReleases;
+use App\Models\Plugin;
+use App\Models\PluginVersion;
+use App\Services\SatisService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncPluginReleasesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_updates_latest_version_on_plugin_when_new_releases_are_synced(): void
+    {
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/releases*' => Http::response([
+                [
+                    'id' => 1,
+                    'tag_name' => 'v1.0.0',
+                    'body' => 'Initial release',
+                    'target_commitish' => 'abc123',
+                    'published_at' => '2026-01-01T00:00:00Z',
+                ],
+                [
+                    'id' => 2,
+                    'tag_name' => 'v1.1.0',
+                    'body' => 'New features',
+                    'target_commitish' => 'def456',
+                    'published_at' => '2026-02-01T00:00:00Z',
+                ],
+            ]),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+            'latest_version' => '0.9.0',
+        ]);
+
+        $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
+        $job->handle(app(SatisService::class));
+
+        $plugin->refresh();
+
+        $this->assertEquals('1.1.0', $plugin->latest_version);
+        $this->assertCount(2, $plugin->versions);
+    }
+
+    public function test_it_does_not_update_latest_version_when_no_new_releases(): void
+    {
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/releases*' => Http::response([
+                [
+                    'id' => 1,
+                    'tag_name' => 'v1.0.0',
+                    'body' => 'Initial release',
+                    'target_commitish' => 'abc123',
+                    'published_at' => '2026-01-01T00:00:00Z',
+                ],
+            ]),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+            'latest_version' => '1.0.0',
+        ]);
+
+        // Pre-create the version so nothing is "new"
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => '2026-01-01T00:00:00Z',
+        ]);
+
+        $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
+        $job->handle(app(SatisService::class));
+
+        $plugin->refresh();
+
+        $this->assertEquals('1.0.0', $plugin->latest_version);
+    }
+}

--- a/tests/Feature/Jobs/SyncPluginReleasesTest.php
+++ b/tests/Feature/Jobs/SyncPluginReleasesTest.php
@@ -41,8 +41,10 @@ class SyncPluginReleasesTest extends TestCase
             'latest_version' => '0.9.0',
         ]);
 
+        $satisService = $this->mock(SatisService::class);
+
         $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
-        $job->handle(app(SatisService::class));
+        $job->handle($satisService);
 
         $plugin->refresh();
 
@@ -79,8 +81,10 @@ class SyncPluginReleasesTest extends TestCase
             'published_at' => '2026-01-01T00:00:00Z',
         ]);
 
+        $satisService = $this->mock(SatisService::class);
+
         $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
-        $job->handle(app(SatisService::class));
+        $job->handle($satisService);
 
         $plugin->refresh();
 


### PR DESCRIPTION
## Summary
- **SyncPluginReleases** job creates `PluginVersion` records (used by admin/Satis) but never updated the `plugins.latest_version` field that the public listing page reads from
- After processing new releases, the job now also updates `latest_version` on the plugin to match the newest version from the `plugin_versions` table

## Test plan
- [x] Added test: new releases update `latest_version` on the plugin
- [x] Added test: no-op when all releases already exist (no false updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)