### PR TITLE
Add status filter tabs to admin Support Tickets list

### DIFF
--- a/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/ListSupportTickets.php
@@ -3,9 +3,25 @@
 namespace App\Filament\Resources\SupportTicketResource\Pages;
 
 use App\Filament\Resources\SupportTicketResource;
+use App\SupportTicket\Status;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Schemas\Components\Tabs\Tab;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListSupportTickets extends ListRecords
 {
     protected static string $resource = SupportTicketResource::class;
+
+    public function getTabs(): array
+    {
+        return [
+            'all' => Tab::make('All'),
+            'new' => Tab::make('New')
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', Status::OPEN)),
+            'in_progress' => Tab::make('In Progress')
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', Status::IN_PROGRESS)),
+            'on_hold' => Tab::make('On Hold')
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', Status::ON_HOLD)),
+        ];
+    }
 }

--- a/tests/Feature/SupportTicketTest.php
+++ b/tests/Feature/SupportTicketTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Filament\Resources\SupportTicketResource;
+use App\Filament\Resources\SupportTicketResource\Pages\ListSupportTickets;
 use App\Filament\Resources\SupportTicketResource\Pages\ViewSupportTicket;
 use App\Filament\Resources\SupportTicketResource\Widgets\TicketRepliesWidget;
 use App\Livewire\Customer\Support\Create;
@@ -1236,6 +1237,30 @@ class SupportTicketTest extends TestCase
         Livewire::actingAs($admin)
             ->test(TicketRepliesWidget::class, ['record' => $ticket])
             ->call('togglePin', $reply->id);
+    }
+
+    #[Test]
+    public function admin_list_page_tabs_filter_tickets_by_status(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $openTicket = SupportTicket::factory()->create(['status' => Status::OPEN]);
+        $inProgressTicket = SupportTicket::factory()->create(['status' => Status::IN_PROGRESS]);
+        $onHoldTicket = SupportTicket::factory()->create(['status' => Status::ON_HOLD]);
+
+        Livewire::actingAs($admin)
+            ->test(ListSupportTickets::class)
+            ->assertCanSeeTableRecords([$openTicket, $inProgressTicket, $onHoldTicket])
+            ->set('activeTab', 'new')
+            ->assertCanSeeTableRecords([$openTicket])
+            ->assertCanNotSeeTableRecords([$inProgressTicket, $onHoldTicket])
+            ->set('activeTab', 'in_progress')
+            ->assertCanSeeTableRecords([$inProgressTicket])
+            ->assertCanNotSeeTableRecords([$openTicket, $onHoldTicket])
+            ->set('activeTab', 'on_hold')
+            ->assertCanSeeTableRecords([$onHoldTicket])
+            ->assertCanNotSeeTableRecords([$openTicket, $inProgressTicket]);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Added filter tabs (All / New / In Progress / On Hold) above the admin Support Tickets table so admins can quickly scope the list by status.
- "New" filters on `Status::OPEN`, "In Progress" on `Status::IN_PROGRESS`, "On Hold" on `Status::ON_HOLD`.

## Test plan
- [x] `php artisan test --filter=admin_list_page_tabs_filter_tickets_by_status` — new feature test verifies each tab scopes records correctly.
- [x] Manually visit the Support Tickets admin page and click each tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)