### PR TITLE
Fix password reset and rework checkout-driven account creation

### DIFF
--- a/app/Contracts/TransactionalNotification.php
+++ b/app/Contracts/TransactionalNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Listeners\SuppressMailNotificationListener;
+
+/**
+ * Marker interface for notifications that must always be delivered,
+ * regardless of the user's email preferences or verification state.
+ *
+ * Account recovery, purchase receipts, and license/entitlement
+ * notifications fall into this category.
+ *
+ * @see SuppressMailNotificationListener
+ */
+interface TransactionalNotification {}

--- a/app/Http/Controllers/Api/LicenseController.php
+++ b/app/Http/Controllers/Api/LicenseController.php
@@ -9,8 +9,10 @@ use App\Http\Resources\Api\LicenseResource;
 use App\Jobs\CreateAnystackLicenseJob;
 use App\Models\License;
 use App\Models\User;
+use App\Notifications\ClaimAccount;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Enum;
 
@@ -45,6 +47,12 @@ class LicenseController extends Controller
                 'password' => Hash::make(Str::random(32)), // Random password
             ]
         );
+
+        if ($user->wasRecentlyCreated) {
+            $user->notify(new ClaimAccount(
+                Password::broker()->createToken($user)
+            ));
+        }
 
         // Create the license via job
         $subscription = Subscription::from($validated['subscription']);

--- a/app/Http/Controllers/Auth/CustomerAuthController.php
+++ b/app/Http/Controllers/Auth/CustomerAuthController.php
@@ -156,9 +156,17 @@ class CustomerAuthController extends Controller
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
             function ($user, $password): void {
-                $user->forceFill([
-                    'password' => $password,
-                ]);
+                $attributes = ['password' => $password];
+
+                // Proving control of the inbox + setting a password is sufficient
+                // to consider the email verified. This also lets the same flow
+                // serve as the "claim your account" path for users created via
+                // checkout.
+                if (! $user->email_verified_at) {
+                    $attributes['email_verified_at'] = now();
+                }
+
+                $user->forceFill($attributes);
 
                 $user->save();
             }

--- a/app/Listeners/SuppressMailNotificationListener.php
+++ b/app/Listeners/SuppressMailNotificationListener.php
@@ -2,7 +2,9 @@
 
 namespace App\Listeners;
 
+use App\Contracts\TransactionalNotification;
 use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Notifications\Events\NotificationSending;
 
@@ -18,8 +20,13 @@ class SuppressMailNotificationListener
             return true;
         }
 
-        // System notifications like email verification should always be sent
-        if ($event->notification instanceof VerifyEmail) {
+        // Transactional notifications (account recovery, verification,
+        // purchase receipts, entitlement grants) must always be delivered.
+        // Framework notifications can't implement our marker, so they're
+        // listed explicitly.
+        if ($event->notification instanceof TransactionalNotification
+            || $event->notification instanceof VerifyEmail
+            || $event->notification instanceof ResetPassword) {
             return true;
         }
 

--- a/app/Livewire/ClaimDonationLicense.php
+++ b/app/Livewire/ClaimDonationLicense.php
@@ -7,6 +7,7 @@ use App\Enums\Subscription;
 use App\Jobs\CreateAnystackLicenseJob;
 use App\Models\OpenCollectiveDonation;
 use App\Models\User;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
@@ -107,6 +108,8 @@ class ClaimDonationLicense extends Component
                 'name' => $this->name,
                 'password' => Hash::make($this->password),
             ]);
+
+            event(new Registered($user));
         }
 
         // Parse name for first/last

--- a/app/Livewire/MobilePricing.php
+++ b/app/Livewire/MobilePricing.php
@@ -4,9 +4,11 @@ namespace App\Livewire;
 
 use App\Enums\Subscription;
 use App\Models\User;
+use App\Notifications\ClaimAccount;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
@@ -182,11 +184,19 @@ class MobilePricing extends Component
             'email' => 'required|email|max:255',
         ]);
 
