### PR TITLE
Only license cart items actually paid for at checkout

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -455,6 +455,7 @@ class CartController extends Controller
         $cart->load('items.plugin', 'items.pluginBundle.plugins', 'items.product');
 
         $lineItems = [];
+        $purchasedItemIds = [];
 
         Log::info('Creating multi-item checkout session', [
             'cart_id' => $cart->id,
@@ -463,6 +464,8 @@ class CartController extends Controller
         ]);
 
         foreach ($cart->items as $item) {
+            $purchasedItemIds[] = $item->id;
+
             if ($item->isBundle()) {
                 $bundle = $item->pluginBundle;
 
@@ -516,9 +519,12 @@ class CartController extends Controller
         // Ensure the user has a valid Stripe customer ID
         $this->ensureValidStripeCustomer($user);
 
-        // Metadata only needs cart_id - we'll look up items from the cart
+        // Record the exact cart items that were turned into priced line items so the
+        // webhook only grants licenses for what was actually purchased, not whatever
+        // happens to be in the cart when the payment is confirmed.
         $metadata = [
             'cart_id' => (string) $cart->id,
+            'cart_item_ids' => implode(',', $purchasedItemIds),
         ];
 
         $session = Cashier::stripe()->checkout->sessions->create([

--- a/app/Jobs/HandleInvoicePaidJob.php
+++ b/app/Jobs/HandleInvoicePaidJob.php
@@ -24,6 +24,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Cashier;
@@ -259,14 +260,17 @@ class HandleInvoicePaidJob implements ShouldQueue
             return;
         }
 
+        $purchasedItems = $this->resolvePurchasedItems($cart);
+
         Log::info('Processing cart purchase from invoice', [
             'invoice_id' => $this->invoice->id,
             'cart_id' => $cartId,
             'user_id' => $user->id,
             'item_count' => $cart->items->count(),
+            'purchased_item_count' => $purchasedItems->count(),
         ]);
 
-        foreach ($cart->items as $item) {
+        foreach ($purchasedItems as $item) {
             if ($item->isProduct()) {
                 $this->processCartProductItem($user, $item);
             } elseif ($item->isBundle()) {
@@ -293,6 +297,34 @@ class HandleInvoicePaidJob implements ShouldQueue
             'cart_id' => $cartId,
             'user_id' => $user->id,
         ]);
+    }
+
+    /**
+     * Resolve which cart items were actually paid for in this invoice.
+     *
+     * The checkout session snapshots the purchased cart item IDs into the invoice
+     * metadata. We grant licenses only for those items so that anything else sitting
+     * in the cart at the time the payment is confirmed (e.g. items left over from an
+     * earlier browsing session or a merged guest cart) is never licensed for free.
+     */
+    private function resolvePurchasedItems(Cart $cart): Collection
+    {
+        $snapshot = (string) ($this->invoice->metadata['cart_item_ids'] ?? '');
+
+        if ($snapshot === '') {
+            // Legacy checkout sessions created before purchased items were snapshotted
+            // do not carry this metadata; fall back to the full cart for those.
+            Log::warning('Invoice has no cart_item_ids snapshot, processing entire cart', [
+                'invoice_id' => $this->invoice->id,
+                'cart_id' => $cart->id,
+            ]);
+
+            return $cart->items;
+        }
+
+        $purchasedItemIds = array_filter(array_map('intval', explode(',', $snapshot)));
+
+        return $cart->items->whereIn('id', $purchasedItemIds)->values();
     }
 
     private function processCartPluginItem(User $user, CartItem $item): void

--- a/tests/Feature/Jobs/HandleInvoicePaidJobTest.php
+++ b/tests/Feature/Jobs/HandleInvoicePaidJobTest.php
@@ -7,6 +7,7 @@ use App\Jobs\HandleInvoicePaidJob;
 use App\Models\Cart;
 use App\Models\CartItem;
 use App\Models\Plugin;
+use App\Models\PluginBundle;
 use App\Models\User;
 use App\Notifications\PurchaseReceipt;
 use App\Notifications\UltraSubscriptionStarted;
@@ -201,6 +202,68 @@ class HandleInvoicePaidJobTest extends TestCase
         (new HandleInvoicePaidJob($invoice))->handle();
 
         Notification::assertSentTo($buyer, PurchaseReceipt::class);
+    }
+
+    #[Test]
+    public function it_only_licenses_cart_items_recorded_in_the_invoice_snapshot(): void
+    {
+        Notification::fake();
+
+        $buyer = User::factory()->create(['stripe_id' => 'cus_test_buyer']);
+
+        $purchasedPlugin = Plugin::factory()->approved()->create(['is_active' => true]);
+
+        $leftoverPlugin = Plugin::factory()->approved()->create(['is_active' => true]);
+        $leftoverBundle = PluginBundle::factory()->create();
+        $leftoverBundle->plugins()->attach($leftoverPlugin->id, ['sort_order' => 1]);
+
+        $cart = Cart::factory()->for($buyer)->create();
+
+        $purchasedItem = CartItem::create([
+            'cart_id' => $cart->id,
+            'plugin_id' => $purchasedPlugin->id,
+            'price_at_addition' => 2500,
+        ]);
+
+        // This bundle is still sitting in the cart but was never part of the checkout.
+        CartItem::create([
+            'cart_id' => $cart->id,
+            'plugin_bundle_id' => $leftoverBundle->id,
+            'bundle_price_at_addition' => 9999,
+        ]);
+
+        $invoice = Invoice::constructFrom([
+            'id' => 'in_test_'.uniqid(),
+            'billing_reason' => Invoice::BILLING_REASON_MANUAL,
+            'customer' => $buyer->stripe_id,
+            'payment_intent' => 'pi_test_'.uniqid(),
+            'currency' => 'usd',
+            'metadata' => [
+                'cart_id' => (string) $cart->id,
+                'cart_item_ids' => (string) $purchasedItem->id,
+            ],
+            'lines' => [],
+        ]);
+
+        (new HandleInvoicePaidJob($invoice))->handle();
+
+        $this->assertDatabaseHas('plugin_licenses', [
+            'user_id' => $buyer->id,
+            'plugin_id' => $purchasedPlugin->id,
+            'plugin_bundle_id' => null,
+            'price_paid' => 2500,
+        ]);
+
+        $this->assertDatabaseMissing('plugin_licenses', [
+            'plugin_bundle_id' => $leftoverBundle->id,
+        ]);
+
+        $this->assertDatabaseMissing('plugin_licenses', [
+            'plugin_id' => $leftoverPlugin->id,
+        ]);
+
+        $this->assertEquals(1, $buyer->pluginLicenses()->count());
+        $this->assertNotNull($cart->fresh()->completed_at);
     }
 
     public static function subscriptionPlanProvider(): array


### PR DESCRIPTION
## Problem

A customer reported that after buying a course via Stripe checkout, an unrelated plugin **bundle** that had been sitting in their cart from an earlier browsing session showed up as licensed — without being charged or receiving a receipt. Investigation confirmed this is a real bug, not a customer error.

### Root cause

When `invoice.paid` fires, `HandleInvoicePaidJob::processCartPurchase()` re-read the **live cart** and created a license for **every item currently in it**, with no cross-check against what Stripe actually charged. The checkout session only stored `cart_id` in metadata ("we'll look up items from the cart").

This is a time-of-check / time-of-use gap: anything in the cart when the webhook runs — a leftover item, or a guest cart merged in on login — got licensed for free. The receipt reflected only the priced line items (the course), exactly matching what the customer saw.

## Fix

- **Snapshot at checkout** (`CartController`): record the exact cart-item IDs that became priced Stripe line items into the session/invoice metadata as `cart_item_ids`.
- **Reconcile in the webhook** (`HandleInvoicePaidJob`): a new `resolvePurchasedItems()` filters the cart down to the snapshotted items before granting any licenses. Anything else in the cart is ignored.
- **Backward compatible**: if the snapshot is absent (checkout sessions created before this deploy), it falls back to the previous whole-cart behavior and logs a warning.

The free-checkout path is intentionally left as-is: it runs synchronously in the same request with no payment gap and only triggers when the entire cart subtotal is \$0, so it cannot mischarge.

## Tests

- New regression test: a cart holding a paid plugin **and** an unpaid leftover bundle, with the invoice snapshot listing only the plugin — asserts the plugin is licensed, the bundle and its plugins are not, and the cart is completed.
- Full `HandleInvoicePaidJobTest` suite passes (8 tests); the existing receipt test exercises the no-snapshot fallback path.
- Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)