### PR TITLE
Fix admin plugin list to show drafts when filtering by Draft status

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -23,6 +23,7 @@ use Filament\Schemas;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\HtmlString;
 
 class PluginResource extends Resource
@@ -333,7 +334,11 @@ class PluginResource extends Resource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
-                    ->options(PluginStatus::class),
+                    ->options(PluginStatus::class)
+                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'])
+                        ? $query->where('status', $data['value'])
+                        : $query->where('status', '!=', PluginStatus::Draft)
+                    ),
                 Tables\Filters\SelectFilter::make('type')
                     ->options(PluginType::class),
                 Tables\Filters\TernaryFilter::make('is_official')

--- a/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
+++ b/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
@@ -2,11 +2,9 @@
 
 namespace App\Filament\Resources\PluginResource\Pages;
 
-use App\Enums\PluginStatus;
 use App\Filament\Resources\PluginResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
-use Illuminate\Database\Eloquent\Builder;
 
 class ListPlugins extends ListRecords
 {
@@ -17,11 +15,5 @@ class ListPlugins extends ListRecords
         return [
             Actions\CreateAction::make(),
         ];
-    }
-
-    protected function getTableQuery(): ?Builder
-    {
-        return parent::getTableQuery()
-            ->where('status', '!=', PluginStatus::Draft);
     }
 }

--- a/tests/Feature/Filament/PluginListDraftFilterTest.php
+++ b/tests/Feature/Filament/PluginListDraftFilterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\PluginStatus;
+use App\Filament\Resources\PluginResource\Pages\ListPlugins;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginListDraftFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_draft_plugins_are_hidden_by_default(): void
+    {
+        $draft = Plugin::factory()->draft()->create();
+        $approved = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertCanNotSeeTableRecords([$draft])
+            ->assertCanSeeTableRecords([$approved]);
+    }
+
+    public function test_draft_plugins_are_visible_when_filtering_by_draft_status(): void
+    {
+        $draft = Plugin::factory()->draft()->create();
+        $approved = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->filterTable('status', PluginStatus::Draft->value)
+            ->assertCanSeeTableRecords([$draft])
+            ->assertCanNotSeeTableRecords([$approved]);
+    }
+}


### PR DESCRIPTION
## Summary

- Moved draft plugin exclusion from the base `ListPlugins::getTableQuery()` into the status `SelectFilter`'s custom `query()` callback
- Drafts are still hidden by default (no filter selected), but now appear when explicitly filtering by "Draft" status
- Previously, selecting "Draft" in the status filter produced conflicting WHERE clauses (`status != 'draft' AND status = 'draft'`) and returned no results

## Test plan

- [x] Added `PluginListDraftFilterTest` with two test cases:
  - Draft plugins hidden by default
  - Draft plugins visible when filtering by Draft status
- [x] All 87 Filament tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)