-        return User::firstOrCreate([
+        $user = User::firstOrCreate([
             'email' => $email,
         ], [
             'password' => Hash::make(Str::random(72)),
         ]);
+
+        if ($user->wasRecentlyCreated) {
+            $user->notify(new ClaimAccount(
+                Password::broker()->createToken($user)
+            ));
+        }
+
+        return $user;
     }
 
     private function successUrl(): string

--- a/app/Livewire/OrderSuccess.php
+++ b/app/Livewire/OrderSuccess.php
@@ -3,7 +3,6 @@
 namespace App\Livewire;
 
 use App\Enums\Subscription;
-use App\Models\License;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Laravel\Cashier\Cashier;
 use Livewire\Attributes\Layout;
@@ -17,9 +16,9 @@ class OrderSuccess extends Component
 {
     public ?string $email = null;
 
-    public ?string $licenseKey = null;
-
     public ?Subscription $subscription = null;
+
+    public bool $isExistingUser = false;
 
     public string $checkoutSessionId;
 
@@ -67,9 +66,10 @@ class OrderSuccess extends Component
             return;
         }
 
-        $this->email = $subscriptionRecord->user->email;
-        $this->licenseKey = License::query()
-            ->whereBelongsTo($subscriptionItem)
-            ->first()?->key;
+        $user = $subscriptionRecord->user;
+        $this->email = $user->email;
+        // Users created via checkout start with email_verified_at = null and
+        // are sent a ClaimAccount email. Verified users already have access.
+        $this->isExistingUser = ! is_null($user->email_verified_at);
     }
 }

--- a/app/Notifications/BundleGranted.php
+++ b/app/Notifications/BundleGranted.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Contracts\TransactionalNotification;
 use App\Models\Plugin;
 use App\Models\PluginBundle;
 use Illuminate\Bus\Queueable;
@@ -10,7 +11,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 
-class BundleGranted extends Notification implements ShouldQueue
+class BundleGranted extends Notification implements ShouldQueue, TransactionalNotification
 {
     use Queueable;
 

--- a/app/Notifications/ClaimAccount.php
+++ b/app/Notifications/ClaimAccount.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Contracts\TransactionalNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ClaimAccount extends Notification implements ShouldQueue, TransactionalNotification
+{
+    use Queueable;
+
+    public function __construct(public string $token) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $url = route('password.reset', [
+            'token' => $this->token,
+            'email' => $notifiable->getEmailForPasswordReset(),
+        ]);
+
+        return (new MailMessage)
+            ->subject('Welcome to NativePHP — Claim Your Account')
+            ->greeting('Welcome to NativePHP!')
+            ->line('Thanks for your purchase. We\'ve created an account for you so you can access your licenses and downloads.')
+            ->line('To finish setting up your account, please click the button below to verify your email address and set a password.')
+            ->action('Claim Your Account', $url)
+            ->line('This link will expire in '.config('auth.passwords.users.expire').' minutes. If it expires, you can request a new one from the password reset page.')
+            ->salutation("Happy coding!\n\nThe NativePHP Team");
+    }
+}

--- a/app/Notifications/LicenseKeyGenerated.php
+++ b/app/Notifications/LicenseKeyGenerated.php
@@ -2,13 +2,14 @@
 
 namespace App\Notifications;
 
+use App\Contracts\TransactionalNotification;
 use App\Enums\Subscription;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class LicenseKeyGenerated extends Notification implements ShouldQueue
