### PR TITLE
Replace consulting form with cal.com booking; restore /build-my-app

### DIFF
--- a/.cursor/rules/laravel-boost.mdc
+++ b/.cursor/rules/laravel-boost.mdc
@@ -11,7 +11,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.19
+- php - 8.4.20
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.19
+- php - 8.4.20
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.19
+- php - 8.4.20
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.19
+- php - 8.4.20
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.19
+- php - 8.4.20
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/app/Livewire/LeadSubmissionForm.php
+++ b/app/Livewire/LeadSubmissionForm.php
@@ -21,6 +21,8 @@ class LeadSubmissionForm extends Component
 
     public string $description = '';
 
+    public string $budget = '';
+
     public string $turnstileToken = '';
 
     #[Locked]
@@ -33,6 +35,7 @@ class LeadSubmissionForm extends Component
             'email' => ['required', 'email', 'max:255'],
             'company' => ['required', 'string', 'max:255'],
             'description' => ['required', 'string', 'max:5000'],
+            'budget' => ['required', 'string', 'in:'.implode(',', array_keys(Lead::BUDGETS))],
         ];
 
         if (config('services.turnstile.secret_key')) {
@@ -45,6 +48,7 @@ class LeadSubmissionForm extends Component
     public function messages(): array
     {
         return [
+            'budget.in' => 'Please select a budget range.',
             'turnstileToken.required' => 'Please complete the security check.',
         ];
     }
@@ -69,6 +73,7 @@ class LeadSubmissionForm extends Component
             'email' => $this->email,
             'company' => $this->company,
             'description' => $this->description,
+            'budget' => $this->budget,
             'ip_address' => request()->ip(),
         ]);
 
@@ -82,6 +87,8 @@ class LeadSubmissionForm extends Component
 
     public function render()
     {
-        return view('livewire.lead-submission-form');
+        return view('livewire.lead-submission-form', [
+            'budgets' => Lead::BUDGETS,
+        ]);
     }
 }

--- a/app/Notifications/NewLeadSubmitted.php
+++ b/app/Notifications/NewLeadSubmitted.php
@@ -24,7 +24,7 @@ class NewLeadSubmitted extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('New Consulting Enquiry: '.$this->lead->company)
+            ->subject('New App Build Enquiry: '.$this->lead->company)
             ->replyTo($this->lead->email, $this->lead->name)
             ->greeting('New lead received!')
             ->line("**Name:** {$this->lead->name}")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "opal-parrot",
