### PR TITLE
Build paid plugins individually with each owner's GitHub token

### DIFF
--- a/app/Console/Commands/SatisBuild.php
+++ b/app/Console/Commands/SatisBuild.php
@@ -31,7 +31,7 @@ class SatisBuild extends Command
         $pluginName = $this->option('plugin');
 
         if ($pluginName) {
-            $plugin = Plugin::where('name', $pluginName)->first();
+            $plugin = Plugin::with('user')->where('name', $pluginName)->first();
 
             if (! $plugin) {
                 $this->error("Plugin '{$pluginName}' not found.");
@@ -46,32 +46,49 @@ class SatisBuild extends Command
             }
 
             $this->info("Triggering Satis build for: {$pluginName}");
-            $result = $satisService->build([$plugin]);
-        } else {
-            $this->info('Triggering Satis build for all approved plugins...');
-            $result = $satisService->buildAll();
+            $result = $satisService->buildForPlugin($plugin);
+
+            if ($result['success'] ?? false) {
+                $this->info('Build triggered successfully!');
+                $this->line("Job ID: {$result['job_id']}");
+
+                return self::SUCCESS;
+            }
+
+            $this->error('Build trigger failed: '.($result['error'] ?? 'Unknown error'));
+
+            if (isset($result['status'])) {
+                $this->line("HTTP Status: {$result['status']}");
+            }
+
+            $this->line('API URL: '.config('services.satis.url'));
+            $this->line('API Key configured: '.(config('services.satis.api_key') ? 'Yes' : 'No'));
+
+            return self::FAILURE;
         }
 
-        if ($result['success']) {
-            $this->info('Build triggered successfully!');
-            $this->line("Job ID: {$result['job_id']}");
+        $this->info('Triggering individual Satis builds for all approved paid plugins...');
+        $result = $satisService->buildAll();
 
-            if (isset($result['plugins_count'])) {
-                $this->line("Plugins: {$result['plugins_count']}");
-            }
+        $count = $result['plugins_count'] ?? 0;
+        $failed = $result['failed'] ?? [];
+
+        if ($count === 0) {
+            $this->warn($result['error'] ?? 'No plugins to build.');
 
             return self::SUCCESS;
         }
 
-        $this->error('Build trigger failed: '.$result['error']);
+        $this->line('Dispatched '.($count - count($failed))."/{$count} plugin build(s).");
 
-        if (isset($result['status'])) {
-            $this->line("HTTP Status: {$result['status']}");
+        if (! empty($failed)) {
+            $this->error('Failed to dispatch: '.implode(', ', $failed));
+
+            return self::FAILURE;
         }
 
-        $this->line('API URL: '.config('services.satis.url'));
-        $this->line('API Key configured: '.(config('services.satis.api_key') ? 'Yes' : 'No'));
+        $this->info('All builds triggered successfully!');
 
-        return self::FAILURE;
+        return self::SUCCESS;
     }
 }