+class LicenseKeyGenerated extends Notification implements ShouldQueue, TransactionalNotification
 {
     use Queueable;
 

--- a/app/Notifications/PluginGranted.php
+++ b/app/Notifications/PluginGranted.php
@@ -2,13 +2,14 @@
 
 namespace App\Notifications;
 
+use App\Contracts\TransactionalNotification;
 use App\Models\Plugin;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class PluginGranted extends Notification implements ShouldQueue
+class PluginGranted extends Notification implements ShouldQueue, TransactionalNotification
 {
     use Queueable;
 

--- a/app/Notifications/ProductGranted.php
+++ b/app/Notifications/ProductGranted.php
@@ -2,13 +2,14 @@
 
 namespace App\Notifications;
 
+use App\Contracts\TransactionalNotification;
 use App\Models\Product;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ProductGranted extends Notification implements ShouldQueue
+class ProductGranted extends Notification implements ShouldQueue, TransactionalNotification
 {
     use Queueable;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "ivory-tiger",
+    "name": "opal-parrot",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/livewire/order-success.blade.php
+++ b/resources/views/livewire/order-success.blade.php
@@ -1,4 +1,4 @@
-<div {!! ! $licenseKey ? 'wire:poll.2s="loadData"' : '' !!}>
+<div {!! ! $subscription ? 'wire:poll.2s="loadData"' : '' !!}>
     {{-- Hero Section --}}
     <section
         class="mt-10 px-5 md:mt-14"
@@ -112,136 +112,51 @@
                             class="text-sm opacity-0"
                             style="transform: none; opacity: 0.5"
                         >
-                            You've purchased a license.
+                            Welcome to NativePHP Ultra.
                         </div>
                     </div>
                 </div>
 
                 <div class="mt-6">
-                    @if ($licenseKey)
-                        <p class="text-gray-600 dark:text-gray-400">
-                            License key
-                        </p>
-                        <div
-                            class="relative mt-2 rounded-md bg-gray-200 p-4 dark:bg-gray-800"
-                            x-data="{
-                                showMessage: false,
-                                copyToClipboard() {
-                                    navigator.clipboard
-                                        .writeText(
-                                            this.$root.querySelector('.copy-license').textContent.trim(),
-                                        )
-                                        .then(() => (this.showMessage = true))
-
-                                    setTimeout(() => (this.showMessage = false), 2000)
-                                },
-                            }"
-                        >
-                            <div
-                                class="absolute top-3 right-2 flex items-center space-x-2"
+                    @if ($subscription)
+                        @if ($isExistingUser)
+                            <p
+                                class="text-center text-gray-600 dark:text-gray-400"
                             >
-                                <div
-                                    x-show="showMessage"
-                                    x-transition
-                                    class="py-1 font-bold text-indigo-400 transition duration-300"
-                                    style="display: none"
-                                >
-                                    Copied!
-                                </div>
-                                <button
-                                    type="button"
-                                    title="Copy to clipboard"
-                                    class="bg-gray-200 p-1 transition duration-300 dark:bg-gray-800"
-                                    @click.prevent="copyToClipboard"
-                                    :class="{
-                                        'text-black/50 hover:text-black/80 dark:text-white/20 dark:hover:text-white/60': !showMessage,
-                                        'text-indigo-400 hover:text-indigo-400': showMessage,
-                                    }"
-                                >
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke-width="1.5"
-                                        stroke="currentColor"
-                                        class="block size-5"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0118 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3l1.5 1.5 3-3.75"
-                                        ></path>
-                                    </svg>
-                                </button>
-                            </div>
-                            <pre
-                                class="mt-0 overflow-clip pt-0"
-                            ><code class="copy-license">{{ $licenseKey }}</code></pre>
-                        </div>
-                        <p
-                            class="mt-2 text-sm text-gray-600 dark:text-gray-400"
-                        >
-                            Store this somewhere safe. You'll need it later.
-                        </p>
-                        @if ($email)
-                            <p class="mt-6 text-gray-600 dark:text-gray-400">
-                                Email
+                                Your subscription is now active. Head to your
+                                dashboard to manage it and access everything
+                                included with Ultra.
                             </p>
-                            <div
-                                class="relative mt-2 rounded-md bg-gray-200 p-4 dark:bg-gray-800"
-                                x-data="{
-                                    showMessage: false,
-                                    copyToClipboard() {
-                                        navigator.clipboard
-                                            .writeText(
-                                                this.$root.querySelector('.copy-email').textContent.trim(),
-                                            )
-                                            .then(() => (this.showMessage = true))
-                                        setTimeout(() => (this.showMessage = false), 2000)
-                                    },
-                                }"
+
+                            <a
+                                href="{{ route('dashboard') }}"
+                                class="mt-6 block w-full rounded-2xl bg-zinc-800 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
                             >
