### PR TITLE
Allow hyphens in GitHub username mentions in release notes

### DIFF
--- a/app/Support/GitHub/Release.php
+++ b/app/Support/GitHub/Release.php
@@ -67,7 +67,7 @@ class Release
         // Change any @ tags to markdown links to GitHub
         if ($this->withUserLinks) {
             $body = preg_replace(
-                '/@([a-zA-Z0-9_]+)/',
+                '/@([a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)/',
                 '[@$1](https://github.com/$1)',
                 $body
             );

--- a/tests/Feature/Support/GitHub/ReleaseTest.php
+++ b/tests/Feature/Support/GitHub/ReleaseTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Support\GitHub;
+
+use App\Support\GitHub\Release;
+use Tests\TestCase;
+
+class ReleaseTest extends TestCase
+{
+    public function test_it_converts_at_mentions_to_github_user_links(): void
+    {
+        $release = new Release([
+            'body' => 'Thanks to @simonhamp for the contribution.',
+        ]);
+
+        $this->assertStringContainsString(
+            '[@simonhamp](https://github.com/simonhamp)',
+            $release->getBodyForMarkdown(),
+        );
+    }
+
+    public function test_it_converts_at_mentions_containing_hyphens_to_github_user_links(): void
+    {
+        $release = new Release([
+            'body' => 'Shout out to @some-user and @a-b-c for shipping this.',
+        ]);
+
+        $output = $release->getBodyForMarkdown();
+
+        $this->assertStringContainsString('[@some-user](https://github.com/some-user)', $output);
+        $this->assertStringContainsString('[@a-b-c](https://github.com/a-b-c)', $output);
+    }
+
+    public function test_it_does_not_match_trailing_hyphens_in_at_mentions(): void
+    {
+        $release = new Release([
+            'body' => 'Mentioning @foo- bar',
+        ]);
+
+        $this->assertStringContainsString('[@foo](https://github.com/foo)- bar', $release->getBodyForMarkdown());
+    }
+}


### PR DESCRIPTION
## Summary
- The regex in `Release::getBodyForMarkdown()` used `[a-zA-Z0-9_]+` to match GitHub usernames in release notes bodies, which doesn't account for the hyphens GitHub usernames are allowed to contain (e.g. `@some-user`).
- Updated the pattern to `[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?` so hyphenated handles are linked correctly, while still refusing to capture leading/trailing hyphens (which GitHub usernames cannot have).
- Added a `ReleaseTest` covering plain, hyphenated, and trailing-hyphen cases.

## Test plan
- [x] `php artisan test --compact tests/Feature/Support/GitHub/ReleaseTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)