### PR TITLE
Add Discord Early Adopter role for EAP customers

### DIFF
--- a/app/Http/Controllers/DiscordIntegrationController.php
+++ b/app/Http/Controllers/DiscordIntegrationController.php
@@ -70,23 +70,30 @@ class DiscordIntegrationController extends Controller
 
             if (! $discord->isGuildMember($discordUser['id'])) {
                 return to_route('customer.integrations')
-                    ->with('warning', 'Discord account connected! Please join the NativePHP Discord server to receive the Max role.');
+                    ->with('warning', 'Discord account connected! Please join the NativePHP Discord server to receive your roles.');
             }
 
+            $rolesAssigned = [];
+
             if ($user->hasMaxAccess()) {
-                $success = $discord->assignMaxRole($discordUser['id']);
-
-                if ($success) {
-                    $user->update([
-                        'discord_role_granted_at' => now(),
-                    ]);
-
-                    return to_route('customer.integrations')
-                        ->with('success', 'Discord account connected and Max role assigned!');
+                if ($discord->assignMaxRole($discordUser['id'])) {
+                    $user->update(['discord_role_granted_at' => now()]);
+                    $rolesAssigned[] = 'Max';
                 }
+            }
+
+            if ($user->isEapCustomer()) {
+                if ($discord->assignEarlyAdopterRole($discordUser['id'])) {
+                    $user->update(['discord_early_adopter_role_granted_at' => now()]);
+                    $rolesAssigned[] = 'Early Adopter';
+                }
+            }
+
+            if (count($rolesAssigned) > 0) {
+                $roleNames = implode(' and ', $rolesAssigned);
 
                 return to_route('customer.integrations')
-                    ->with('warning', 'Discord account connected, but we could not assign the Max role. Please try again later.');
+                    ->with('success', "Discord account connected and {$roleNames} role(s) assigned!");
             }
 
             return to_route('customer.integrations')
@@ -106,15 +113,23 @@ class DiscordIntegrationController extends Controller
     {
         $user = Auth::user();
 
-        if ($user->discord_role_granted_at && $user->discord_id) {
+        if ($user->discord_id) {
             $discord = DiscordApi::make();
-            $discord->removeMaxRole($user->discord_id);
+
+            if ($user->discord_role_granted_at) {
+                $discord->removeMaxRole($user->discord_id);
+            }
+
+            if ($user->discord_early_adopter_role_granted_at) {
+                $discord->removeEarlyAdopterRole($user->discord_id);
+            }
         }
 
         $user->update([
             'discord_id' => null,
             'discord_username' => null,
             'discord_role_granted_at' => null,
+            'discord_early_adopter_role_granted_at' => null,
         ]);
 
         return back()->with('success', 'Discord account disconnected successfully.');

--- a/app/Livewire/DiscordAccessBanner.php
+++ b/app/Livewire/DiscordAccessBanner.php
@@ -12,6 +12,8 @@ class DiscordAccessBanner extends Component
 
     public bool $hasMaxRole = false;
 
+    public bool $hasEarlyAdopterRole = false;
+
     public bool $isGuildMember = false;
 
     public function mount(bool $inline = false): void
@@ -26,6 +28,7 @@ class DiscordAccessBanner extends Component
 
         if (! $user || ! $user->discord_id) {
             $this->hasMaxRole = false;
+            $this->hasEarlyAdopterRole = false;
             $this->isGuildMember = false;
 
             return;
@@ -39,14 +42,20 @@ class DiscordAccessBanner extends Component
             return [
                 'isGuildMember' => $discord->isGuildMember($user->discord_id),
                 'hasMaxRole' => $discord->hasMaxRole($user->discord_id),
+                'hasEarlyAdopterRole' => $discord->hasEarlyAdopterRole($user->discord_id),
             ];
         });
 
         $this->isGuildMember = $status['isGuildMember'];
         $this->hasMaxRole = $status['hasMaxRole'];
+        $this->hasEarlyAdopterRole = $status['hasEarlyAdopterRole'];
 
         if ($this->hasMaxRole && ! $user->discord_role_granted_at) {
             $user->update(['discord_role_granted_at' => now()]);
+        }
+
+        if ($this->hasEarlyAdopterRole && ! $user->discord_early_adopter_role_granted_at) {
+            $user->update(['discord_early_adopter_role_granted_at' => now()]);
         }
     }
 
@@ -94,6 +103,42 @@ class DiscordAccessBanner extends Component
             session()->flash('success', 'Max role assigned successfully!');
         } else {
             session()->flash('error', 'Failed to assign Max role. Please try again later.');
+        }
+    }
+
+    public function requestEarlyAdopterRole(): void
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->discord_id) {
+            session()->flash('error', 'Please connect your Discord account first.');
+
+            return;
+        }
+
+        if (! $user->isEapCustomer()) {
+            session()->flash('error', 'The Early Adopter role is for early access program customers.');
+
+            return;
+        }
+
+        $discord = DiscordApi::make();
+
+        if (! $discord->isGuildMember($user->discord_id)) {
+            session()->flash('error', 'Please join the NativePHP Discord server first.');
+
+            return;
+        }
+
+        $success = $discord->assignEarlyAdopterRole($user->discord_id);
+
+        if ($success) {
+            $user->update(['discord_early_adopter_role_granted_at' => now()]);
+            Cache::forget("discord_role_status_{$user->id}");
+            $this->checkRoleStatus();
+            session()->flash('success', 'Early Adopter role assigned successfully!');
+        } else {
+            session()->flash('error', 'Failed to assign Early Adopter role. Please try again later.');
         }
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -570,6 +570,7 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
             'mobile_repo_access_granted_at' => 'datetime',
             'claude_plugins_repo_access_granted_at' => 'datetime',
             'discord_role_granted_at' => 'datetime',
