### PR TITLE
Add per-account payout percentage to developer accounts

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -110,6 +110,9 @@ class UserResource extends Resource
                         Forms\Components\Placeholder::make('developerAccount.accepted_plugin_terms_at')
                             ->label('Plugin Terms Accepted')
                             ->content(fn (User $record) => $record->developerAccount->accepted_plugin_terms_at?->format('M j, Y g:i A') ?? '—'),
+                        Forms\Components\Placeholder::make('developerAccount.payout_percentage')
+                            ->label('Payout Percentage')
+                            ->content(fn (User $record) => $record->developerAccount->payout_percentage.'%'),
                         Forms\Components\Placeholder::make('developerAccount.plugin_terms_version')
                             ->label('Terms Version')
                             ->content(fn (User $record) => $record->developerAccount->plugin_terms_version ?? '—'),

--- a/app/Jobs/HandleInvoicePaidJob.php
+++ b/app/Jobs/HandleInvoicePaidJob.php
@@ -523,7 +523,7 @@ class HandleInvoicePaidJob implements ShouldQueue
         if ($plugin->developerAccount && $plugin->developerAccount->canReceivePayouts() && $amount > 0) {
             $platformFeePercent = ($user->hasActiveUltraSubscription() && ! $plugin->isOfficial())
                 ? 0
-                : PluginPayout::PLATFORM_FEE_PERCENT;
+                : $plugin->developerAccount->platformFeePercent();
 
             $split = PluginPayout::calculateSplit($amount, $platformFeePercent);
 
@@ -565,7 +565,7 @@ class HandleInvoicePaidJob implements ShouldQueue
         if ($plugin->developerAccount && $plugin->developerAccount->canReceivePayouts() && $allocatedAmount > 0) {
             $platformFeePercent = ($user->hasActiveUltraSubscription() && ! $plugin->isOfficial())
                 ? 0
-                : PluginPayout::PLATFORM_FEE_PERCENT;
+                : $plugin->developerAccount->platformFeePercent();
 
             $split = PluginPayout::calculateSplit($allocatedAmount, $platformFeePercent);
 

--- a/app/Models/DeveloperAccount.php
+++ b/app/Models/DeveloperAccount.php
@@ -66,6 +66,11 @@ class DeveloperAccount extends Model
             && $this->plugin_terms_version === self::CURRENT_PLUGIN_TERMS_VERSION;
     }
 
+    public function platformFeePercent(): int
+    {
+        return 100 - $this->payout_percentage;
+    }
+
     protected function casts(): array
     {
         return [
@@ -74,6 +79,7 @@ class DeveloperAccount extends Model
             'charges_enabled' => 'boolean',
             'onboarding_completed_at' => 'datetime',
             'accepted_plugin_terms_at' => 'datetime',
+            'payout_percentage' => 'integer',
         ];
     }
 }

--- a/database/factories/DeveloperAccountFactory.php
+++ b/database/factories/DeveloperAccountFactory.php
@@ -28,6 +28,7 @@ class DeveloperAccountFactory extends Factory
             'onboarding_completed_at' => now(),
             'country' => 'US',
             'payout_currency' => 'USD',
+            'payout_percentage' => 70,
         ];
     }
 

--- a/database/migrations/2026_04_13_172153_add_payout_percentage_to_developer_accounts_table.php
+++ b/database/migrations/2026_04_13_172153_add_payout_percentage_to_developer_accounts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('developer_accounts', function (Blueprint $table) {
+            $table->unsignedTinyInteger('payout_percentage')->default(70)->after('payout_currency');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('developer_accounts', function (Blueprint $table) {
+            $table->dropColumn('payout_percentage');
+        });
+    }
+};

