### PR TITLE
Refine plugin page: collapsible details, condensed price card, masked credentials & Ultra banner

### DIFF
--- a/.cursor/rules/laravel-boost.mdc
+++ b/.cursor/rules/laravel-boost.mdc
@@ -11,7 +11,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.21
+- php - 8.4.22
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.21
+- php - 8.4.22
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.21
+- php - 8.4.22
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.21
+- php - 8.4.22
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.21
+- php - 8.4.22
 - filament/filament (FILAMENT) - v5
 - laravel/cashier (CASHIER) - v15
 - laravel/framework (LARAVEL) - v12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "frosty-otter",
+    "name": "bold-condor",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -136,14 +136,22 @@
                                     </button>
                                 </div>
                                 @auth
+                                    @php
+                                        $pluginCredentialUser = auth()->user();
+                                        $pluginCredentialEmail = $pluginCredentialUser->email;
+                                        $pluginCredentialKey = $pluginCredentialUser->getPluginLicenseKey();
+                                        [$pluginCredentialEmailLocal, $pluginCredentialEmailDomain] = array_pad(explode('@', $pluginCredentialEmail, 2), 2, '');
+                                        $maskedPluginCredentialEmail = mb_substr($pluginCredentialEmailLocal, 0, 1).str_repeat('•', 6).($pluginCredentialEmailDomain !== '' ? '@'.$pluginCredentialEmailDomain : '');
+                                        $maskedPluginCredentialKey = str_repeat('•', 16);
+                                    @endphp
                                     <div class="flex items-center gap-2 rounded-lg bg-zinc-900 dark:bg-zinc-800">
                                         <div class="min-w-0 flex-1 overflow-x-auto p-3">
-                                            <code class="block whitespace-pre font-mono text-xs text-zinc-100">composer config http-basic.plugins.nativephp.com {{ auth()->user()->email }} {{ auth()->user()->getPluginLicenseKey() }}</code>
+                                            <code class="block whitespace-pre font-mono text-xs text-zinc-100">composer config http-basic.plugins.nativephp.com {{ $maskedPluginCredentialEmail }} {{ $maskedPluginCredentialKey }}</code>
                                         </div>
                                         <button
                                             type="button"
                                             x-data="{ copied: false }"
-                                            x-on:click="navigator.clipboard.writeText('composer config http-basic.plugins.nativephp.com {{ auth()->user()->email }} {{ auth()->user()->getPluginLicenseKey() }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
+                                            x-on:click="navigator.clipboard.writeText('composer config http-basic.plugins.nativephp.com {{ $pluginCredentialEmail }} {{ $pluginCredentialKey }}').then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
                                             class="shrink-0 self-stretch px-3 text-zinc-400 hover:text-zinc-200"
                                             title="Copy command"
                                         >
@@ -227,20 +235,20 @@
                     <div class="mb-4 rounded-2xl border-2 border-indigo-500 bg-gradient-to-br from-indigo-50 to-purple-50 p-6 dark:border-indigo-400 dark:from-indigo-950/50 dark:to-purple-950/50">
                         <div class="text-center">
                             @if ($hasDiscount && $regularPrice)
-                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Price</p>
-                                <p class="mt-1 text-lg text-gray-400 line-through dark:text-gray-500">
-                                    ${{ number_format($regularPrice->amount / 100) }}
-                                </p>
-                                <p class="text-4xl font-bold text-gray-900 dark:text-white">
-                                    ${{ number_format($bestPrice->amount / 100) }}
+                                <p class="flex items-baseline justify-center gap-2">
+                                    <span class="text-lg text-gray-400 line-through dark:text-gray-500">
+                                        ${{ number_format($regularPrice->amount / 100) }}
+                                    </span>
+                                    <span class="text-4xl font-bold text-gray-900 dark:text-white">
+                                        ${{ number_format($bestPrice->amount / 100) }}
+                                    </span>
                                 </p>
                                 <p class="mt-1 text-xs font-medium text-green-600 dark:text-green-400">
                                     {{ $bestPrice->tier->label() }} pricing applied
                                 </p>
                                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">One-time purchase</p>
                             @else
-                                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Price</p>
-                                <p class="mt-1 text-4xl font-bold text-gray-900 dark:text-white">
+                                <p class="text-4xl font-bold text-gray-900 dark:text-white">
                                     ${{ number_format($bestPrice->amount / 100) }}
                                 </p>
                                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">One-time purchase</p>
@@ -261,11 +269,71 @@
                     </div>
                 @endif
 
