### PR TITLE
Fix date-dependent course tests and remove early bird course copy

### DIFF
--- a/database/migrations/2026_03_07_143318_seed_masterclass_product.php
+++ b/database/migrations/2026_03_07_143318_seed_masterclass_product.php
@@ -16,7 +16,7 @@ return new class extends Migration
             'slug' => 'nativephp-masterclass',
             'description' => 'Go from zero to published app. Learn to build native mobile and desktop applications using the PHP and Laravel skills you already have.',
             'is_active' => true,
-            'published_at' => now(),
+            'published_at' => '2026-03-07 00:00:00',
         ]);
 
         ProductPrice::create([

--- a/resources/views/course.blade.php
+++ b/resources/views/course.blade.php
@@ -646,10 +646,6 @@
                     The NativePHP Masterclass is coming <strong class="text-gray-900 dark:text-white">Summer/Fall 2026</strong>.
                     We're putting the finishing touches on the content to make sure it's the best learning experience possible.
                 </p>
-                <p class="mt-4 text-gray-600 dark:text-gray-400">
-                    Grab the early bird price now and you'll be first in line when the doors open.
-                    Sign up below to stay in the loop.
-                </p>
             </div>
         </section>
 

--- a/tests/Feature/CourseContentTest.php
+++ b/tests/Feature/CourseContentTest.php
@@ -65,6 +65,8 @@ class CourseContentTest extends TestCase
     #[Test]
     public function course_dashboard_shows_purchase_page_for_non_owners(): void
     {
+        Carbon::setTestNow('2026-06-14 23:59:59');
+
         $user = User::factory()->create();
 
         Livewire::actingAs($user)
@@ -72,6 +74,8 @@ class CourseContentTest extends TestCase
             ->assertSee('Build native apps')
             ->assertSee('Get Early Bird Access')
             ->assertSee('$199');
+
+        Carbon::setTestNow();
     }
 
     #[Test]

--- a/tests/Feature/CoursePageTest.php
+++ b/tests/Feature/CoursePageTest.php
@@ -71,6 +71,7 @@ class CoursePageTest extends TestCase
     #[Test]
     public function course_checkout_redirects_to_stripe_with_cart_success_url(): void
     {
+        Carbon::setTestNow('2026-06-14 23:59:59');
         config(['services.stripe.course_price_id_199' => 'price_test123']);
 
         $user = User::factory()->create(['stripe_id' => 'cus_test123']);
@@ -125,6 +126,8 @@ class CoursePageTest extends TestCase
         $this->assertNotNull($capturedParams, 'Stripe checkout session should have been created');
         $this->assertStringContainsString(route('cart.success'), $capturedParams['success_url']);
         $this->assertStringContainsString('{CHECKOUT_SESSION_ID}', $capturedParams['success_url']);
+
+        Carbon::setTestNow();
     }
 
     #[Test]

--- a/tests/Feature/DashboardLayoutTest.php
+++ b/tests/Feature/DashboardLayoutTest.php
@@ -221,6 +221,7 @@ class DashboardLayoutTest extends TestCase
     public function test_dashboard_shows_masterclass_countdown_for_non_owner_before_deadline(): void
     {
         Feature::define(ShowMasterclass::class, true);
+        Carbon::setTestNow('2026-06-14 23:59:59');
 
         $user = User::factory()->create();
 
@@ -230,6 +231,8 @@ class DashboardLayoutTest extends TestCase
             ->assertSee('The NativePHP Masterclass')
             ->assertSee('Lock in early bird pricing')
             ->assertSee('Get the course');
+
+        Carbon::setTestNow();
     }
 
     public function test_dashboard_hides_masterclass_countdown_after_deadline(): void


### PR DESCRIPTION
## What

- **Fix flaky date-dependent course tests.** The masterclass seed migration set `published_at => now()`, so under `RefreshDatabase` the product's publish date was pinned to the moment the test suite ran rather than its real launch date. Any test time-travelling to before "now" then saw the product as unpublished. Changed it to the fixed launch date `2026-03-07 00:00:00` (matching production), making `Product::isActive()` deterministic when tests pin the clock.
- **Pin the clock in the "before deadline" tests.** `DashboardLayoutTest::test_dashboard_shows_masterclass_countdown_for_non_owner_before_deadline` and `CoursePageTest::course_checkout_redirects_to_stripe_with_cart_success_url` relied on the real clock being before the `2026-06-15` price-increase deadline. They now pin to `2026-06-14 23:59:59` (mirroring their "after deadline" siblings) and reset afterward.
- **Remove early-bird copy** from the `/course` page ("Grab the early bird price now and you'll be first in line when the doors open. Sign up below to stay in the loop.").

## Why

These tests were failing on/after the deadline date because they assumed the real clock was before the price-increase deadline and assumed the product was always published. The fixes make the tests independent of the wall clock.

## Testing

`php artisan test tests/Feature/CoursePageTest.php tests/Feature/DashboardLayoutTest.php` → 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)