+    "name": "jovial-camel",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/build-my-app.blade.php
+++ b/resources/views/build-my-app.blade.php
@@ -1,0 +1,161 @@
+<x-layout title="Build My App">
+    @push('head')
+        <style>html { scroll-behavior: smooth; }</style>
+        @if (config('services.turnstile.site_key'))
+            <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+        @endif
+    @endpush
+
+    <div class="mx-auto max-w-5xl">
+        {{-- Hero --}}
+        <section class="mt-12">
+            <div class="text-center">
+                <h1
+                    x-init="
+                        () => {
+                            motion.inView($el, (element) => {
+                                motion.animate(
+                                    $el,
+                                    {
+                                        opacity: [0, 1],
+                                        x: [-10, 0],
+                                    },
+                                    {
+                                        duration: 0.7,
+                                        ease: motion.easeOut,
+                                    },
+                                )
+                            })
+                        }
+                    "
+                    class="text-4xl md:text-5xl"
+                >
+                    <span class="text-[#99ceb2] dark:text-indigo-500">{</span>
+                    <span class="font-bold">Build My App</span>
+                    <span class="text-[#99ceb2] dark:text-indigo-500">}</span>
+                </h1>
+
+                <p
+                    x-init="
+                        () => {
+                            motion.inView($el, (element) => {
+                                motion.animate(
+                                    $el,
+                                    {
+                                        opacity: [0, 1],
+                                        x: [10, 0],
+                                    },
+                                    {
+                                        duration: 0.7,
+                                        ease: motion.easeOut,
+                                    },
+                                )
+                            })
+                        }
+                    "
+                    class="mx-auto mt-6 max-w-2xl text-lg text-gray-600 dark:text-zinc-400"
+                >
+                    Got an app idea? Let's build it together. The NativePHP core team partners with founders and businesses
+                    to design, build, and ship cross-platform apps with PHP and Laravel.
+                </p>
+            </div>
+        </section>
+
+        {{-- What We Build --}}
+        <section class="mt-20">
+            <div
+                x-init="
+                    () => {
+                        motion.inView($el, (element) => {
+                            motion.animate(
+                                Array.from($el.children),
+                                {
+                                    y: [10, 0],
+                                    opacity: [0, 1],
+                                    scale: [0.9, 1],
+                                },
+                                {
+                                    duration: 0.7,
+                                    ease: motion.backOut,
+                                    delay: motion.stagger(0.1),
+                                },
+                            )
+                        })
+                    }
+                "
+                class="grid gap-6 md:grid-cols-3"
+            >
+                <div class="rounded-2xl bg-gray-100 p-6 text-center dark:bg-[#1a1a2e]">
+                    <div class="mx-auto grid size-12 place-items-center rounded-full bg-white text-black ring-1 ring-black/5 dark:bg-gray-900 dark:text-white dark:ring-white/10">
+                        <x-icons.device-mobile-phone class="size-6" />
+                    </div>
+                    <h3 class="mt-4 text-lg font-semibold">Mobile Apps</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-zinc-400">
+                        iOS and Android apps built with NativePHP for Mobile, ready for the App Store and Play Store.
+                    </p>
+                </div>
+
+                <div class="rounded-2xl bg-gray-100 p-6 text-center dark:bg-[#1a1a2e]">
+                    <div class="mx-auto grid size-12 place-items-center rounded-full bg-white text-black ring-1 ring-black/5 dark:bg-gray-900 dark:text-white dark:ring-white/10">
+                        <x-icons.pc class="size-6" />
+                    </div>
+                    <h3 class="mt-4 text-lg font-semibold">Desktop Apps</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-zinc-400">
+                        Native desktop apps for macOS, Windows, and Linux using NativePHP for Desktop.
+                    </p>
+                </div>
+
+                <div class="rounded-2xl bg-gray-100 p-6 text-center dark:bg-[#1a1a2e]">
+                    <div class="mx-auto grid size-12 place-items-center rounded-full bg-white text-black ring-1 ring-black/5 dark:bg-gray-900 dark:text-white dark:ring-white/10">
+                        <x-heroicon-o-rocket-launch class="size-6" />
+                    </div>
+                    <h3 class="mt-4 text-lg font-semibold">End-to-End Delivery</h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-zinc-400">
+                        From idea and design through to launch, marketing, and ongoing iteration. We sweat the details.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        {{-- Form --}}
+        <section id="enquiry-form" class="mt-24 scroll-mt-24 pb-24">
+            <h2
+                x-init="
+                    () => {
+                        motion.inView($el, (element) => {
+                            motion.animate(
+                                $el,
+                                {
+                                    opacity: [0, 1],
+                                    x: [-10, 0],
+                                },
+                                {
+                                    duration: 0.7,
+                                    ease: motion.easeOut,
+                                },
+                            )
+                        })
+                    }
+                "
+                class="text-center text-3xl font-semibold"
+            >
+                Tell Us About Your App
+            </h2>
+            <p class="mx-auto mt-4 max-w-2xl text-center text-gray-600 dark:text-zinc-400">
+                Share your idea and rough budget. We'll be in touch to plan the next steps.
+            </p>
+
+            <div class="mx-auto mt-8 max-w-2xl rounded-2xl bg-gray-100 p-8 dark:bg-[#1a1a2e] md:p-12">
+                <livewire:lead-submission-form />
+            </div>
+
+            <p class="mx-auto mt-6 max-w-2xl text-center text-sm text-gray-500 dark:text-gray-400">
+                Just need a quick technical session?
+                <a href="{{ route('consulting') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">
+                    Book a consulting slot
+                </a>
+                instead.
+            </p>
+        </section>
+    </div>
+</x-layout>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -255,6 +255,17 @@
                     </li>
                     <li>
                         <a