-                                <div
-                                    class="absolute top-3 right-2 flex items-center space-x-2"
-                                >
-                                    <div
-                                        x-show="showMessage"
-                                        x-transition
-                                        class="py-1 font-bold text-indigo-400 transition duration-300"
-                                        style="display: none"
-                                    >
-                                        Copied!
-                                    </div>
-                                    <button
-                                        type="button"
-                                        title="Copy to clipboard"
-                                        class="bg-gray-200 p-1 transition duration-300 dark:bg-gray-800"
-                                        @click.prevent="copyToClipboard"
-                                        :class="{
-                                        'text-black/50 hover:text-black/80 dark:text-white/20 dark:hover:text-white/60': !showMessage,
-                                        'text-indigo-400 hover:text-indigo-400': showMessage,
-                                    }"
-                                    >
-                                        <svg
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            fill="none"
-                                            viewBox="0 0 24 24"
-                                            stroke-width="1.5"
-                                            stroke="currentColor"
-                                            class="block size-5"
-                                        >
-                                            <path
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0118 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3l1.5 1.5 3-3.75"
-                                            ></path>
-                                        </svg>
-                                    </button>
-                                </div>
-                                <pre
-                                    class="mt-0 overflow-clip pt-0"
-                                ><code class="copy-email">{{ $email }}</code></pre>
-                            </div>
+                                Go to Dashboard
+                            </a>
+                        @else
+                            <p
+                                class="text-center text-gray-600 dark:text-gray-400"
+                            >
+                                We've sent a link to
+                                <span
+                                    class="font-medium dark:text-gray-300"
+                                >{{ $email }}</span>
+                                so you can claim your account and access your
+                                dashboard.
+                            </p>
+
+                            <p
+                                class="mt-4 text-center text-sm text-gray-600 dark:text-gray-400"
+                            >
+                                Didn't get the email? Check your spam folder, or
+                                reach out to
+                                <a
+                                    href="mailto:support@nativephp.com"
+                                    class="font-medium text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-300"
+                                >support@nativephp.com</a>
+                                and we'll sort it out.
+                            </p>
                         @endif
                     @else
                         <div
@@ -261,103 +176,17 @@
                             <span
                                 class="ml-2 text-lg text-gray-600 dark:text-gray-400"
                             >
-                                License registration in progress
+                                Finalising your subscription
                             </span>
                         </div>
                         <p
                             class="mt-6 text-center text-gray-600 dark:text-gray-400"
                         >
-                            Please
-                            <span class="font-medium dark:text-gray-300">
-                                check your email
-                            </span>
-                            shortly for a copy of your license key. This page
-                            will also update if your license key is ready.
-                        </p>
-
-                        <p
-                            class="mt-2 text-center text-gray-600 dark:text-gray-400"
-                        >
-                            Once you receive your license key, you can start
-                            building amazing mobile apps with NativePHP!
+                            This will only take a moment. The page will update
+                            automatically.
                         </p>
                     @endif
                 </div>
-
-                <a
-                    href="/docs/mobile/1/getting-started/installation"
-                    class="mt-10 block w-full rounded-2xl bg-zinc-800 py-4 text-center text-sm font-medium text-white transition duration-200 ease-in-out hover:bg-zinc-900 dark:bg-[#d68ffe] dark:text-black dark:hover:bg-[#e1acff]"
-                >
-                    <div class="flex items-center justify-center gap-2">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="size-5"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                        >
-                            <path
-                                d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"
-                            ></path>
-                            <path
-                                d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"
-                            ></path>
-                        </svg>
-                        <span>View Installation Guide</span>
-                    </div>
-                </a>
-
-                @if ($subscription === \App\Enums\Subscription::Max)
-                    <div
-                        class="mt-6 rounded-xl bg-indigo-50 p-4 dark:bg-indigo-900/20"
-                    >
-                        <div class="flex">
-                            <div class="shrink-0">
-                                <svg
-                                    class="h-5 w-5 text-indigo-400"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    aria-hidden="true"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z"
-                                        clip-rule="evenodd"
-                                    />
-                                </svg>
-                            </div>
-                            <div class="ml-3">
-                                <h3
-                                    class="text-sm font-medium text-indigo-800 dark:text-indigo-300"
-                                >
-                                    Repo Access
-                                </h3>
-                                <div
-                                    class="mt-2 text-sm text-indigo-700 dark:text-indigo-200"
-                                >
-                                    <p>
-                                        As a Max subscriber, you have access to
-                                        the NativePHP/mobile repository. To
-                                        access it, please log in to
-                                        <!-- display: inline -->
-                                        <a
-                                            href="https://auth.anystack.sh/?accountType=customer"
-                                            class="font-medium underline hover:text-indigo-600 dark:hover:text-indigo-100"
-                                            target="_blank"
-                                            >AnyStack.sh</a
-                                        >
-                                        using the same email address you used
-                                        for your purchase.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                @endif
             </div>
         </div>
 
