### PR TITLE
Fix HTML entities showing in support form

### DIFF
--- a/resources/views/livewire/customer/support/create.blade.php
+++ b/resources/views/livewire/customer/support/create.blade.php
@@ -35,11 +35,11 @@
 
                         <flux:radio.group wire:model.live="selectedProduct" variant="cards" class="flex-col">
                             @foreach ([
-                                'mobile' => ['label' => 'Mobile', 'desc' => 'iOS & Android apps'],
-                                'desktop' => ['label' => 'Desktop', 'desc' => 'macOS, Windows & Linux apps'],
-                                'nativephp.com' => ['label' => 'nativephp.com', 'desc' => 'Website, account & billing'],
+                                'mobile' => ['label' => 'Mobile', 'desc' => 'iOS and Android apps'],
+                                'desktop' => ['label' => 'Desktop', 'desc' => 'macOS, Windows and Linux apps'],
+                                'nativephp.com' => ['label' => 'nativephp.com', 'desc' => 'Website, account and billing'],
                             ] as $value => $product)
-                                <flux:radio value="{{ $value }}" label="{{ $product['label'] }}" description="{{ $product['desc'] }}" />
+                                <flux:radio :value="$value" :label="$product['label']" :description="$product['desc']" />
                             @endforeach
                         </flux:radio.group>
                     </div>
@@ -105,7 +105,7 @@
                                         wire:model="reproductionSteps"
                                         label="Steps to reproduce"
                                         rows="4"
-                                        placeholder="1. Open the app&#10;2. Navigate to...&#10;3. Click on..."
+                                        :placeholder="implode(PHP_EOL, ['1. Open the app', '2. Navigate to...', '3. Click on...'])"
                                     />
 
                                     <flux:field>

--- a/resources/views/livewire/customer/support/show.blade.php
+++ b/resources/views/livewire/customer/support/show.blade.php
@@ -133,7 +133,7 @@
                     </div>
 
                     <div class="mt-3 flex items-center justify-end gap-3">
-                        <flux:text class="text-xs">&#8984;/Ctrl + Enter to send</flux:text>
+                        <flux:text class="text-xs">⌘/Ctrl + Enter to send</flux:text>
                         <flux:button type="submit" variant="primary" icon="arrow-uturn-left">
                             Send Reply
                         </flux:button>

--- a/tests/Feature/SupportFormPlaceholderTest.php
+++ b/tests/Feature/SupportFormPlaceholderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Customer\Support\Create;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SupportFormPlaceholderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function reproduction_steps_placeholder_does_not_render_literal_html_entities(): void
+    {
+        config(['subscriptions.plans.max.stripe_price_id' => 'price_test_max_yearly']);
+        $user = User::factory()->create();
+        License::factory()->max()->active()->create(['user_id' => $user->id]);
+        Subscription::factory()->for($user)->active()->create([
+            'stripe_price' => 'price_test_max_yearly',
+        ]);
+
+        $html = Livewire::actingAs($user)
+            ->test(Create::class)
+            ->set('selectedProduct', 'mobile')
+            ->call('nextStep')
+            ->html();
+
+        $this->assertStringNotContainsString('&#10;', $html);
+        $this->assertStringContainsString("1. Open the app\n2. Navigate to...\n3. Click on...", $html);
+    }
+}


### PR DESCRIPTION
## Summary

The customer support request form was rendering literal HTML entities in the UI:

- Product card descriptions on step 1 showed `&amp;` (e.g. "iOS &amp; Android apps") because passing an interpolated value to a Flux component attribute (`description="{{ $product['desc'] }}"`) ends up double-encoding — `{{ }}` runs `e()` once, then the component template echoes it through `{{ }}` again.
- The "Steps to reproduce" textarea placeholder used `&#10;` HTML entity references, which under some render paths come through as literal text rather than newlines.
- The reply hint on the ticket show page used `&#8984;` for the Mac Command symbol with the same risk.

## Changes

- `resources/views/livewire/customer/support/create.blade.php`
  - Replaced `&` with `and` in the product card descriptions to dodge the Flux double-escape entirely.
  - Switched `placeholder="… &#10; …"` to a `:placeholder="implode(PHP_EOL, [...])"` binding so newlines render reliably.
- `resources/views/livewire/customer/support/show.blade.php`
  - Replaced `&#8984;` with the literal `⌘` character in the reply hint.
- `tests/Feature/SupportFormPlaceholderTest.php`
  - Added a regression test asserting the placeholder no longer contains `&#10;` and renders real newlines.

## Test plan

- [x] `php artisan test --compact tests/Feature/SupportTicketTest.php tests/Feature/SupportFormPlaceholderTest.php` — all 83 tests pass
- [x] Verified visually in the browser: product card descriptions and placeholder lines render correctly with no entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)