### PR TITLE
Clarify subscription renewals are non-refundable

### DIFF
--- a/.cursor/rules/laravel-boost.mdc
+++ b/.cursor/rules/laravel-boost.mdc
@@ -11,7 +11,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.20
+- php - 8.4.21
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.20
+- php - 8.4.21
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.20
+- php - 8.4.21
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.20
+- php - 8.4.21
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.20
+- php - 8.4.21
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "noble-lynx",
+    "name": "frosty-otter",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/terms-of-service.blade.php
+++ b/resources/views/terms-of-service.blade.php
@@ -47,10 +47,10 @@
                     aria-hidden="true"
                 />
                 <time
-                    datetime="2026-03-20"
+                    datetime="2026-05-18"
                     class="text-sm"
                 >
-                    March 20, 2026
+                    May 18, 2026
                 </time>
             </div>
         </header>
@@ -185,6 +185,14 @@
                 Due to the nature of the Service, no returns are accepted for
                 platform subscriptions. Refunds are offered on a case-by-case
                 basis at our sole discretion.
+            </p>
+            <p>
+                Subscription renewals are non-refundable. It is Your
+                responsibility to cancel Your subscription before the start of
+                the next billing cycle if You do not wish to renew. Once a
+                renewal has been processed, You will not be entitled to a
+                refund for that billing period, in whole or in part, regardless
+                of usage.
             </p>
 
             <h3>Plugin Purchases</h3>


### PR DESCRIPTION
## Summary
- Add an explicit clause to the Platform Subscription section of the Terms of Service stating that subscription renewals are non-refundable and that cancellation responsibility lies with the user before the next billing cycle.
- Bump the "Last updated" date on the Terms of Service page to May 18, 2026 to reflect the change.

## Why
Existing terms only stated that refunds for platform subscriptions are at our discretion. This adds clearer, explicit language around renewals so users understand they will not be refunded for an auto-renewed billing period once it has processed.

## Test plan
- [x] Visually verify the Terms of Service page renders the new paragraph under "Platform Subscription".
- [x] Confirm the "Last updated" date displays as May 18, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)