-                <div class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50">
-                    <h2 class="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                        Plugin Details
-                    </h2>
+                {{-- Included with Ultra --}}
+                @if ($plugin->isPaid() && $plugin->isOfficial())
+                    @php
+                        $hasUltraSubscription = auth()->user()?->hasActiveUltraSubscription() ?? false;
+                    @endphp
+                    <div class="mb-4 rounded-2xl border border-zinc-300 bg-gradient-to-br from-zinc-100 to-zinc-200 p-6 dark:border-zinc-600 dark:from-zinc-800 dark:to-zinc-900">
+                        <div class="flex items-start gap-3">
+                            <div class="shrink-0 text-zinc-700 dark:text-zinc-300">
+                                <x-heroicon-s-bolt class="size-6" />
+                            </div>
+                            <div>
+                                <p class="font-medium text-zinc-900 dark:text-zinc-100">Included with Ultra</p>
+                                <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
+                                    @if ($hasUltraSubscription)
+                                        This plugin is included with your Ultra subscription &mdash; for you and your team.
+                                    @else
+                                        You don't need to purchase any first-party NativePHP plugins with Ultra &mdash; they're all included for you and your team from just ${{ config('subscriptions.plans.max.price_monthly') }}/month.
+                                    @endif
+                                </p>
+                                @if (! $hasUltraSubscription)
+                                    @auth
+                                        <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-500">
+                                            You can still purchase this plugin to keep access even if you cancel your subscription.
+                                        </p>
+                                    @endauth
+                                @endif
+                                <a
+                                    href="{{ $hasUltraSubscription ? route('customer.ultra.index') : route('pricing') }}"
+                                    class="mt-4 inline-flex items-center rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
+                                >
+                                    {{ $hasUltraSubscription ? 'Go to your dashboard' : 'Learn more' }}
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                @endif
 
+                <div
+                    x-data="{ open: false }"
+                    class="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50"
+                >
+                    <button
+                        type="button"
+                        x-on:click="open = !open"
+                        :aria-expanded="open"
+                        class="flex w-full items-center justify-between gap-2"
+                    >
+                        <h2 class="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                            Plugin Details
+                        </h2>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke-width="2"
+                            stroke="currentColor"
+                            class="size-4 shrink-0 text-gray-400 transition-transform duration-200"
+                            :class="{ 'rotate-180': open }"
+                            aria-hidden="true"
+                        >
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                        </svg>
+                    </button>
+
+                    <div x-show="open" x-collapse x-cloak>
                     <dl class="mt-4 grid grid-cols-2 gap-3">
                         {{-- Author --}}
                         <div class="col-span-2 rounded-xl bg-gray-50 p-3 dark:bg-slate-700/30">
@@ -411,6 +479,7 @@
                             </p>
                         </div>
                     @endif
+                    </div>
                 </div>
 
                 {{-- Bundles containing this plugin --}}
@@ -460,34 +529,6 @@
                                 </li>
                             @endforeach
                         </ul>
-                    </div>
-                @endif
-
-                {{-- Included with Ultra --}}
-                @if ($plugin->isPaid() && $plugin->isOfficial())
-                    <div class="mt-4 rounded-2xl border border-zinc-300 bg-gradient-to-br from-zinc-100 to-zinc-200 p-6 dark:border-zinc-600 dark:from-zinc-800 dark:to-zinc-900">
-                        <div class="flex items-start gap-3">
-                            <div class="shrink-0 text-zinc-700 dark:text-zinc-300">
-                                <x-heroicon-s-bolt class="size-6" />
-                            </div>
-                            <div>
-                                <p class="font-medium text-zinc-900 dark:text-zinc-100">Included with Ultra</p>
-                                <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                                    You don't need to purchase any first-party NativePHP plugins with Ultra &mdash; they're all included for you and your team from just ${{ config('subscriptions.plans.max.price_monthly') }}/month.
-                                </p>
-                                @auth
-                                    <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-500">
-                                        You can still purchase this plugin to keep access even if you cancel your subscription.
-                                    </p>
-                                @endauth
-                                <a
-                                    href="{{ route('pricing') }}"
-                                    class="mt-4 inline-flex items-center rounded-md bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
-                                >
-                                    Learn more
-                                </a>
-                            </div>
-                        </div>
                     </div>
                 @endif
 

--- a/tests/Feature/PluginShowInstallCredentialsTest.php
+++ b/tests/Feature/PluginShowInstallCredentialsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginShowInstallCredentialsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    private function paidPlugin(): Plugin
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create();
+        PluginPrice::factory()->regular()->amount(4900)->create(['plugin_id' => $plugin->id]);
+
+        return $plugin;
+    }
+
+    public function test_install_credentials_are_masked(): void
+    {
+        $user = User::factory()->create(['email' => 'developer@example.test']);
+        $plugin = $this->paidPlugin();
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('d••••••@example.test', false)
+            ->assertSee(str_repeat('•', 16), false);
+    }
+
+    public function test_copy_command_still_contains_the_real_credentials(): void
+    {
+        $user = User::factory()->create(['email' => 'developer@example.test']);
+        $key = $user->getPluginLicenseKey();
+        $plugin = $this->paidPlugin();
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('developer@example.test', false)
+            ->assertSee($key, false);
+    }
+}

