### PR TITLE
Add image grid layout for plugin README content

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -275,7 +275,7 @@ nav.docs-navigation li:has(.third-tier .exact-active) > .subsection-header {
 }
 
 .prose p:has(img) img {
-    @apply inline-block w-full shadow-none;
+    @apply inline-block w-full rounded-none shadow-none;
 }
 
 /*

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -270,6 +270,14 @@ nav.docs-navigation li:has(.third-tier .exact-active) > .subsection-header {
     @apply rounded-none shadow-none;
 }
 
+.prose p:has(img) {
+    @apply grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3;
+}
+
+.prose p:has(img) img {
+    @apply inline-block w-full shadow-none;
+}
+
 /*
  Margin and rounding are personal preferences,
  overflow-x-auto is recommended.


### PR DESCRIPTION
## Summary
- Styles `<p>` tags containing images in plugin README prose content as a responsive grid
- 1 column on mobile, 2 on `sm`, 3 on `lg`, with `gap-4` spacing
- Removes box shadow from images within the grid for a cleaner look

## Test plan
- [ ] Visit a plugin page with multiple images in a `<p>` tag (e.g. `/plugins/srwiez/nativephp-mobile-screenshots`)
- [ ] Verify images display in a grid with up to 3 columns on large screens
- [ ] Verify responsive behaviour: 1 col on mobile, 2 on sm, 3 on lg
- [ ] Verify single-image `<p>` tags still render correctly
- [ ] Verify non-image prose content is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)