+                            href="{{ route('build-my-app') }}"
+                            class="inline-block px-px py-1.5 transition duration-300 will-change-transform hover:translate-x-1 hover:text-gray-700 dark:hover:text-gray-300"
+                        >
+                            <span class="inline-flex items-center gap-1.5">
+                                Build
+                                <span class="rounded-full bg-emerald-500 px-1.5 py-px text-[10px] font-bold leading-tight text-white">New</span>
+                            </span>
+                        </a>
+                    </li>
+                    <li>
+                        <a
                             href="{{ route('course') }}"
                             class="inline-block px-px py-1.5 transition duration-300 will-change-transform hover:translate-x-1 hover:text-gray-700 dark:hover:text-gray-300"
                         >

--- a/resources/views/components/navbar/mobile-menu.blade.php
+++ b/resources/views/components/navbar/mobile-menu.blade.php
@@ -97,6 +97,7 @@
                     $isBlogActive = request()->routeIs('blog*');
                     $isPartnersActive = request()->routeIs('partners*');
                     $isServicesActive = request()->routeIs('consulting');
+                    $isBuildActive = request()->routeIs('build-my-app');
                     $isCourseActive = request()->routeIs('course');
                     $isSupportActive = request()->routeIs('support.*');
                     $isSponsorActive = request()->routeIs('sponsoring*');
@@ -252,6 +253,32 @@
 
                         <div class="inline-flex items-center gap-2">
                             Consulting
+                            <span class="rounded-full bg-emerald-500 px-1.5 py-px text-[10px] font-bold leading-tight text-white">New</span>
+                        </div>
+                    </a>
+                </div>
+
+                {{-- Build Link (mobile only, shown in navbar on desktop) --}}
+                <div class="lg:hidden">
+                    <a
+                        href="{{ route('build-my-app') }}"
+                        @class([
+                            'flex items-center gap-2 py-3 transition duration-200',
+                            'font-medium' => $isBuildActive,
+                            'opacity-70 hover:translate-x-1 hover:opacity-100 dark:opacity-50' => ! $isBuildActive,
+                        ])
+                        aria-current="{{ $isBuildActive ? 'page' : 'false' }}"
+                    >
+                        @if ($isBuildActive)
+                            <x-icons.right-arrow
+                                class="size-4 shrink-0"
+                                aria-hidden="true"
+                                focusable="false"
+                            />
+                        @endif
+
+                        <div class="inline-flex items-center gap-2">
+                            Build
                             <span class="rounded-full bg-emerald-500 px-1.5 py-px text-[10px] font-bold leading-tight text-white">New</span>
                         </div>
                     </a>

--- a/resources/views/components/navigation-bar.blade.php
+++ b/resources/views/components/navigation-bar.blade.php
@@ -81,7 +81,7 @@
             {{-- Ultra link (desktop only) --}}
             <a
                 href="{{ route('pricing') }}"
-                class="hidden items-center gap-1.5 rounded-full bg-violet-500/10 px-3 py-1.5 text-sm font-medium text-violet-600 transition duration-200 hover:bg-violet-500/20 lg:inline-flex dark:text-violet-400 dark:hover:bg-violet-500/20"
+                class="hidden items-center gap-1.5 rounded-full bg-orange-500/10 px-3 py-1.5 text-sm font-medium text-orange-600 transition duration-200 hover:bg-orange-500/20 lg:inline-flex dark:text-orange-400 dark:hover:bg-orange-500/20"
             >
                 Ultra
             </a>
@@ -100,6 +100,14 @@
                 class="hidden items-center gap-1.5 rounded-full bg-blue-500/10 px-3 py-1.5 text-sm font-medium text-blue-600 transition duration-200 hover:bg-blue-500/20 lg:inline-flex dark:text-blue-400 dark:hover:bg-blue-500/20"
             >
                 Consulting
