### PR TITLE
docs(mobile/3): note Inertia 3 axios requirement

### DIFF
--- a/resources/views/docs/mobile/3/getting-started/development.md
+++ b/resources/views/docs/mobile/3/getting-started/development.md
@@ -66,6 +66,27 @@ npm run build -- --mode=ios
 npm run build -- --mode=android
 ```
 
+<aside>
+
+#### Using Inertia 3?
+
+NativePHP Mobile routes every outgoing HTTP request through the embedded PHP runtime
+by intercepting `axios` at bundle time. [Inertia 3 removed axios][inertia-axios] in
+favour of native `fetch`, so fresh Inertia 3 projects won't declare it — the
+NativePHP build will fail until you add axios as a direct dependency:
+
+```shell
+npm install axios
+```
+
+Then follow the [Inertia docs on using axios][inertia-axios] to tell Inertia to use
+it for its client-side requests. Apps on Inertia 2 (or using axios directly) already
+have it installed and don't need any change.
+
+[inertia-axios]: https://inertiajs.com/docs/v3/installation/client-side-setup#using-axios
+
+</aside>
+
 ## Compile your app
 
 To compile and run your app, simply run:


### PR DESCRIPTION
## Summary

Adds an aside to \`mobile/3/getting-started/development.md\` (in the existing nativephpMobile Vite plugin section) explaining that fresh Inertia 3 projects need to reinstall axios for NativePHP Mobile to work.

## Context

NativePHP Mobile intercepts \`axios\` at bundle time and swaps its transport adapter so every HTTP request routes through the embedded PHP runtime. Through Inertia 2 this was always satisfied transitively by \`@inertiajs/vue3\` / \`@inertiajs/react\`. Inertia 3 removed axios in favour of native \`fetch\`, so fresh Inertia 3 projects now build cleanly into a NativePHP app that can't talk to its own backend.

The paired package change — [NativePHP/mobile-air#100](https://github.com/NativePHP/mobile-air/pull/100) — makes the Vite plugin fail fast (checking the project's \`package.json\` for a declared axios dependency) with an error pointing users here and at the Inertia docs.

## Placement

Inline aside inside **Build your frontend → The \`nativephpMobile\` Vite plugin**, right after the \`--mode=ios\`/\`--mode=android\` build commands. That's the natural home for build-time concerns, and the surrounding section already contextualises the Vite plugin where the check fires.

## Preview

> #### Using Inertia 3?
>
> NativePHP Mobile routes every outgoing HTTP request through the embedded PHP runtime by intercepting \`axios\` at bundle time. [Inertia 3 removed axios](https://inertiajs.com/docs/v3/installation/client-side-setup#using-axios) in favour of native \`fetch\`, so fresh Inertia 3 projects won't declare it — the NativePHP build will fail until you add axios as a direct dependency:
>
> ```shell
> npm install axios
> ```
>
> Then follow the [Inertia docs on using axios](https://inertiajs.com/docs/v3/installation/client-side-setup#using-axios) to tell Inertia to use it for its client-side requests. Apps on Inertia 2 (or using axios directly) already have it installed and don't need any change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)