--- a/app/Jobs/Concerns/ResolvesGitHubToken.php
+++ b/app/Jobs/Concerns/ResolvesGitHubToken.php
@@ -11,6 +11,12 @@ trait ResolvesGitHubToken
     {
         /** @var Plugin $plugin */
         $plugin = $this->plugin;
+
+        return $this->resolveGitHubTokenFor($plugin);
+    }
+
+    protected function resolveGitHubTokenFor(Plugin $plugin): ?string
+    {
         $user = $plugin->user;
 
         if ($user && $user->hasGitHubToken()) {

--- a/app/Services/SatisService.php
+++ b/app/Services/SatisService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\PluginType;
+use App\Jobs\Concerns\ResolvesGitHubToken;
 use App\Models\Plugin;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
@@ -10,6 +11,8 @@ use Illuminate\Support\Facades\Log;
 
 class SatisService
 {
+    use ResolvesGitHubToken;
+
     protected string $apiUrl;
 
     protected string $apiKey;
@@ -21,13 +24,60 @@ class SatisService
     }
 
     /**
-     * Trigger a full satis build with all approved plugins.
+     * Rebuild every approved paid plugin.
+     *
+     * Each plugin is built individually using its owner's GitHub token. A single
+     * satis build can only authenticate to github.com as one identity, but the
+     * plugins live in private repos across different owners/orgs — so one shared
+     * token can't clone them all and falls back to unauthenticated requests that
+     * hit the 60/hour rate limit. Per-plugin builds are partial (merging) on the
+     * satis side, so a failure never overwrites the published index with an
+     * incomplete set.
      */
-    public function buildAll(?string $githubToken = null): array
+    public function buildAll(): array
     {
-        $plugins = $this->getApprovedPlugins();
+        $plugins = Plugin::query()
+            ->approved()
+            ->where('type', PluginType::Paid)
+            ->with('user')
+            ->get();
 
-        return $this->triggerBuild($plugins, $githubToken, fullBuild: true);
+        if ($plugins->isEmpty()) {
+            return [
+                'success' => false,
+                'error' => 'No plugins to build',
+                'plugins_count' => 0,
+                'failed' => [],
+                'results' => [],
+            ];
+        }
+
+        $results = [];
+        $failed = [];
+
+        foreach ($plugins as $plugin) {
+            $result = $this->buildForPlugin($plugin);
+            $results[$plugin->name] = $result;
+
+            if (! ($result['success'] ?? false)) {
+                $failed[] = $plugin->name;
+            }
+        }
+
+        return [
+            'success' => empty($failed),
+            'plugins_count' => $plugins->count(),
+            'failed' => $failed,
+            'results' => $results,
+        ];
+    }
+
+    /**
+     * Build a single plugin using its owner's GitHub token.
+     */
+    public function buildForPlugin(Plugin $plugin): array
+    {
+        return $this->build([$plugin], $this->resolveGitHubTokenFor($plugin));
     }
 
     /**
@@ -98,26 +148,6 @@ class SatisService
                 'error' => $e->getMessage(),
             ];
         }
-    }
-
-    /**
-     * Get all approved plugins formatted for satis.
-     *
-     * @return array<int, array{name: string, repository_url: string, type: string, is_official: bool}>
-     */
-    protected function getApprovedPlugins(): array
-    {
-        return Plugin::query()
-            ->approved()
-            ->where('type', PluginType::Paid)
-            ->get()
-            ->map(fn (Plugin $plugin) => [
-                'name' => $plugin->name,
-                'repository_url' => $plugin->repository_url,
-                'is_official' => $plugin->is_official ?? false,
-            ])
-            ->values()
-            ->all();
     }
 
     /**

--- a/tests/Feature/SatisSync/SatisSyncTest.php
+++ b/tests/Feature/SatisSync/SatisSyncTest.php
@@ -141,13 +141,17 @@ class SatisSyncTest extends TestCase
         $this->assertTrue($result['success']);
         $this->assertEquals(1, $result['plugins_count']);
 
+        // buildAll dispatches an individual partial build per paid plugin, each
+        // authenticated with the owner's token, so a single failure can never
+        // authoritatively overwrite the published index.
+        Http::assertSentCount(1);
         Http::assertSent(function ($request) use ($paidPlugin) {
             $data = $request->data();
             $plugins = $data['plugins'] ?? [];
 
             return count($plugins) === 1
                 && $plugins[0]['name'] === $paidPlugin->name
-                && $data['full_build'] === true;
+                && $data['full_build'] === false;
         });
     }
 }


### PR DESCRIPTION
## Problem

A full Satis rebuild (`php artisan satis:build` with no `--plugin`) sent every paid plugin in a single request using one shared GitHub token. A satis build can only authenticate to `github.com` as one identity, but paid plugins live in private repos across different owners/orgs — so one token can't clone them all and the rest fall back to unauthenticated requests, hitting GitHub's 60/hour rate limit. Combined with satis's `--skip-errors`, the build "succeeded" with most repos skipped and authoritatively overwrote `packages.json` with a near-empty index.

(Per-plugin syncs via `SyncPluginReleases` already used the owner's token, so only the full-rebuild path was affected.)

## Changes

- **`buildAll()` now builds each approved paid plugin individually**, using its owner's GitHub token (resolved via `ResolvesGitHubToken`). Each is a partial, merging build on the satis side, so a single failure can never overwrite the published index with an incomplete set. Returns a per-plugin summary (`plugins_count`, `failed`, `results`).
- **Refactor `ResolvesGitHubToken`** to expose `resolveGitHubTokenFor(Plugin)` (the existing `getGitHubToken()` delegates to it, behaviour unchanged); `SatisService` now uses the trait.
- **Add `SatisService::buildForPlugin()`** — resolve owner token + build one plugin. The `satis:build --plugin` path now uses it too (previously it sent no token).
- **`satis:build` command** reports per-plugin dispatch results.
- **Test** updated: `buildAll` now sends one partial build per paid plugin (`full_build === false`), asserted via `Http::assertSentCount(1)`.

## Note

This is the root-cause fix; the companion guard in plugins.nativephp.com (NativePHP/plugins.nativephp.com#7) refuses to publish an incomplete full build as defense-in-depth. Paid plugins whose owner has not connected GitHub still fall back to `config('services.github.token')` (`GITHUB_TOKEN`), which is currently unset and not in `.env.example` — worth setting. The long-term fix is the GitHub App (in progress separately).

## Testing

`php artisan test tests/Feature/SatisSync/SatisSyncTest.php tests/Feature/Jobs/SyncPluginReleasesTest.php` → 11 passed. `php -l` and Pint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)