+            </a>
+
+            {{-- Build link (desktop only) --}}
+            <a
+                href="{{ route('build-my-app') }}"
+                class="hidden items-center gap-1.5 rounded-full bg-violet-500/10 px-3 py-1.5 text-sm font-medium text-violet-600 transition duration-200 hover:bg-violet-500/20 lg:inline-flex dark:text-violet-400 dark:hover:bg-violet-500/20"
+            >
+                Build
             </a>
 
             {{-- Bifrost button (visible on large screens) --}}

--- a/resources/views/consulting.blade.php
+++ b/resources/views/consulting.blade.php
@@ -1,9 +1,6 @@
 <x-layout title="Consulting">
     @push('head')
         <style>html { scroll-behavior: smooth; }</style>
-        @if (config('services.turnstile.site_key'))
-            <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-        @endif
     @endpush
 
     <div class="mx-auto max-w-5xl">
@@ -307,12 +304,16 @@
                         We've worked with all kinds of organisations, from indie developers and small funded startups, to large enterprises including blue-chip and pharmaceutical companies.
                     </p>
                     <p>
-                        We bill hourly and scope every engagement to your needs. Whether you need a half-day architecture
+                        We bill hourly at <strong class="font-semibold text-gray-900 dark:text-white">$250/hour</strong> and scope every engagement to your needs. Whether you need a half-day architecture
                         review, regular guidance and advice, or daily delivery, we can tailor the arrangement to fit.
+                        <a href="{{ route('pricing') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">Ultra subscribers</a>
+                        get a discounted hourly rate, and our
+                        <a href="{{ route('partners') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">partners</a>
+                        get an even better one.
                     </p>
                     <p>
-                        Every engagement begins with a free, no-commitments discovery call so we can understand your goals, assess feasibility,
-                        and outline a clear path forward.
+                        Pick a slot that works for you &mdash; you can book a session as soon as two hours from now.
+                        We'll dive straight into your problem, no preamble required.
                     </p>
                 </div>
             </div>
@@ -343,12 +344,12 @@
             >
                 {{-- Book a Consultation --}}
                 <a
-                    href="#enquiry-form"
+                    href="#book-a-session"
                     class="group rounded-2xl bg-zinc-800 p-8 text-white transition duration-200 hover:bg-zinc-900 dark:bg-indigo-700/80 dark:hover:bg-indigo-900"
                 >
-                    <h3 class="text-xl font-semibold">Book a Consultation</h3>
+                    <h3 class="text-xl font-semibold">Book a Session</h3>
                     <p class="mt-2 text-sm text-gray-300 dark:text-indigo-200">
-                        Tell us about your project and we'll arrange a discovery call.
+                        Pick a time and jump straight into a working session with us.
                     </p>
                     <div class="mt-4 inline-flex items-center gap-2 text-sm font-medium transition duration-200 group-hover:translate-x-1">
                         Get started
@@ -388,8 +389,8 @@
             </div>
         </section>
 