@@ -496,38 +325,6 @@
                     </p>
                 </div>
 
-                @if ($subscription === \App\Enums\Subscription::Max)
-                    <div
-                        class="dark:bg-mirage dark:hover:bg-haiti dark:hover:ring-cloud rounded-2xl bg-gray-100 p-6 transition duration-200 hover:bg-gray-200/70 hover:ring-1 hover:ring-black/60"
-                    >
-                        <div
-                            class="mb-4 flex h-12 w-12 items-center justify-center rounded-full"
-                        >
-                            <x-icons.github class="dark:text-white" />
-                        </div>
-                        <h4 class="text-lg font-medium">Access the Repo</h4>
-                        <p class="mt-2 text-gray-600 dark:text-gray-400">
-                            <a
-                                href="https://auth.anystack.sh/register?accountType=customer"
-                                target="_blank"
-                                class="text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-300"
-                            >
-                                Create a customer account
-                            </a>
-                            on Anystack to gain access to the NativePHP for
-                            Mobile
-                            <a
-                                href="https://github.com/nativephp/mobile/issues"
-                                target="_blank"
-                                class="text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-300"
-                            >
-                                repository
-                            </a>
-                            where you can let us know if you find any bugs as
-                            you build.
-                        </p>
-                    </div>
-                @endif
             </div>
         </div>
     </section>

--- a/tests/Feature/CustomerAuthenticationTest.php
+++ b/tests/Feature/CustomerAuthenticationTest.php
@@ -4,8 +4,11 @@ namespace Tests\Feature;
 
 use App\Features\ShowAuthButtons;
 use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
 use Laravel\Pennant\Feature;
 use Tests\TestCase;
 