--- a/tests/Feature/PluginShowPriceCardTest.php
+++ b/tests/Feature/PluginShowPriceCardTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginShowPriceCardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PRO_PRICE_ID = 'price_1RoZeVAyFo6rlwXqtnOViUCf';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_price_card_omits_the_price_label(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create();
+
+        PluginPrice::factory()->regular()->amount(9900)->create([
+            'plugin_id' => $plugin->id,
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('$99')
+            ->assertSee('One-time purchase')
+            ->assertDontSee('>Price</p>', false);
+    }
+
+    public function test_discounted_price_card_shows_strike_through_before_current_price(): void
+    {
+        $user = User::factory()->create();
+        Subscription::factory()
+            ->for($user)
+            ->active()
+            ->create(['stripe_price' => self::PRO_PRICE_ID]);
+
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'is_active' => true,
+            'is_official' => true,
+        ]);
+
+        PluginPrice::factory()->regular()->amount(9900)->create([
+            'plugin_id' => $plugin->id,
+        ]);
+        PluginPrice::factory()->subscriber()->amount(4900)->create([
+            'plugin_id' => $plugin->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('pricing applied')
+            ->assertDontSee('>Price</p>', false)
+            ->assertSeeInOrder(['line-through', '$99', '$49'], false);
+    }
+
+    public function test_plugin_details_section_is_collapsible_and_collapsed_by_default(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Plugin Details')
+            ->assertSee('x-data="{ open: false }"', false)
+            ->assertSee('x-collapse', false);
+    }
+}

--- a/tests/Feature/PluginShowUltraCardTest.php
+++ b/tests/Feature/PluginShowUltraCardTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginShowUltraCardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MAX_PRICE_ID = 'price_1RoZk0AyFo6rlwXqjkLj4hZ0';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+
+        config(['subscriptions.plans.max.stripe_price_id' => self::MAX_PRICE_ID]);
+    }
+
+    public function test_ultra_card_shows_on_paid_first_party_plugin_for_guest(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create(['is_official' => true]);
+        PluginPrice::factory()->regular()->amount(4900)->create(['plugin_id' => $plugin->id]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Included with Ultra')
+            ->assertSee('Learn more')
+            ->assertSee(route('pricing'));
+    }
+
+    public function test_ultra_card_is_hidden_on_free_first_party_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create(['is_official' => true]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertDontSee('Included with Ultra');
+    }
+
+    public function test_ultra_card_is_hidden_on_third_party_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create(['is_official' => false]);
+        PluginPrice::factory()->regular()->amount(4900)->create(['plugin_id' => $plugin->id]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertDontSee('Included with Ultra');
+    }
+
+    public function test_ultra_subscriber_sees_dashboard_link(): void
+    {
+        $user = User::factory()->create();
+        Subscription::factory()
+            ->for($user)
+            ->active()
+            ->create(['stripe_price' => self::MAX_PRICE_ID]);
+
+        $plugin = Plugin::factory()->approved()->paid()->create(['is_official' => true]);
+        PluginPrice::factory()->regular()->amount(4900)->create(['plugin_id' => $plugin->id]);
+
+        $this->actingAs($user)
+            ->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Included with Ultra')
+            ->assertSee('Go to your dashboard')
+            ->assertSee(route('customer.ultra.index'))
+            ->assertDontSee('You can still purchase this plugin');
+    }
+}


### PR DESCRIPTION
## What & why

A set of UI refinements to the public plugin page (`resources/views/plugin-show.blade.php`) to tidy up the sidebar and improve clarity.

### Plugin Details — collapsible
- The **Plugin Details** sidebar section is now collapsible and **collapsed by default**, using the existing Alpine `x-collapse` pattern. A chevron in the header rotates to indicate state.

### Price card — condensed
- Removed the redundant **"Price"** label.
- When a discount applies, the strike-through regular price now sits **inline, before** the discounted price (matching the strike-through convention used elsewhere in the app).

### "Included with Ultra" card
- Moved directly **under the Add to Cart card**.
- Always visible (no longer hidden behind `@auth`) on **paid first-party (official)** plugins, for guests and logged-in users alike.
- For users with an active Ultra subscription, the copy adapts and the button links to their Ultra dashboard (`/dashboard/ultra`); everyone else gets the "Learn more" → pricing button.

### Masked install credentials
- The logged-in install command now **masks** the email and license key by default (e.g. `d••••••@example.com` and a bulleted key).
- The **copy button still copies the real underlying values** to the clipboard.

## Tests
Added feature tests:
- `PluginShowPriceCardTest` — price label removed, strike-through-before-current ordering, collapsed-by-default details markup.
- `PluginShowUltraCardTest` — card shows on paid first-party plugins, hidden on free/third-party, Ultra subscribers get the dashboard link.
- `PluginShowInstallCredentialsTest` — credentials render masked while the copy command retains the real values.

All plugin-page tests pass; Pint clean.

> Note: a few incidental, pre-existing working-tree changes are included (PHP patch version bump in the Boost guideline files, workspace name in `package-lock.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)