+            'discord_early_adopter_role_granted_at' => 'datetime',
         ];
     }
 }

--- a/app/Support/DiscordApi.php
+++ b/app/Support/DiscordApi.php
@@ -12,7 +12,8 @@ class DiscordApi
     public function __construct(
         private ?string $botToken,
         private ?string $guildId,
-        private ?string $maxRoleId
+        private ?string $maxRoleId,
+        private ?string $earlyAdopterRoleId
     ) {}
 
     public static function make(): static
@@ -20,7 +21,8 @@ class DiscordApi
         return new static(
             config('services.discord.bot_token', ''),
             config('services.discord.guild_id', ''),
-            config('services.discord.max_role_id', '')
+            config('services.discord.max_role_id', ''),
+            config('services.discord.early_adopter_role_id', '')
         );
     }
 
@@ -71,17 +73,47 @@ class DiscordApi
 
     public function assignMaxRole(string $discordUserId): bool
     {
+        return $this->assignRole($discordUserId, $this->maxRoleId, 'Max');
+    }
+
+    public function removeMaxRole(string $discordUserId): bool
+    {
+        return $this->removeRole($discordUserId, $this->maxRoleId, 'Max');
+    }
+
+    public function hasMaxRole(string $discordUserId): bool
+    {
+        return $this->hasRole($discordUserId, $this->maxRoleId);
+    }
+
+    public function assignEarlyAdopterRole(string $discordUserId): bool
+    {
+        return $this->assignRole($discordUserId, $this->earlyAdopterRoleId, 'Early Adopter');
+    }
+
+    public function removeEarlyAdopterRole(string $discordUserId): bool
+    {
+        return $this->removeRole($discordUserId, $this->earlyAdopterRoleId, 'Early Adopter');
+    }
+
+    public function hasEarlyAdopterRole(string $discordUserId): bool
+    {
+        return $this->hasRole($discordUserId, $this->earlyAdopterRoleId);
+    }
+
+    private function assignRole(string $discordUserId, ?string $roleId, string $roleName): bool
+    {
         $response = Http::withToken($this->botToken, 'Bot')
             ->put(sprintf(
                 '%s/guilds/%s/members/%s/roles/%s',
                 self::BASE_URL,
                 $this->guildId,
                 $discordUserId,
-                $this->maxRoleId
+                $roleId
             ));
 
         if ($response->failed()) {
-            Log::error('Failed to assign Discord Max role', [
+            Log::error("Failed to assign Discord {$roleName} role", [
                 'discord_user_id' => $discordUserId,
                 'status' => $response->status(),
                 'response' => $response->json(),
@@ -93,7 +125,7 @@ class DiscordApi
         return true;
     }
 
-    public function removeMaxRole(string $discordUserId): bool
+    private function removeRole(string $discordUserId, ?string $roleId, string $roleName): bool
     {
         $response = Http::withToken($this->botToken, 'Bot')
             ->delete(sprintf(
@@ -101,11 +133,11 @@ class DiscordApi
                 self::BASE_URL,
                 $this->guildId,
                 $discordUserId,
-                $this->maxRoleId
+                $roleId
             ));
 
         if ($response->failed()) {
-            Log::error('Failed to remove Discord Max role', [
+            Log::error("Failed to remove Discord {$roleName} role", [
                 'discord_user_id' => $discordUserId,
                 'status' => $response->status(),
                 'response' => $response->json(),
@@ -117,7 +149,7 @@ class DiscordApi
         return true;
     }
 
-    public function hasMaxRole(string $discordUserId): bool
+    private function hasRole(string $discordUserId, ?string $roleId): bool
     {
         $response = Http::withToken($this->botToken, 'Bot')
             ->get(sprintf(
@@ -140,6 +172,6 @@ class DiscordApi
         $member = $response->json();
         $roles = $member['roles'] ?? [];
 
-        return in_array($this->maxRoleId, $roles, true);
+        return in_array($roleId, $roles, true);
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -57,6 +57,7 @@ return [
         'bot_token' => env('DISCORD_BOT_TOKEN'),
         'guild_id' => env('DISCORD_GUILD_ID'),
         'max_role_id' => env('DISCORD_MAX_ROLE_ID'),
+        'early_adopter_role_id' => env('DISCORD_EARLY_ADOPTER_ROLE_ID'),
     ],
 
     'turnstile' => [

--- a/database/migrations/2026_04_17_154933_add_discord_early_adopter_role_granted_at_to_users_table.php
+++ b/database/migrations/2026_04_17_154933_add_discord_early_adopter_role_granted_at_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('discord_early_adopter_role_granted_at')->nullable()->after('discord_role_granted_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('discord_early_adopter_role_granted_at');
+        });
+    }
+};

--- a/resources/views/livewire/customer/integrations.blade.php
+++ b/resources/views/livewire/customer/integrations.blade.php
@@ -29,7 +29,7 @@
         <div class="mt-4 prose dark:prose-invert prose-sm max-w-none">
             <ul class="list-disc list-inside space-y-2">
                 <li><strong>GitHub:</strong> Max license holders can access the private <code>nativephp/mobile</code> repository. Plugin Dev Kit license holders and Ultra subscribers can access <code>nativephp/claude-code</code>.</li>
-                <li><strong>Discord:</strong> Max license holders receive a special "Max" role in the NativePHP Discord server.</li>
+                <li><strong>Discord:</strong> Max license holders receive a special "Max" role in the NativePHP Discord server. Early Access Program customers receive the "Early Adopter" role.</li>
             </ul>
             <p class="mt-4">
                 Need help? Join our <a href="https://discord.gg/nativephp" target="_blank" class="text-blue-600 hover:underline dark:text-blue-400">Discord community</a>.
@@ -47,7 +47,7 @@
             <livewire:git-hub-access-banner :inline="true" />
         @endif
 
-        @if(auth()->user()->hasMaxAccess())
+        @if(auth()->user()->isEapCustomer())
             <livewire:discord-access-banner :inline="true" />
         @endif
     </div>

--- a/resources/views/livewire/discord-access-banner.blade.php
+++ b/resources/views/livewire/discord-access-banner.blade.php
@@ -10,7 +10,7 @@
                     </div>
                     <div class="ml-4">
                         <h3 class="font-medium text-gray-900 dark:text-white">
-                            Discord Max Role
+                            Discord Roles
                         </h3>
                         <div class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                             @if(auth()->user()->discord_username)
@@ -22,32 +22,38 @@
                                             Not in Server
                                         </span>
                                     </p>
-                                @elseif($hasMaxRole)
-                                    <p class="mt-1">
-                                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                                            Max Role Active
-                                        </span>
-                                    </p>
-                                @elseif(auth()->user()->hasMaxAccess())
-                                    <p class="mt-1">
-                                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                                            Eligible
-                                        </span>
-                                    </p>
+                                @else
+                                    <div class="mt-1 flex flex-wrap gap-1">
+                                        @if($hasMaxRole)
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                                Max Role Active
+                                            </span>
+                                        @elseif(auth()->user()->hasMaxAccess())
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                                Max Eligible
+                                            </span>
+                                        @endif
+
+                                        @if($hasEarlyAdopterRole)
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                                Early Adopter Active
+                                            </span>
+                                        @elseif(auth()->user()->isEapCustomer())
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                                Early Adopter Eligible
+                                            </span>
+                                        @endif
+                                    </div>
                                 @endif
                             @else
-                                <p>Connect your Discord account to receive the Max role.</p>
+                                <p>Connect your Discord account to receive your roles.</p>
                             @endif
                         </div>
                     </div>
                 </div>
                 <div class="flex flex-wrap gap-2 lg:flex-shrink-0">
                     @if(auth()->user()->discord_username)
-                        @if($hasMaxRole)
-                            <a href="https://discord.gg/nativephp" target="_blank" rel="noopener noreferrer" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                Open Discord
-                            </a>
-                        @elseif(!$isGuildMember)
+                        @if(!$isGuildMember)
                             <a href="https://discord.gg/nativephp" target="_blank" rel="noopener noreferrer" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                 Join Discord Server
                             </a>
@@ -55,11 +61,24 @@
                                 <span wire:loading.remove wire:target="refreshStatus">Check Status</span>
                                 <span wire:loading wire:target="refreshStatus">Checking...</span>
                             </button>
-                        @elseif(auth()->user()->hasMaxAccess())
-                            <button wire:click="requestMaxRole" type="button" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                <span wire:loading.remove wire:target="requestMaxRole">Request Max Role</span>
-                                <span wire:loading wire:target="requestMaxRole">Requesting...</span>
-                            </button>
+                        @else
+                            @if(!$hasMaxRole && auth()->user()->hasMaxAccess())
+                                <button wire:click="requestMaxRole" type="button" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    <span wire:loading.remove wire:target="requestMaxRole">Request Max Role</span>
+                                    <span wire:loading wire:target="requestMaxRole">Requesting...</span>
+                                </button>
+                            @endif
+                            @if(!$hasEarlyAdopterRole && auth()->user()->isEapCustomer())
+                                <button wire:click="requestEarlyAdopterRole" type="button" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    <span wire:loading.remove wire:target="requestEarlyAdopterRole">Request Early Adopter Role</span>
+                                    <span wire:loading wire:target="requestEarlyAdopterRole">Requesting...</span>
+                                </button>
+                            @endif
+                            @if(($hasMaxRole || !auth()->user()->hasMaxAccess()) && ($hasEarlyAdopterRole || !auth()->user()->isEapCustomer()))
+                                <a href="https://discord.gg/nativephp" target="_blank" rel="noopener noreferrer" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    Open Discord
+                                </a>
+                            @endif
                         @endif
                         <form action="{{ route('discord.disconnect') }}" method="POST">
                             @csrf

--- a/tests/Feature/DiscordIntegrationTest.php
+++ b/tests/Feature/DiscordIntegrationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DiscordIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'services.discord.client_id' => 'test-client-id',
+            'services.discord.client_secret' => 'test-client-secret',
+            'services.discord.bot_token' => 'test-bot-token',
+            'services.discord.guild_id' => 'test-guild-id',
+            'services.discord.max_role_id' => 'max-role-id',
+            'services.discord.early_adopter_role_id' => 'early-adopter-role-id',
+        ]);
+    }
+
+    #[Test]
+    public function callback_assigns_early_adopter_role_for_eap_customer(): void
+    {
+        $user = User::factory()->create();
+
+        License::factory()
+            ->for($user)
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        Http::fake([
+            'discord.com/api/oauth2/token' => Http::response([
+                'access_token' => 'test-access-token',
+            ]),
+            'discord.com/api/v10/users/@me' => Http::response([
+                'id' => '999888777',
+                'username' => 'eapuser',
+            ]),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777' => Http::response([
+                'roles' => [],
+            ], 200),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/early-adopter-role-id' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/auth/discord/callback?code=test-code');
+
+        $response->assertRedirect(route('customer.integrations'));
+        $response->assertSessionHas('success');
+
+        $user->refresh();
+        $this->assertEquals('999888777', $user->discord_id);
+        $this->assertEquals('eapuser', $user->discord_username);
+        $this->assertNotNull($user->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function callback_assigns_both_roles_for_eap_customer_with_max_access(): void
+    {
+        $user = User::factory()->create();
+
+        License::factory()
+            ->for($user)
+            ->max()
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        Http::fake([
+            'discord.com/api/oauth2/token' => Http::response([
+                'access_token' => 'test-access-token',
+            ]),
+            'discord.com/api/v10/users/@me' => Http::response([
+                'id' => '999888777',
+                'username' => 'maxeapuser',
+            ]),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777' => Http::response([
+                'roles' => [],
+            ], 200),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/*' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/auth/discord/callback?code=test-code');
+
+        $response->assertRedirect(route('customer.integrations'));
+        $response->assertSessionHas('success');
+
+        $user->refresh();
+        $this->assertNotNull($user->discord_role_granted_at);
+        $this->assertNotNull($user->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function callback_does_not_assign_early_adopter_role_for_non_eap_customer(): void
+    {
+        $user = User::factory()->create();
+
+        License::factory()
+            ->for($user)
+            ->afterEap()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        Http::fake([
+            'discord.com/api/oauth2/token' => Http::response([
+                'access_token' => 'test-access-token',
+            ]),
+            'discord.com/api/v10/users/@me' => Http::response([
+                'id' => '999888777',
+                'username' => 'newuser',
+            ]),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777' => Http::response([
+                'roles' => [],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/auth/discord/callback?code=test-code');
+
+        $response->assertRedirect(route('customer.integrations'));
+
+        $user->refresh();
+        $this->assertNull($user->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function disconnect_removes_early_adopter_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '999888777',
+            'discord_username' => 'testuser',
+            'discord_role_granted_at' => now(),
+            'discord_early_adopter_role_granted_at' => now(),
+        ]);
+
+        Http::fake([
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/*' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->delete('/dashboard/discord/disconnect');
+
+        $response->assertSessionHas('success', 'Discord account disconnected successfully.');
+
+        $user->refresh();
+        $this->assertNull($user->discord_id);
+        $this->assertNull($user->discord_username);
+        $this->assertNull($user->discord_role_granted_at);
+        $this->assertNull($user->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function disconnect_only_removes_early_adopter_role_when_max_role_was_not_granted(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '999888777',
+            'discord_username' => 'testuser',
+            'discord_role_granted_at' => null,
+            'discord_early_adopter_role_granted_at' => now(),
+        ]);
+
+        Http::fake([
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/early-adopter-role-id' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->delete('/dashboard/discord/disconnect');
+
+        $response->assertSessionHas('success', 'Discord account disconnected successfully.');
+
+        $user->refresh();
+        $this->assertNull($user->discord_id);
+        $this->assertNull($user->discord_early_adopter_role_granted_at);
+
+        Http::assertSentCount(1);
+    }
+}

--- a/tests/Feature/Livewire/DiscordAccessBannerTest.php
+++ b/tests/Feature/Livewire/DiscordAccessBannerTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\DiscordAccessBanner;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DiscordAccessBannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'services.discord.bot_token' => 'test-bot-token',
+            'services.discord.guild_id' => 'test-guild-id',
+            'services.discord.max_role_id' => 'max-role-id',
+            'services.discord.early_adopter_role_id' => 'early-adopter-role-id',
+        ]);
+    }
+
+    #[Test]
+    public function it_shows_not_connected_state_when_discord_is_not_linked(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Connect your Discord account to receive your roles.');
+    }
+
+    #[Test]
+    public function it_shows_connected_username_when_discord_is_linked(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('testuser');
+    }
+
+    #[Test]
+    public function it_shows_not_in_server_when_user_is_not_a_guild_member(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: false);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Not in Server');
+    }
+
+    #[Test]
+    public function it_shows_max_role_active_when_user_has_max_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true, roles: ['max-role-id']);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Max Role Active');
+    }
+
+    #[Test]
+    public function it_shows_early_adopter_active_when_user_has_early_adopter_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true, roles: ['early-adopter-role-id']);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Early Adopter Active');
+    }
+
+    #[Test]
+    public function it_shows_early_adopter_eligible_for_eap_customer_without_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        License::factory()
+            ->for($user)
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Early Adopter Eligible');
+    }
+
+    #[Test]
+    public function it_shows_request_early_adopter_role_button_for_eligible_user(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        License::factory()
+            ->for($user)
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Request Early Adopter Role');
+    }
+
+    #[Test]
+    public function it_assigns_early_adopter_role_on_request(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        License::factory()
+            ->for($user)
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestEarlyAdopterRole')
+            ->assertHasNoErrors();
+
+        $this->assertNotNull($user->fresh()->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function it_does_not_assign_early_adopter_role_for_non_eap_customer(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        // License created after EAP cutoff
+        License::factory()
+            ->for($user)
+            ->afterEap()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestEarlyAdopterRole');
+
+        $this->assertNull($user->fresh()->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function it_does_not_assign_early_adopter_role_when_not_guild_member(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        License::factory()
+            ->for($user)
+            ->eapEligible()
+            ->active()
+            ->withoutSubscriptionItem()
+            ->create();
+
+        $this->fakeDiscordApi(isGuildMember: false);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestEarlyAdopterRole');
+
+        $this->assertNull($user->fresh()->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function it_shows_both_roles_active_when_user_has_both(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true, roles: ['max-role-id', 'early-adopter-role-id']);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Max Role Active')
+            ->assertSee('Early Adopter Active');
+    }
+
+    /**
+     * @param  array<string>  $roles
+     */
+    private function fakeDiscordApi(bool $isGuildMember, array $roles = []): void
+    {
+        Cache::flush();
+
+        $memberResponse = $isGuildMember
+            ? Http::response(['roles' => $roles], 200)
+            : Http::response([], 404);
+
+        Http::fake([
+            'discord.com/api/v10/guilds/test-guild-id/members/*/roles/*' => Http::response([], 204),
+            'discord.com/api/v10/guilds/test-guild-id/members/*' => $memberResponse,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the existing Max Discord role flow for Early Access Program (EAP) customers. Users who purchased licenses before June 1, 2025 (`isEapCustomer()`) can now receive the **Early Adopter** Discord role (role ID `1326505265079521353`) automatically when connecting their Discord account, or via a dedicated request button on the access banner.

## Changes

- **`config/services.php`**: New `early_adopter_role_id` config key backed by `DISCORD_EARLY_ADOPTER_ROLE_ID` env var.
- **`app/Support/DiscordApi.php`**: Refactored role API calls into shared `assignRole` / `removeRole` / `hasRole` helpers and added `assignEarlyAdopterRole()`, `removeEarlyAdopterRole()`, and `hasEarlyAdopterRole()`.
- **Migration**: Adds `discord_early_adopter_role_granted_at` timestamp to `users` table.
- **`User` model**: Casts the new timestamp.
- **`DiscordAccessBanner` Livewire component**: Tracks `hasEarlyAdopterRole` status and adds a `requestEarlyAdopterRole()` action gated on `isEapCustomer()` and guild membership.
- **Blade banner**: Displays Max and Early Adopter role badges side by side (Active / Eligible) and renders a request button for each eligible role independently.
- **`DiscordIntegrationController`**: On OAuth callback, assigns both Max and Early Adopter roles when applicable. On disconnect, removes both roles.

## Configuration

Add to `.env`:
```
DISCORD_EARLY_ADOPTER_ROLE_ID=1326505265079521353
```

## Test plan

- [x] Unit/feature tests pass (16 new tests, 1074 tests total green)
- [ ] Connect Discord as an EAP-only customer → Early Adopter role is granted, badge shows Active
- [ ] Connect Discord as Max + EAP customer → both roles are granted
- [ ] Connect Discord as non-EAP customer → no Early Adopter role granted
- [ ] EAP customer who joins the server after connecting clicks "Request Early Adopter Role" → role granted
- [ ] Disconnect Discord while holding the Early Adopter role → role removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)