-        {{-- Enquiry Form --}}
-        <section id="enquiry-form" class="mt-24 scroll-mt-24">
+        {{-- Book a Session --}}
+        <section id="book-a-session" class="mt-24 scroll-mt-24">
             <h2
                 x-init="
                     () => {
@@ -410,14 +411,38 @@
                 "
                 class="text-center text-3xl font-semibold"
             >
-                Request a Consultation
+                Book a Session
             </h2>
             <p class="mx-auto mt-4 max-w-2xl text-center text-gray-600 dark:text-zinc-400">
-                Tell us about your project and we'll be in touch to arrange a discovery call.
+                Grab a slot on our calendar &mdash; available as soon as two hours from now &mdash; and we'll get straight to work.
+                Sessions are billed at <strong class="font-semibold text-gray-900 dark:text-white">$250/hour</strong> and paid up front.
+                <a href="{{ route('pricing') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">Ultra subscribers</a>
+                get a discounted rate, and
+                <a href="{{ route('partners') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">partners</a>
+                get an even better one.
             </p>
 
-            <div class="mx-auto mt-8 max-w-2xl rounded-2xl bg-gray-100 p-8 dark:bg-[#1a1a2e] md:p-12">
-                <livewire:lead-submission-form />
+            <div class="mx-auto mt-8 flex max-w-2xl flex-col items-center gap-4 rounded-2xl bg-gray-100 p-8 text-center dark:bg-[#1a1a2e] md:p-12">
+                <a
+                    href="https://cal.com/team/nativephp/consult"
+                    target="_blank"
+                    rel="noopener"
+                    class="inline-flex items-center gap-2 rounded-xl bg-zinc-800 px-6 py-3 text-sm font-medium text-white transition duration-200 hover:bg-zinc-900 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:bg-indigo-700/80 dark:hover:bg-indigo-900"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                        <line x1="16" y1="2" x2="16" y2="6"></line>
+                        <line x1="8" y1="2" x2="8" y2="6"></line>
+                        <line x1="3" y1="10" x2="21" y2="10"></line>
+                    </svg>
+                    See available times
+                </a>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    Got a bigger project to scope?
+                    <a href="{{ route('build-my-app') }}" class="font-medium text-blue-600 hover:underline dark:text-blue-400">
+                        Tell us about your app instead
+                    </a>.
+                </p>
             </div>
         </section>
 

--- a/resources/views/livewire/customer/support/index.blade.php
+++ b/resources/views/livewire/customer/support/index.blade.php
@@ -13,6 +13,18 @@
         </flux:callout>
     @endif
 
+    <flux:callout icon="calendar-days" class="mb-6">
+        <flux:callout.heading>Need help even more quickly?</flux:callout.heading>
+        <flux:callout.text>
+            Book a session with the NativePHP core team &mdash; available as soon as two hours from now. Discounted for Ultra subscribers.
+        </flux:callout.text>
+        <x-slot name="actions">
+            <flux:button href="https://cal.com/team/nativephp/consult-ultra" target="_blank" rel="noopener" icon-trailing="arrow-up-right">
+                Book a session
+            </flux:button>
+        </x-slot>
+    </flux:callout>
+
     @if($this->supportTickets->count() > 0)
         <flux:table>
             <flux:table.columns>

--- a/resources/views/livewire/lead-submission-form.blade.php
+++ b/resources/views/livewire/lead-submission-form.blade.php
@@ -56,16 +56,33 @@
 
             <div>
                 <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Tell us about your project *
+                    Tell us about your app *
                 </label>
                 <textarea
                     wire:model="description"
                     id="description"
                     rows="5"
-                    placeholder="Tell us about your project, goals, timeline, and any specific requirements..."
+                    placeholder="Describe your app idea, the problems it solves, target platforms, and any specific requirements..."
                     class="mt-1 block w-full rounded-md border-gray-300 focus:border-gray-500 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:text-sm"
                 ></textarea>
                 @error('description') <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p> @enderror
+            </div>
+
+            <div>
+                <label for="budget" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Budget Range *
+                </label>
+                <select
+                    wire:model="budget"
+                    id="budget"
+                    class="mt-1 block w-full rounded-md border-gray-300 focus:border-gray-500 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:text-sm"
+                >
+                    <option value="">Select a budget range</option>
+                    @foreach ($budgets as $value => $label)
+                        <option value="{{ $value }}">{{ $label }}</option>
+                    @endforeach
+                </select>
+                @error('budget') <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p> @enderror
             </div>
 
             <div>
@@ -100,7 +117,7 @@
                     class="rounded-xl bg-zinc-800 px-6 py-3 text-sm font-medium text-white transition duration-200 hover:bg-zinc-900 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-700/80 dark:hover:bg-indigo-900"
                     wire:loading.attr="disabled"
                 >
-                    <span wire:loading.remove>Request Consultation</span>
+                    <span wire:loading.remove>Send Enquiry</span>
                     <span wire:loading>Submitting...</span>
                 </button>
             </div>

--- a/resources/views/livewire/mobile-pricing.blade.php
+++ b/resources/views/livewire/mobile-pricing.blade.php
@@ -273,6 +273,15 @@
                     >
                         <x-icons.checkmark class="size-5 shrink-0" />
                     </div>
+                    <div class="font-medium">Discounted consult hourly rate</div>
+                </div>
+                <div class="flex items-center gap-2">
+                    <div
+                        class="grid size-7 shrink-0 place-items-center rounded-xl bg-[#D4FD7D] dark:bg-[#d68ffe] dark:text-black"
+                        aria-hidden="true"
+                    >
+                        <x-icons.checkmark class="size-5 shrink-0" />
+                    </div>
                     <div class="font-medium">Teams &mdash; invite your whole team to share your Ultra benefits</div>
                 </div>
                 <div class="flex items-center gap-2">

--- a/resources/views/support/index.blade.php
+++ b/resources/views/support/index.blade.php
@@ -88,5 +88,27 @@
             </a>
 
         </div>
+
+        {{-- Book a Consulting Session --}}
+        <div class="mt-10 flex flex-col items-center gap-4 rounded-xl border border-gray-200 bg-gray-50 p-6 text-center sm:flex-row sm:gap-6 sm:text-left dark:border-gray-700/50 dark:bg-gray-800/30">
+            <div class="grid size-12 shrink-0 place-items-center rounded-full bg-white text-gray-700 ring-1 ring-black/5 dark:bg-gray-900 dark:text-gray-300 dark:ring-white/10">
+                <svg xmlns="http://www.w3.org/2000/svg" class="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                </svg>
+            </div>
+            <div class="flex-1">
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Need help even more quickly?</h2>
+                <p class="mt-1 text-gray-600 dark:text-gray-400">
+                    Book a working session with the NativePHP core team &mdash; available as soon as two hours from now.
+                    Discounted rate for Ultra subscribers.
+                </p>
+            </div>
+            <a href="{{ route('consulting') }}" class="inline-flex items-center rounded-md bg-gray-800 px-4 py-2 text-sm font-medium text-white shadow-sm transition duration-200 hover:bg-gray-900 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-white">
+                Book a session
+            </a>
+        </div>
     </section>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -164,7 +164,7 @@ Route::view('privacy-policy', 'privacy-policy')->name('privacy-policy');
 Route::view('terms-of-service', 'terms-of-service')->name('terms-of-service');
 Route::view('developer-terms', 'developer-terms')->name('developer-terms');
 Route::view('partners', 'partners')->name('partners');
-Route::redirect('build-my-app', '/consulting', 301);
+Route::view('build-my-app', 'build-my-app')->name('build-my-app');
 Route::view('consulting', 'consulting')->name('consulting');
 Route::view('the-vibes', 'the-vibes')->name('the-vibes');
 Route::view('the-vibes-prospectus', 'the-vibes-prospectus')->name('the-vibes-prospectus');

--- a/tests/Feature/LeadSubmissionTest.php
+++ b/tests/Feature/LeadSubmissionTest.php
@@ -26,19 +26,19 @@ class LeadSubmissionTest extends TestCase
     }
 
     #[Test]
