### PR TITLE
Fix LogicException on grant-to-user Select validation (#54)

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -385,6 +385,7 @@ class PluginResource extends Resource
                                         ->mapWithKeys(fn (User $user) => [$user->id => "{$user->name} ({$user->email})"])
                                         ->toArray();
                                 })
+                                ->getOptionLabelUsing(fn ($value): ?string => ($user = User::find($value)) ? "{$user->name} ({$user->email})" : null)
                                 ->required(),
                         ])
                         ->action(function (Plugin $record, array $data): void {

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -139,6 +139,7 @@ class EditPlugin extends EditRecord
                                     ->mapWithKeys(fn (User $user) => [$user->id => "{$user->name} ({$user->email})"])
                                     ->toArray();
                             })
+                            ->getOptionLabelUsing(fn ($value): ?string => ($user = User::find($value)) ? "{$user->name} ({$user->email})" : null)
                             ->required(),
                     ])
                     ->action(function (array $data): void {

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -178,6 +178,7 @@ class ProductResource extends Resource
                                         ->mapWithKeys(fn (User $user) => [$user->id => "{$user->name} ({$user->email})"])
                                         ->toArray();
                                 })
+                                ->getOptionLabelUsing(fn ($value): ?string => ($user = User::find($value)) ? "{$user->name} ({$user->email})" : null)
                                 ->required(),
                         ])
                         ->action(function (Product $record, array $data): void {

--- a/tests/Feature/Filament/GrantPluginToUserActionTest.php
+++ b/tests/Feature/Filament/GrantPluginToUserActionTest.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\PluginResource\Pages\EditPlugin;
 use App\Filament\Resources\PluginResource\Pages\ListPlugins;
 use App\Models\Plugin;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -58,5 +59,40 @@ class GrantPluginToUserActionTest extends TestCase
         Livewire::actingAs($this->admin)
             ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
             ->assertActionVisible('grantToUser');
+    }
+
+    public function test_grant_to_user_action_can_be_called_with_user_id_on_list(): void
+    {
+        $plugin = Plugin::factory()->paid()->approved()->create();
+        $recipient = User::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->callAction(
+                TestAction::make('grantToUser')->table($plugin),
+                data: ['user_id' => $recipient->id],
+            )
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('plugin_licenses', [
+            'user_id' => $recipient->id,
+            'plugin_id' => $plugin->id,
+        ]);
+    }
+
+    public function test_grant_to_user_action_can_be_called_with_user_id_on_edit(): void
+    {
+        $plugin = Plugin::factory()->paid()->approved()->create();
+        $recipient = User::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->callAction('grantToUser', data: ['user_id' => $recipient->id])
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('plugin_licenses', [
+            'user_id' => $recipient->id,
+            'plugin_id' => $plugin->id,
+        ]);
     }
 }

--- a/tests/Feature/Filament/GrantProductToUserActionTest.php
+++ b/tests/Feature/Filament/GrantProductToUserActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\ProductResource\Pages\ListProducts;
+use App\Models\Product;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class GrantProductToUserActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_grant_to_user_action_can_be_called_with_user_id(): void
+    {
+        $product = Product::factory()->active()->create();
+        $recipient = User::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListProducts::class)
+            ->callAction(
+                TestAction::make('grantToUser')->table($product),
+                data: ['user_id' => $recipient->id],
+            )
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('product_licenses', [
+            'user_id' => $recipient->id,
+            'product_id' => $product->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #54 — `LogicException: Filament failed to validate the [mountedActions.0.data.user_id] field's selected options because it did not have an [options()] or [getOptionLabelUsing()] configuration.`

The **"Grant to User"** Filament actions use a searchable `Select::make('user_id')` field that defined `->getSearchResultsUsing()` but **not** `->getOptionLabelUsing()`. On form submission Filament builds an `in` validation rule for the select and needs the valid option keys. A purely search-driven select has no static option set, so Filament falls back to `getOptionLabelUsing()` to validate the chosen value — and without it, `Select::getInValidationRuleValues()` throws the `LogicException`.

The correct pattern already existed on `PluginBundleResource`; three sibling grant actions were missing it.

## Changes

- Added `->getOptionLabelUsing(...)` to the `user_id` select in:
  - `app/Filament/Resources/PluginResource.php` (the action in the reported stack trace)
  - `app/Filament/Resources/PluginResource/Pages/EditPlugin.php`
  - `app/Filament/Resources/ProductResource.php`
- Added tests that actually invoke the action with `user_id` data (the existing tests only checked visibility, never the validation path):
  - New submission tests in `GrantPluginToUserActionTest`
  - New `GrantProductToUserActionTest`

`LicensesRelationManager` selects use `->relationship()`, which supplies options automatically, so they were unaffected.

## Test plan

- [x] `php artisan test --compact tests/Feature/Filament/GrantPluginToUserActionTest.php tests/Feature/Filament/GrantProductToUserActionTest.php tests/Feature/Filament/GrantBundleToUserActionTest.php` — 9 passed
- [x] Verified the new tests fail with the original `LogicException` when the fix is reverted
- [x] `vendor/bin/pint --dirty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)