@@ -94,5 +97,73 @@ class CustomerAuthenticationTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertRedirect('/login');
+    }
+
+    public function test_password_reset_email_is_sent_for_unverified_users(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->unverified()->create([
+            'email' => 'unverified-customer@gmail.com',
+        ]);
+
+        $this->post('/forgot-password', ['email' => $user->email]);
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_password_reset_email_is_sent_for_opted_out_users(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'opted-out-customer@gmail.com',
+            'receives_notification_emails' => false,
+        ]);
+
+        $this->post('/forgot-password', ['email' => $user->email]);
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_password_reset_verifies_email_when_unverified(): void
+    {
+        $user = User::factory()->unverified()->create([
+            'email' => 'claimer@gmail.com',
+        ]);
+        $token = Password::broker()->createToken($user);
+
+        $response = $this->post('/reset-password', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertRedirect('/login');
+
+        $user->refresh();
+        $this->assertNotNull($user->email_verified_at);
+        $this->assertTrue(Hash::check('new-password-123', $user->password));
+    }
+
+    public function test_password_reset_preserves_existing_verification_timestamp(): void
+    {
+        $verifiedAt = now()->subMonth()->startOfDay();
+        $user = User::factory()->create([
+            'email' => 'already-verified@gmail.com',
+            'email_verified_at' => $verifiedAt,
+        ]);
+        $token = Password::broker()->createToken($user);
+
+        $this->post('/reset-password', [
+            'token' => $token,
+            'email' => $user->email,
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $user->refresh();
+        $this->assertTrue($user->email_verified_at->equalTo($verifiedAt));
     }
 }

--- a/tests/Feature/Livewire/OrderSuccessTest.php
+++ b/tests/Feature/Livewire/OrderSuccessTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Livewire;
 
 use App\Enums\Subscription;
 use App\Livewire\OrderSuccess;
-use App\Models\License;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Cashier\Cashier;
@@ -37,90 +36,88 @@ class OrderSuccessTest extends TestCase
     }
 
     #[Test]
-    public function it_displays_loading_state_when_no_license_key_is_available()
+    public function it_displays_loading_state_when_subscription_record_is_not_yet_available()
     {
         Livewire::test(OrderSuccess::class, ['checkoutSessionId' => 'cs_test_123'])
             ->assertSet('email', null)
-            ->assertSet('licenseKey', null)
-            ->assertSee('License registration in progress')
-            ->assertSee('check your email');
+            ->assertSet('subscription', null)
+            ->assertSee('Finalising your subscription')
+            ->assertSeeHtml('wire:poll.2s="loadData"');
     }
 
     #[Test]
-    public function it_displays_license_key_when_available_in_database()
+    public function it_shows_dashboard_link_for_existing_users(): void
     {
         $user = User::factory()->create([
             'email' => 'test@example.com',
             'stripe_id' => 'cus_test123',
+            'email_verified_at' => now(),
         ]);
 
-        $subscription = Cashier::$subscriptionModel::factory()
-            ->for($user, 'user')
-            ->create([
-                'stripe_id' => 'sub_test123',
-            ]);
-
-        $subscriptionItem = Cashier::$subscriptionItemModel::factory()
-            ->for($subscription, 'subscription')
-            ->create([
-                'stripe_id' => 'si_test123',
-                'stripe_price' => Subscription::Max->stripePriceId(),
-            ]);
-
-        $license = License::factory()
-            ->for($user, 'user')
-            ->for($subscriptionItem, 'subscriptionItem')
-            ->create([
-                'key' => 'db-license-key-12345',
-                'policy_name' => 'max',
-            ]);
+        $this->buildSubscriptionRecord($user);
 
         Livewire::test(OrderSuccess::class, ['checkoutSessionId' => 'cs_test_123'])
             ->assertSet('email', 'test@example.com')
-            ->assertSet('licenseKey', 'db-license-key-12345')
-            ->assertSee('db-license-key-12345')
-            ->assertSee('test@example.com')
-            ->assertDontSee('License registration in progress');
+            ->assertSet('isExistingUser', true)
+            ->assertSee('Go to Dashboard')
+            ->assertSeeHtml(route('dashboard'))
+            ->assertDontSee('claim your account')
+            ->assertDontSee('Finalising your subscription');
     }
 
     #[Test]
-    public function it_polls_for_updates_from_database()
+    public function it_shows_claim_message_for_new_users(): void
+    {
+        $user = User::factory()->unverified()->create([
+            'email' => 'test@example.com',
+            'stripe_id' => 'cus_test123',
+        ]);
+
+        $this->buildSubscriptionRecord($user);
+
+        Livewire::test(OrderSuccess::class, ['checkoutSessionId' => 'cs_test_123'])
+            ->assertSet('email', 'test@example.com')
+            ->assertSet('isExistingUser', false)
+            ->assertSee('claim your account')
+            ->assertSee('test@example.com')
+            ->assertSee('support@nativephp.com')
+            ->assertDontSee('Go to Dashboard');
+    }
+
+    #[Test]
+    public function it_polls_until_subscription_record_appears(): void
     {
         $component = Livewire::test(OrderSuccess::class, ['checkoutSessionId' => 'cs_test_123'])
-            ->assertSet('licenseKey', null)
-            ->assertSee('License registration in progress')
+            ->assertSet('subscription', null)
+            ->assertSee('Finalising your subscription')
             ->assertSeeHtml('wire:poll.2s="loadData"');
 
         $user = User::factory()->create([
             'email' => 'test@example.com',
             'stripe_id' => 'cus_test123',
+            'email_verified_at' => now(),
         ]);
 
+        $this->buildSubscriptionRecord($user);
+
+        $component->call('loadData')
+            ->assertSet('subscription', Subscription::Max)
+            ->assertSee('Go to Dashboard')
+            ->assertDontSee('Finalising your subscription');
+    }
+
+    private function buildSubscriptionRecord(User $user): void
+    {
         $subscription = Cashier::$subscriptionModel::factory()
             ->for($user, 'user')
-            ->create([
-                'stripe_id' => 'sub_test123',
-            ]);
+            ->create(['stripe_id' => 'sub_test123']);
 
-        $subscriptionItem = Cashier::$subscriptionItemModel::factory()
+        Cashier::$subscriptionItemModel::factory()
             ->for($subscription, 'subscription')
             ->create([
                 'stripe_id' => 'si_test123',
                 'stripe_price' => Subscription::Max->stripePriceId(),
             ]);
-
-        $license = License::factory()
-            ->for($user, 'user')
-            ->for($subscriptionItem, 'subscriptionItem')
-            ->create([
-                'key' => 'db-polled-license-key',
-                'policy_name' => 'max',
-            ]);
-
-        $component->call('loadData')
-            ->assertSet('licenseKey', 'db-polled-license-key')
-            ->assertSee('db-polled-license-key')
-            ->assertDontSee('License registration in progress');
     }
 
     #[Test]

--- a/tests/Feature/MobilePricingTest.php
+++ b/tests/Feature/MobilePricingTest.php
@@ -5,8 +5,10 @@ namespace Tests\Feature;
 use App\Livewire\MobilePricing;
 use App\Models\License;
 use App\Models\User;
+use App\Notifications\ClaimAccount;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Notification;
 use Laravel\Cashier\Cashier;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
@@ -75,6 +77,40 @@ class MobilePricingTest extends TestCase
         Livewire::test(MobilePricing::class)
             ->call('handlePurchaseRequest', ['email' => 'invalid-email'])
             ->assertHasErrors('email');
+    }
+
+    #[Test]
+    public function purchase_with_new_email_sends_claim_account_notification()
+    {
+        Notification::fake();
+
+        // Invalid plan short-circuits the Stripe call but the user is still
+        // created — we want to assert the claim email is dispatched in that path.
+        Livewire::test(MobilePricing::class)
+            ->call('handlePurchaseRequest', [
+                'email' => 'new-customer@example.com',
+                'plan' => 'not-a-real-plan',
+            ]);
+
+        $user = User::where('email', 'new-customer@example.com')->first();
+        $this->assertNotNull($user);
+        Notification::assertSentTo($user, ClaimAccount::class);
+    }
+
+    #[Test]
+    public function purchase_with_existing_email_does_not_send_claim_account_notification()
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'existing@example.com']);
+
+        Livewire::test(MobilePricing::class)
+            ->call('handlePurchaseRequest', [
+                'email' => 'existing@example.com',
+                'plan' => 'not-a-real-plan',
+            ]);
+
+        Notification::assertNotSentTo($user, ClaimAccount::class);
     }
 
     #[Test]