-    public function consulting_page_is_accessible(): void
+    public function build_my_app_page_is_accessible(): void
     {
-        $this->get(route('consulting'))
+        $this->get(route('build-my-app'))
             ->assertOk()
             ->assertSeeLivewire(LeadSubmissionForm::class);
     }
 
     #[Test]
-    public function build_my_app_redirects_to_consulting(): void
+    public function consulting_page_is_accessible(): void
     {
-        $this->get('/build-my-app')
-            ->assertRedirect('/consulting')
-            ->assertStatus(301);
+        $this->get(route('consulting'))
+            ->assertOk()
+            ->assertSee('cal.com/team/nativephp/consult', false);
     }
 
     #[Test]
@@ -51,6 +51,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'john@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app for my business.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'test-token')
             ->call('submit')
             ->assertSet('submitted', true)
@@ -61,6 +62,7 @@ class LeadSubmissionTest extends TestCase
             'email' => 'john@example.com',
             'company' => 'Acme Corp',
             'description' => 'I need a mobile app for my business.',
+            'budget' => '10k_to_25k',
         ]);
 
         Notification::assertSentTo(
@@ -84,9 +86,10 @@ class LeadSubmissionTest extends TestCase
             ->set('email', '')
             ->set('company', '')
             ->set('description', '')
+            ->set('budget', '')
             ->set('turnstileToken', 'test-token')
             ->call('submit')
-            ->assertHasErrors(['name', 'email', 'company', 'description']);
+            ->assertHasErrors(['name', 'email', 'company', 'description', 'budget']);
     }
 
     #[Test]
