### PR TITLE
Move Contributing into Getting Started and fix docs image width

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -270,11 +270,11 @@ nav.docs-navigation li:has(.third-tier .exact-active) > .subsection-header {
     @apply rounded-none shadow-none;
 }
 
-.prose p:has(img) {
+.prose-gallery p:has(img) {
     @apply grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3;
 }
 
-.prose p:has(img) img {
+.prose-gallery p:has(img) img {
     @apply inline-block max-w-full rounded-none shadow-none;
 }
 

--- a/resources/views/docs/mobile/3/contributing/_index.md
+++ b/resources/views/docs/mobile/3/contributing/_index.md
@@ -1,4 +1,0 @@
----
-title: Contributing
-order: 70
----

--- a/resources/views/docs/mobile/3/getting-started/contributing.md
+++ b/resources/views/docs/mobile/3/getting-started/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-order: 1
+order: 700
 ---
 
 ## Contributing

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -200,7 +200,7 @@
                                 })
                             }
                         "
-                        class="prose min-w-0 max-w-none grow text-gray-600 prose-headings:scroll-mt-20 dark:text-gray-400 dark:prose-headings:text-white"
+                        class="prose prose-gallery min-w-0 max-w-none grow text-gray-600 prose-headings:scroll-mt-20 dark:text-gray-400 dark:prose-headings:text-white"
                         aria-labelledby="plugin-title"
                     >
                         @if ($plugin->readme_html)


### PR DESCRIPTION
## What

- **Docs navigation:** Move the Mobile v3 **Contributing** page out of its own top-level section and into the **Getting Started** section as the final item (`order: 700`, after Support Policy). Removes the now-empty `contributing/` section.
- **Docs/blog image width:** Scope the README image grid layout to the plugin README container only.

## Why

A previous change (#367) added a grid layout to `.prose p:has(img)` for plugin README image galleries. Because `.prose` is shared across docs, blog, and plugin READMEs, every paragraph containing a single image — including doc screenshots — was placed into a multi-column grid cell and shrank instead of spanning full width (e.g. EDGE Components → Introduction).

The grid rules are now scoped to a `prose-gallery` class applied only to the plugin README container, so docs and blog images fall back to the default full-width `.prose img` styling while plugin READMEs keep their gallery grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)