--- a/tests/Feature/DeveloperAccountPayoutTest.php
+++ b/tests/Feature/DeveloperAccountPayoutTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\HandleInvoicePaidJob;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\DeveloperAccount;
+use App\Models\Plugin;
+use App\Models\PluginPayout;
+use App\Models\PluginPrice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use PHPUnit\Framework\Attributes\Test;
+use Stripe\Invoice;
+use Tests\TestCase;
+
+class DeveloperAccountPayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MAX_PRICE_ID = 'price_1RoZk0AyFo6rlwXqjkLj4hZ0';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['subscriptions.plans.max.stripe_price_id' => self::MAX_PRICE_ID]);
+    }
+
+    #[Test]
+    public function payout_percentage_defaults_to_seventy(): void
+    {
+        $account = DeveloperAccount::factory()->create();
+
+        $this->assertEquals(70, $account->payout_percentage);
+    }
+
+    #[Test]
+    public function platform_fee_percent_is_inverse_of_payout_percentage(): void
+    {
+        $account = DeveloperAccount::factory()->create(['payout_percentage' => 80]);
+
+        $this->assertEquals(20, $account->platformFeePercent());
+    }
+
+    #[Test]
+    public function platform_fee_percent_with_default_payout_percentage(): void
+    {
+        $account = DeveloperAccount::factory()->create();
+
+        $this->assertEquals(30, $account->platformFeePercent());
+    }
+
+    #[Test]
+    public function custom_payout_percentage_is_used_for_plugin_purchase(): void
+    {
+        $buyer = User::factory()->create(['stripe_id' => 'cus_test_buyer_'.uniqid()]);
+
+        $developerAccount = DeveloperAccount::factory()->create(['payout_percentage' => 80]);
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'is_active' => true,
+            'is_official' => false,
+            'user_id' => $developerAccount->user_id,
+            'developer_account_id' => $developerAccount->id,
+        ]);
+        PluginPrice::factory()->regular()->amount(10000)->create(['plugin_id' => $plugin->id]);
+
+        $cart = Cart::factory()->for($buyer)->create();
+        CartItem::create([
+            'cart_id' => $cart->id,
+            'plugin_id' => $plugin->id,
+            'plugin_price_id' => $plugin->prices->first()->id,
+            'price_at_addition' => 10000,
+        ]);
+
+        $invoice = $this->createStripeInvoice($cart->id, $buyer->stripe_id);
+        $job = new HandleInvoicePaidJob($invoice);
+        $job->handle();
+
+        $payout = PluginPayout::first();
+        $this->assertNotNull($payout);
+        $this->assertEquals(10000, $payout->gross_amount);
+        $this->assertEquals(2000, $payout->platform_fee);
+        $this->assertEquals(8000, $payout->developer_amount);
+    }
+
+    #[Test]
+    public function ultra_subscriber_overrides_custom_payout_percentage_to_full(): void
+    {
+        $buyer = User::factory()->create(['stripe_id' => 'cus_test_buyer_'.uniqid()]);
+        Subscription::factory()->for($buyer)->active()->create(['stripe_price' => self::MAX_PRICE_ID]);
+
+        $developerAccount = DeveloperAccount::factory()->create(['payout_percentage' => 80]);
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'is_active' => true,
+            'is_official' => false,
+            'user_id' => $developerAccount->user_id,
+            'developer_account_id' => $developerAccount->id,
+        ]);
+        PluginPrice::factory()->regular()->amount(10000)->create(['plugin_id' => $plugin->id]);
+
+        $cart = Cart::factory()->for($buyer)->create();
+        CartItem::create([
+            'cart_id' => $cart->id,
+            'plugin_id' => $plugin->id,
+            'plugin_price_id' => $plugin->prices->first()->id,
+            'price_at_addition' => 10000,
+        ]);
+
+        $invoice = $this->createStripeInvoice($cart->id, $buyer->stripe_id);
+        $job = new HandleInvoicePaidJob($invoice);
+        $job->handle();
+
+        $payout = PluginPayout::first();
+        $this->assertNotNull($payout);
+        $this->assertEquals(10000, $payout->gross_amount);
+        $this->assertEquals(0, $payout->platform_fee);
+        $this->assertEquals(10000, $payout->developer_amount);
+    }
+
+    #[Test]
+    public function developer_with_hundred_percent_payout_gets_full_amount(): void
+    {
+        $buyer = User::factory()->create(['stripe_id' => 'cus_test_buyer_'.uniqid()]);
+
+        $developerAccount = DeveloperAccount::factory()->create(['payout_percentage' => 100]);
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'is_active' => true,
+            'is_official' => false,
+            'user_id' => $developerAccount->user_id,
+            'developer_account_id' => $developerAccount->id,
+        ]);
+        PluginPrice::factory()->regular()->amount(5000)->create(['plugin_id' => $plugin->id]);
+
+        $cart = Cart::factory()->for($buyer)->create();
+        CartItem::create([
+            'cart_id' => $cart->id,
+            'plugin_id' => $plugin->id,
+            'plugin_price_id' => $plugin->prices->first()->id,
+            'price_at_addition' => 5000,
+        ]);
+
+        $invoice = $this->createStripeInvoice($cart->id, $buyer->stripe_id);
+        $job = new HandleInvoicePaidJob($invoice);
+        $job->handle();
+
+        $payout = PluginPayout::first();
+        $this->assertNotNull($payout);
+        $this->assertEquals(5000, $payout->gross_amount);
+        $this->assertEquals(0, $payout->platform_fee);
+        $this->assertEquals(5000, $payout->developer_amount);
+    }
+
+    private function createStripeInvoice(string $cartId, string $customerId): Invoice
+    {
+        return Invoice::constructFrom([
+            'id' => 'in_test_'.uniqid(),
+            'billing_reason' => Invoice::BILLING_REASON_MANUAL,
+            'customer' => $customerId,
+            'payment_intent' => 'pi_test_'.uniqid(),
+            'currency' => 'usd',
+            'metadata' => ['cart_id' => $cartId],
+            'lines' => [],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `payout_percentage` column (unsigned tinyInteger, default 70) to the `developer_accounts` table
- Invoice payout logic now reads the developer account's `payout_percentage` instead of the hardcoded `PLATFORM_FEE_PERCENT` constant
- Ultra subscriber purchases still override to 100% developer payout (0% platform fee) for third-party plugins
- Displays the payout percentage in the Filament admin panel on the user resource

## Test plan
- [x] Default payout percentage is 70%
- [x] `platformFeePercent()` correctly returns the inverse (100 - payout_percentage)
- [x] Custom payout percentage (e.g. 80%) results in correct platform fee on purchase
- [x] Ultra subscriber override still gives 100% to developer regardless of custom percentage
- [x] Developer with 100% payout percentage gets full amount
- [x] Existing payout tests (`MaxSubscriberPayoutTest`, `PluginPayoutTest`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)