@@ -97,9 +100,24 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'not-an-email')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'test-token')
             ->call('submit')
             ->assertHasErrors(['email']);
+    }
+
+    #[Test]
+    public function budget_must_be_a_valid_option(): void
+    {
+        Livewire::test(LeadSubmissionForm::class)
+            ->set('name', 'John Doe')
+            ->set('email', 'john@example.com')
+            ->set('company', 'Acme Corp')
+            ->set('description', 'I need a mobile app.')
+            ->set('budget', 'not-a-real-budget')
+            ->set('turnstileToken', 'test-token')
+            ->call('submit')
+            ->assertHasErrors(['budget']);
     }
 
     #[Test]
@@ -113,6 +131,7 @@ class LeadSubmissionTest extends TestCase
                 ->set('email', "john{$i}@example.com")
                 ->set('company', 'Acme Corp')
                 ->set('description', 'I need a mobile app.')
+                ->set('budget', '10k_to_25k')
                 ->set('turnstileToken', 'test-token')
                 ->call('submit')
                 ->assertSet('submitted', true);
@@ -125,6 +144,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'limited@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'test-token')
             ->call('submit')
             ->assertHasErrors(['form']);
@@ -144,6 +164,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'john@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', '')
             ->call('submit')
             ->assertSet('submitted', true);
@@ -167,6 +188,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'john@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'invalid-token')
             ->call('submit')
             ->assertHasErrors(['turnstileToken']);
@@ -192,6 +214,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'john@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'valid-token')
             ->call('submit')
             ->assertSet('submitted', true);
@@ -209,6 +232,7 @@ class LeadSubmissionTest extends TestCase
             ->set('email', 'john@example.com')
             ->set('company', 'Acme Corp')
             ->set('description', 'I need a mobile app.')
+            ->set('budget', '10k_to_25k')
             ->set('turnstileToken', 'test-token')
             ->call('submit');
 


### PR DESCRIPTION
## Summary

- The `/consulting` page no longer collects leads via a form. Instead, it drives visitors straight into a paid working session through [cal.com/team/nativephp/consult](https://cal.com/team/nativephp/consult), bookable as soon as 2 hours from now. The "discovery call" funnel has been retired.
- The page is up-front about the **$250/hour** rate, with linked notes that **Ultra subscribers** get a discounted rate (linking to `/pricing`) and **partners** get an even better one (linking to `/partners`).
- `/build-my-app` is restored as a focused landing page for prospective app projects. The lead-submission form is back here, including the **budget** field that we removed in #353.
- The `/support` page gets a "Need help even more quickly? Book a session" callout at the bottom linking to `/consulting`.
- The dashboard support tickets screen gets a Flux callout linking directly to the Ultra-rate calendar: [cal.com/team/nativephp/consult-ultra](https://cal.com/team/nativephp/consult-ultra).
- Navigation: a new **Build** pill (violet) joins Consulting and Masterclass on desktop, the mobile menu, and the footer's Explore column. Ultra has been recoloured orange to make Build's violet stand out.
- Ultra plan card gets a new feature line: "Discounted consult hourly rate".
- `NewLeadSubmitted` mail subject is now "New App Build Enquiry" since the form lives on `/build-my-app` rather than `/consulting`.

## Test plan

- [x] `php artisan test --compact tests/Feature/LeadSubmissionTest.php` — 11 tests pass (covers budget field validation, build-my-app page renders, consulting page renders cal.com link)
- [x] `php artisan test --compact tests/Feature/NavigationMobileMenuBreakpointTest.php` — passes
- [x] `vendor/bin/pint --dirty --format agent` — pass
- [x] Spot-check `/consulting`, `/build-my-app`, `/support`, dashboard support tickets, `/ultra` in the browser
- [x] Verify the cal.com links open the correct event types