### PR TITLE
Document iOS permission strings override in mobile v3 config

### DIFF
--- a/resources/views/docs/mobile/3/getting-started/configuration.md
+++ b/resources/views/docs/mobile/3/getting-started/configuration.md
@@ -303,6 +303,35 @@ Set your Apple Developer Team ID for code signing:
 This is typically detected from your installed certificates, but you can override it here. Find your Team ID
 in your Apple Developer account under Membership details.
 
+## iOS Permission Strings
+
+Plugins declare their own iOS `Info.plist` usage descriptions through their manifests (see
+[Permissions & Dependencies](../plugins/permissions-dependencies)). When you install multiple plugins that
+claim the same key — for example, `mobile-camera` and `mobile-scanner` both setting
+`NSCameraUsageDescription` — the merged result is whichever plugin loaded last, which isn't always what you
+want to show App Store reviewers.
+
+The top-level `permissions` array in `config/nativephp.php` lets you override those merged values. Anything
+you set here is applied **after** all plugin manifests are merged, so it always wins:
+
+```php
+'permissions' => [
+    'NSCameraUsageDescription' => 'Used to take a profile photo.',
+    'NSMicrophoneUsageDescription' => 'Used to record audio with your videos.',
+    'NSPhotoLibraryUsageDescription' => 'Used to select photos for your post.',
+],
+```
+
+Use this when you want a single, explicit usage string for App Store review, or when you need to tailor a
+plugin-provided description to match how your app actually uses the permission.
+
+<aside>
+
+This block is iOS-only. Android doesn't declare permission rationale in its manifest — rationale strings
+are shown at runtime by app code, so there's no equivalent override.
+
+</aside>
+
 ## App Store Connect
 
 Configure automated iOS uploads with the App Store Connect API:


### PR DESCRIPTION
## Summary

Adds an "iOS Permission Strings" section to the mobile v3 Configuration docs, explaining the top-level `permissions` array in `config/nativephp.php` that overrides plugin-supplied `Info.plist` usage descriptions after manifest merging.

Placed between the existing "Development Team (iOS)" and "App Store Connect" sections so it sits with the other iOS-focused config.

## Test plan

- [x] Verify the new section renders correctly on the docs site
- [x] Confirm the `../plugins/permissions-dependencies` link resolves


---
_Generated by [Claude Code](https://claude.ai/code/session_01Edf3oPrqSjEN8uxw8tR9RY)_