### PR TITLE
Use max-width instead of width for prose images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "rustic-finch",
+    "name": "ivory-tiger",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -275,7 +275,7 @@ nav.docs-navigation li:has(.third-tier .exact-active) > .subsection-header {
 }
 
 .prose p:has(img) img {
-    @apply inline-block w-full rounded-none shadow-none;
+    @apply inline-block max-w-full rounded-none shadow-none;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Changes `.prose p:has(img) img` from `w-full` (width: 100%) to `max-w-full` (max-width: 100%)
- Images inside prose paragraphs now retain their intrinsic size when smaller than the container, instead of always stretching to fill the full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)