--- a/tests/Feature/SuppressMailNotificationListenerTest.php
+++ b/tests/Feature/SuppressMailNotificationListenerTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Contracts\TransactionalNotification;
 use App\Listeners\SuppressMailNotificationListener;
 use App\Models\Plugin;
 use App\Models\User;
+use App\Notifications\LicenseKeyGenerated;
 use App\Notifications\PluginApproved;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\Events\NotificationSending;
 use Tests\TestCase;
@@ -87,6 +90,74 @@ class SuppressMailNotificationListenerTest extends TestCase
         $listener = new SuppressMailNotificationListener;
 
         $this->assertFalse($listener->handle($event));
+    }
+
+    public function test_allows_password_reset_for_opted_out_users(): void
+    {
+        $user = User::factory()->create(['receives_notification_emails' => false]);
+
+        $event = new NotificationSending(
+            $user,
+            new ResetPassword('token'),
+            'mail',
+        );
+
+        $listener = new SuppressMailNotificationListener;
+
+        $this->assertTrue($listener->handle($event));
+    }
+
+    public function test_allows_password_reset_for_unverified_users(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $event = new NotificationSending(
+            $user,
+            new ResetPassword('token'),
+            'mail',
+        );
+
+        $listener = new SuppressMailNotificationListener;
+
+        $this->assertTrue($listener->handle($event));
+    }
+
+    public function test_allows_transactional_notifications_for_opted_out_users(): void
+    {
+        $user = User::factory()->create(['receives_notification_emails' => false]);
+
+        $event = new NotificationSending(
+            $user,
+            new LicenseKeyGenerated('test-key'),
+            'mail',
+        );
+
+        $listener = new SuppressMailNotificationListener;
+
+        $this->assertTrue($listener->handle($event));
+    }
+
+    public function test_allows_transactional_notifications_for_unverified_users(): void
+    {
+        $user = User::factory()->unverified()->create();
+
+        $event = new NotificationSending(
+            $user,
+            new LicenseKeyGenerated('test-key'),
+            'mail',
+        );
+
+        $listener = new SuppressMailNotificationListener;
+
+        $this->assertTrue($listener->handle($event));
+    }
+
+    public function test_license_key_generated_is_marked_transactional(): void
+    {
+        $this->assertInstanceOf(
+            TransactionalNotification::class,
+            new LicenseKeyGenerated('test-key'),
+        );
     }
 
     public function test_allows_non_mail_channels_for_unverified_users(): void


### PR DESCRIPTION
## Summary

Fixes a class of bug where users created via the Ultra checkout flow (e.g. `alex.ganderton@arrangemy.com`) end up stranded — no verification email, no license email, and password reset silently fails — because `SuppressMailNotificationListener` was dropping any mail to users who were unverified or opted-out of notification emails, with only `VerifyEmail` carved out.

## What changed

**Listener / transactional notifications**
- New `App\Contracts\TransactionalNotification` marker interface
- `SuppressMailNotificationListener` now bypasses anything implementing the marker, plus framework `VerifyEmail` and `ResetPassword`
- Tagged `LicenseKeyGenerated`, `BundleGranted`, `PluginGranted`, `ProductGranted` as transactional

**Account claim flow**
- New `ClaimAccount` notification — uses the password broker token so it routes through the existing reset-password UI; one email verifies their address and sets a password
- `CustomerAuthController::resetPassword` now sets `email_verified_at = now()` when null on a successful reset, so the same flow serves both real password resets and first-time account claims
- `MobilePricing::findOrCreateUser` and `Api\LicenseController::store` dispatch `ClaimAccount` when the user is newly created
- `ClaimDonationLicense::claim` now fires `Registered` (user already chose their own password there, so just needs verification)

**Order success page**
- Dropped license-key copy and Anystack registration callout (we no longer generate licenses)
- For Ultra: existing/verified users see a "Go to Dashboard" button; newly-created users see a "we've sent a link to {email}, contact support@nativephp.com if you haven't received it" message
- Polling key switched from `licenseKey` to `subscription`

## Test plan

- [x] `php artisan test --compact tests/Feature/SuppressMailNotificationListenerTest.php tests/Feature/CustomerAuthenticationTest.php tests/Feature/MobilePricingTest.php tests/Feature/Livewire/OrderSuccessTest.php tests/Feature/ClaimDonationLicenseTest.php` — 67 passing
- [x] `vendor/bin/pint --dirty --format agent` — clean
- [ ] Manual: verify the order success page renders the "claim your account" copy for a user with `email_verified_at = null`, and "Go to Dashboard" for a verified user
- [ ] Manual: trigger password reset for an opted-out user and confirm the email arrives in Mailgun
- [ ] Follow-up (separate PR): backfill / re-send `ClaimAccount` to the population of stranded users created via `MobilePricing` who never received any email

🤖 Generated with [Claude Code](https://claude.com/claude-code)