### PR TITLE
Add OpenGraph images and SEO meta tags to plugin pages

### DIFF
--- a/app/Console/Commands/GeneratePluginOgImages.php
+++ b/app/Console/Commands/GeneratePluginOgImages.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\GeneratePluginOgImage;
+use App\Models\Plugin;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class GeneratePluginOgImages extends Command
+{
+    protected $signature = 'plugins:generate-og-images
+        {--missing : Only generate images that do not already exist on disk}';
+
+    protected $description = 'Generate (or regenerate) the OpenGraph images for plugins';
+
+    public function handle(): int
+    {
+        $plugins = Plugin::query()->get();
+
+        if ($this->option('missing')) {
+            $plugins = $plugins->reject(
+                fn (Plugin $plugin) => Storage::disk('public')->exists("og-images/plugins/{$plugin->id}.png")
+            );
+        }
+
+        if ($plugins->isEmpty()) {
+            $this->info('No plugins need OG images.');
+
+            return self::SUCCESS;
+        }
+
+        $this->withProgressBar($plugins, function (Plugin $plugin): void {
+            GeneratePluginOgImage::dispatchSync($plugin);
+        });
+
+        $this->newLine(2);
+        $this->info("Generated OG images for {$plugins->count()} plugin(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -6,6 +6,7 @@ use App\Enums\PluginStatus;
 use App\Enums\PluginTier;
 use App\Enums\PluginType;
 use App\Filament\Resources\PluginResource;
+use App\Jobs\GeneratePluginOgImage;
 use App\Jobs\ReviewPluginRepository;
 use App\Jobs\SyncPlugin;
 use App\Jobs\SyncPluginReleases;
@@ -22,6 +23,11 @@ use Illuminate\Support\HtmlString;
 class EditPlugin extends EditRecord
 {
     protected static string $resource = PluginResource::class;
+
+    protected function afterSave(): void
+    {
+        GeneratePluginOgImage::dispatch($this->record);
+    }
 
     public function getSubheading(): string|HtmlString|null
     {

--- a/app/Http/Controllers/PluginDirectoryController.php
+++ b/app/Http/Controllers/PluginDirectoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Plugin;
 use App\Models\PluginBundle;
+use Artesaos\SEOTools\Facades\SEOTools;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
@@ -71,6 +72,8 @@ class PluginDirectoryController extends Controller
         $bestPrice = $plugin->getBestPriceForUser($user);
         $regularPrice = $plugin->getRegularPrice();
 
+        $this->setPluginSeo($plugin);
+
         return view('plugin-show', [
             'plugin' => $plugin,
             'bundles' => $bundles,
@@ -99,9 +102,32 @@ class PluginDirectoryController extends Controller
             abort(404);
         }
 
+        $this->setPluginSeo($plugin, suffix: 'License');
+
         return view('plugin-license', [
             'plugin' => $plugin,
             'isAdminPreview' => (! $plugin->isApproved() || ! $plugin->is_active) && ($isAdmin || $isOwner),
         ]);
+    }
+
+    protected function setPluginSeo(Plugin $plugin, string $suffix = 'Plugin'): void
+    {
+        $name = $plugin->display_name ?? $plugin->name;
+        $description = $plugin->description ?: "{$name} is a plugin for NativePHP Mobile.";
+
+        SEOTools::setTitle("{$name} - {$suffix}");
+        SEOTools::setDescription($description);
+
+        SEOTools::opengraph()->setTitle($name);
+        SEOTools::opengraph()->setDescription($description);
+        SEOTools::opengraph()->setType('website');
+
+        SEOTools::twitter()->setTitle($name);
+        SEOTools::twitter()->setDescription($description);
+
+        if ($plugin->og_image) {
+            SEOTools::opengraph()->addImage($plugin->og_image);
+            SEOTools::twitter()->setImage($plugin->og_image);
+        }
     }
 }

--- a/app/Jobs/GeneratePluginOgImage.php
+++ b/app/Jobs/GeneratePluginOgImage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Plugin;
+use App\Services\OgImageService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class GeneratePluginOgImage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Plugin $plugin) {}
+
+    public function handle(OgImageService $ogImageService): void
+    {
+        $ogImageUrl = $ogImageService->generateForPlugin($this->plugin);
+
+        $this->plugin->update([
+            'og_image' => $ogImageUrl,
+        ]);
+    }
+}

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -10,6 +10,7 @@ use App\Enums\PriceTier;
 use App\Jobs\SendNewPluginNotifications;
 use App\Notifications\PluginApproved;
 use App\Notifications\PluginRejected;
+use App\Services\OgImageService;
 use App\Services\PluginSyncService;
 use App\Services\SatisService;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -82,6 +83,8 @@ class Plugin extends Model
             if ($plugin->name) {
                 resolve(SatisService::class)->removePackage($plugin->name);
             }
+
+            resolve(OgImageService::class)->deleteForPlugin($plugin);
         });
     }
 

--- a/app/Services/OgImageService.php
+++ b/app/Services/OgImageService.php
@@ -3,10 +3,12 @@
 namespace App\Services;
 
 use App\Models\Article;
+use App\Models\Plugin;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Colors\Rgb\Color;
 use SimonHamp\TheOg\BorderPosition;
 use SimonHamp\TheOg\Image;
+use SimonHamp\TheOg\Interfaces\Layout;
 
 class OgImageService
 {
@@ -15,27 +17,31 @@ class OgImageService
      */
     public function generate(Article $article): string
     {
-        $image = new Image;
+        return $this->render(
+            "og-images/{$article->slug}.png",
+            $article->title,
+            $article->excerpt ?? '',
+            url('/blog/'.$article->slug),
+        );
+    }
 
-        // Ensure the directory exists
-        $directory = Storage::disk('public')->path('og-images');
-        if (! is_dir($directory)) {
-            mkdir($directory, 0755, true);
-        }
-
-        $image
-            ->layout(new NativePhpLayout)
-            ->title($article->title)
-            ->description($article->excerpt ?? '')
-            ->backgroundColor('#ffffff')
-            ->titleColor('#141624')
-            ->descriptionColor('#141624')
-            ->border(BorderPosition::All, new Color(80, 91, 147), 5)
-            ->watermark(public_path('logo.svg'))
-            ->url(url('/blog/'.$article->slug))
-            ->save($this->getImagePath($article));
-
-        return $this->getImageUrl($article);
+    /**
+     * Generate an OG image for the given plugin.
+     */
+    public function generateForPlugin(Plugin $plugin): string
+    {
+        return $this->render(
+            "og-images/plugins/{$plugin->id}.png",
+            $plugin->display_name ?? $plugin->name,
+            $plugin->description ?? '',
+            route('plugins.show', $plugin->routeParams()),
+            new PluginOgLayout(
+                version: $plugin->latest_version,
+                mobileVersion: $plugin->mobile_min_version,
+                iosVersion: $plugin->ios_version,
+                androidVersion: $plugin->android_version,
+            ),
+        );
     }
 
     /**
@@ -43,28 +49,55 @@ class OgImageService
      */
     public function delete(Article $article): bool
     {
-        if ($article->og_image) {
-            $path = str_replace('/storage/', '', parse_url($article->og_image, PHP_URL_PATH));
+        return $this->deleteByUrl($article->og_image);
+    }
 
-            return Storage::disk('public')->delete($path);
+    /**
+     * Delete the OG image for the given plugin.
+     */
+    public function deleteForPlugin(Plugin $plugin): bool
+    {
+        return $this->deleteByUrl($plugin->og_image);
+    }
+
+    /**
+     * Render an OG image to the public disk and return its public URL.
+     */
+    protected function render(string $path, string $title, string $description, string $url, ?Layout $layout = null): string
+    {
+        $fullPath = Storage::disk('public')->path($path);
+
+        $directory = dirname($fullPath);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
         }
 
-        return false;
+        (new Image)
+            ->layout($layout ?? new NativePhpLayout)
+            ->title($title)
+            ->description($description)
+            ->backgroundColor('#ffffff')
+            ->titleColor('#141624')
+            ->descriptionColor('#141624')
+            ->border(BorderPosition::All, new Color(80, 91, 147), 5)
+            ->watermark(public_path('logo.svg'))
+            ->url($url)
+            ->save($fullPath);
+
+        return Storage::disk('public')->url($path);
     }
 
     /**
-     * Get the file path for storing the OG image.
+     * Delete a previously generated OG image given its public URL.
      */
-    protected function getImagePath(Article $article): string
+    protected function deleteByUrl(?string $ogImageUrl): bool
     {
-        return Storage::disk('public')->path("og-images/{$article->slug}.png");
-    }
+        if (! $ogImageUrl) {
+            return false;
+        }
 
-    /**
-     * Get the public URL for the OG image.
-     */
-    protected function getImageUrl(Article $article): string
-    {
-        return Storage::disk('public')->url("og-images/{$article->slug}.png");
+        $path = str_replace('/storage/', '', parse_url($ogImageUrl, PHP_URL_PATH));
+
+        return Storage::disk('public')->delete($path);
     }
 }

--- a/app/Services/PillBox.php
+++ b/app/Services/PillBox.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services;
+
+use Intervention\Image\Geometry\Factories\CircleFactory;
+use Intervention\Image\Geometry\Factories\RectangleFactory;
+use Intervention\Image\Geometry\Point;
+use Intervention\Image\Geometry\Rectangle;
+use Intervention\Image\Interfaces\SizeInterface;
+use SimonHamp\TheOg\Layout\TextBox;
+
+/**
+ * A "pill" feature: text centered on a stadium-shaped (fully rounded) background.
+ *
+ * Intervention has no rounded-rectangle primitive, so the pill is composed from a
+ * centre rectangle plus a circle at each end.
+ */
+class PillBox extends TextBox
+{
+    protected string $backgroundColor = '#eef1f6';
+
+    protected int $paddingX = 24;
+
+    protected int $pillHeight = 56;
+
+    public function backgroundColor(string $color): self
+    {
+        $this->backgroundColor = $color;
+
+        return $this;
+    }
+
+    public function paddingX(int $padding): self
+    {
+        $this->paddingX = $padding;
+
+        return $this;
+    }
+
+    public function pillHeight(int $height): self
+    {
+        $this->pillHeight = $height;
+
+        return $this;
+    }
+
+    public function dimensions(): SizeInterface
+    {
+        return new Rectangle($this->textWidth() + ($this->paddingX * 2), $this->pillHeight);
+    }
+
+    public function render(): void
+    {
+        $position = $this->calculatePosition();
+        $width = $this->dimensions()->width();
+        $height = $this->dimensions()->height();
+        $radius = intval(floor($height / 2));
+        $x = $position->x();
+        $y = $position->y();
+
+        $this->canvas()->drawRectangle($x + $radius, $y, function (RectangleFactory $rectangle) use ($width, $height, $radius): void {
+            $rectangle->size(max(0, $width - ($radius * 2)), $height);
+            $rectangle->background($this->backgroundColor);
+        });
+
+        foreach ([$x + $radius, $x + $width - $radius] as $centerX) {
+            $this->canvas()->drawCircle($centerX, $y + $radius, function (CircleFactory $circle) use ($height): void {
+                $circle->diameter($height);
+                $circle->background($this->backgroundColor);
+            });
+        }
+
+        $modifier = $this->modifier($this->text);
+        $modifier->position = new Point($x + intval(floor($width / 2)), $y + intval(floor($height / 2)));
+
+        $this->canvas()->modify($modifier);
+    }
+
+    protected function textWidth(): int
+    {
+        return $this->canvas()->driver()
+            ->fontProcessor()
+            ->boxSize($this->text, $this->interventionFontInstance())
+            ->width();
+    }
+}

--- a/app/Services/PluginOgLayout.php
+++ b/app/Services/PluginOgLayout.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services;
+
+use Intervention\Image\Colors\Rgb\Color;
+use SimonHamp\TheOg\Layout\Position;
+
+class PluginOgLayout extends NativePhpLayout
+{
+    protected const PILL_GAP = 16;
+
+    public function __construct(
+        protected ?string $version = null,
+        protected ?string $mobileVersion = null,
+        protected ?string $iosVersion = null,
+        protected ?string $androidVersion = null,
+    ) {}
+
+    public function features(): void
+    {
+        parent::features();
+
+        $pills = $this->pills();
+
+        if ($pills === []) {
+            return;
+        }
+
+        $anchor = $this->getFeature('description') ?? $this->getFeature('title');
+
+        foreach (array_values($pills) as $index => $label) {
+            $pill = (new PillBox)
+                ->name("pill_{$index}")
+                ->text($label)
+                ->color(new Color(51, 65, 85))
+                ->backgroundColor('#eef1f6')
+                ->font($this->config->theme->getDescriptionFont())
+                ->size(28)
+                ->hAlign('center')
+                ->vAlign('middle')
+                ->box($this->mountArea()->box->width(), 56);
+
+            if ($index === 0) {
+                $pill->position(
+                    x: 0,
+                    y: 44,
+                    relativeTo: fn () => $anchor->anchor(Position::BottomLeft),
+                );
+            } else {
+                $previous = 'pill_'.($index - 1);
+
+                $pill->position(
+                    x: self::PILL_GAP,
+                    y: 0,
+                    relativeTo: fn () => $this->getFeature($previous)->anchor(Position::TopRight),
+                );
+            }
+
+            $this->addFeature($pill);
+        }
+    }
+
+    /**
+     * The plugin detail labels to render as pills, omitting any unknown values.
+     *
+     * @return list<string>
+     */
+    public function pills(): array
+    {
+        $pills = [];
+
+        if ($this->version) {
+            $pills[] = 'v'.ltrim($this->version, 'v');
+        }
+
+        if ($this->mobileVersion) {
+            $pills[] = 'NativePHP Mobile '.$this->mobileVersion;
+        }
+
+        if ($this->iosVersion) {
+            $pills[] = 'iOS '.$this->asMinimum($this->iosVersion);
+        }
+
+        if ($this->androidVersion) {
+            $pills[] = 'Android '.$this->asMinimum($this->androidVersion);
+        }
+
+        return $pills;
+    }
+
+    /**
+     * Present a bare version number as a minimum (e.g. "18.2" becomes "18.2+").
+     */
+    protected function asMinimum(string $version): string
+    {
+        return str_ends_with($version, '+') ? $version : $version.'+';
+    }
+}

--- a/app/Services/PluginSyncService.php
+++ b/app/Services/PluginSyncService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Jobs\GeneratePluginOgImage;
 use App\Models\Plugin;
 use App\Support\CommonMark\CommonMark;
 use Illuminate\Support\Facades\Http;
@@ -117,6 +118,8 @@ class PluginSyncService
         ]);
 
         $plugin->update($updateData);
+
+        GeneratePluginOgImage::dispatch($plugin);
 
         Log::info('[PluginSync] Sync complete', ['plugin_id' => $plugin->id, 'name' => $plugin->name]);
 

--- a/database/migrations/2026_06_29_171859_add_og_image_to_plugins_table.php
+++ b/database/migrations/2026_06_29_171859_add_og_image_to_plugins_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->string('og_image')->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn('og_image');
+        });
+    }
+};

--- a/tests/Feature/PluginOgImageTest.php
+++ b/tests/Feature/PluginOgImageTest.php
@@ -6,6 +6,7 @@ use App\Jobs\GeneratePluginOgImage;
 use App\Models\Plugin;
 use App\Services\PluginOgLayout;
 use App\Services\PluginSyncService;
+use App\Services\SatisService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
@@ -116,6 +117,11 @@ class PluginOgImageTest extends TestCase
     public function test_deleting_plugin_removes_its_og_image(): void
     {
         Storage::fake('public');
+
+        // The plugin's deleting hook also talks to Satis, which we don't exercise here.
+        $this->mock(SatisService::class)
+            ->shouldReceive('removePackage')
+            ->andReturn([]);
 
         $plugin = Plugin::factory()->approved()->create([
             'og_image' => 'https://nativephp.com.test/storage/og-images/plugins/42.png',

--- a/tests/Feature/PluginOgImageTest.php
+++ b/tests/Feature/PluginOgImageTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\GeneratePluginOgImage;
+use App\Models\Plugin;
+use App\Services\PluginOgLayout;
+use App\Services\PluginSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PluginOgImageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_generates_and_stores_og_image(): void
+    {
+        Storage::fake('public');
+
+        $plugin = Plugin::factory()->approved()->create([
+            'display_name' => 'Generated Plugin',
+            'description' => 'A plugin with a generated OG image.',
+            'latest_version' => '1.0.1',
+            'mobile_min_version' => '^3.0',
+            'ios_version' => '18.2',
+            'android_version' => '26',
+        ]);
+
+        GeneratePluginOgImage::dispatchSync($plugin);
+
+        $plugin->refresh();
+
+        $this->assertNotNull($plugin->og_image);
+        Storage::disk('public')->assertExists("og-images/plugins/{$plugin->id}.png");
+    }
+
+    public function test_sync_dispatches_og_image_generation(): void
+    {
+        Queue::fake();
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/contents/composer.json' => Http::response([
+                'content' => base64_encode(json_encode(['name' => 'acme/test-plugin'])),
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json' => Http::response([], 404),
+            'raw.githubusercontent.com/*' => Http::response('', 404),
+            'api.github.com/repos/acme/test-plugin/releases/latest' => Http::response([], 404),
+            'api.github.com/repos/acme/test-plugin/tags*' => Http::response([]),
+            'api.github.com/repos/acme/test-plugin/contents/LICENSE*' => Http::response([], 404),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        (new PluginSyncService)->sync($plugin);
+
+        Queue::assertPushed(GeneratePluginOgImage::class, fn (GeneratePluginOgImage $job) => $job->plugin->is($plugin));
+    }
+
+    public function test_pills_include_all_known_plugin_details(): void
+    {
+        $layout = new PluginOgLayout(
+            version: '2.3.1',
+            mobileVersion: '^3.0.0',
+            iosVersion: '15.0+',
+            androidVersion: '12+',
+        );
+
+        $this->assertSame(
+            ['v2.3.1', 'NativePHP Mobile ^3.0.0', 'iOS 15.0+', 'Android 12+'],
+            $layout->pills(),
+        );
+    }
+
+    public function test_pills_omit_unknown_plugin_details(): void
+    {
+        $layout = new PluginOgLayout(
+            version: null,
+            mobileVersion: '^3.0.0',
+            iosVersion: '16.0+',
+            androidVersion: null,
+        );
+
+        $this->assertSame(['NativePHP Mobile ^3.0.0', 'iOS 16.0+'], $layout->pills());
+    }
+
+    public function test_pills_are_empty_when_no_details_are_known(): void
+    {
+        $this->assertSame([], (new PluginOgLayout)->pills());
+    }
+
+    public function test_pills_do_not_double_the_version_prefix(): void
+    {
+        $this->assertSame(['v1.2.3'], (new PluginOgLayout(version: 'v1.2.3'))->pills());
+    }
+
+    public function test_pills_present_platform_versions_as_minimums(): void
+    {
+        $layout = new PluginOgLayout(iosVersion: '18.2', androidVersion: '26');
+
+        $this->assertSame(['iOS 18.2+', 'Android 26+'], $layout->pills());
+    }
+
+    public function test_pills_do_not_double_the_minimum_suffix(): void
+    {
+        $layout = new PluginOgLayout(iosVersion: '15.0+', androidVersion: '12+');
+
+        $this->assertSame(['iOS 15.0+', 'Android 12+'], $layout->pills());
+    }
+
+    public function test_deleting_plugin_removes_its_og_image(): void
+    {
+        Storage::fake('public');
+
+        $plugin = Plugin::factory()->approved()->create([
+            'og_image' => 'https://nativephp.com.test/storage/og-images/plugins/42.png',
+        ]);
+
+        Storage::disk('public')->put('og-images/plugins/42.png', 'fake-image-bytes');
+
+        $plugin->delete();
+
+        Storage::disk('public')->assertMissing('og-images/plugins/42.png');
+    }
+
+    public function test_backfill_command_generates_images_for_all_plugins(): void
+    {
+        Storage::fake('public');
+
+        $plugins = Plugin::factory()->approved()->count(2)->create(['og_image' => null]);
+
+        $this->artisan('plugins:generate-og-images')->assertSuccessful();
+
+        foreach ($plugins as $plugin) {
+            Storage::disk('public')->assertExists("og-images/plugins/{$plugin->id}.png");
+            $this->assertNotNull($plugin->fresh()->og_image);
+        }
+    }
+
+    public function test_backfill_command_missing_option_skips_existing_images(): void
+    {
+        Storage::fake('public');
+
+        $existing = Plugin::factory()->approved()->create();
+        Storage::disk('public')->put("og-images/plugins/{$existing->id}.png", 'original-bytes');
+
+        $needsImage = Plugin::factory()->approved()->create(['og_image' => null]);
+
+        $this->artisan('plugins:generate-og-images', ['--missing' => true])->assertSuccessful();
+
+        $this->assertSame('original-bytes', Storage::disk('public')->get("og-images/plugins/{$existing->id}.png"));
+        Storage::disk('public')->assertExists("og-images/plugins/{$needsImage->id}.png");
+    }
+}

--- a/tests/Feature/PluginShowSeoMetaTest.php
+++ b/tests/Feature/PluginShowSeoMetaTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginShowSeoMetaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_plugin_show_sets_title_and_opengraph_meta(): void
+    {
+        $plugin = Plugin::factory()->approved()->create([
+            'display_name' => 'Awesome Plugin',
+            'description' => 'Does awesome things.',
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('<title>Awesome Plugin - Plugin - NativePHP</title>', false)
+            ->assertSee('<meta property="og:title" content="Awesome Plugin">', false)
+            ->assertSee('<meta property="og:description" content="Does awesome things.">', false)
+            ->assertSee('<meta name="twitter:title" content="Awesome Plugin">', false)
+            ->assertSee('<meta name="twitter:description" content="Does awesome things.">', false);
+    }
+
+    public function test_plugin_show_uses_generated_og_image(): void
+    {
+        $ogImage = 'https://nativephp.com.test/storage/og-images/plugins/1.png';
+
+        $plugin = Plugin::factory()->approved()->create([
+            'display_name' => 'Imaged Plugin',
+            'og_image' => $ogImage,
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('<meta property="og:image" content="'.e($ogImage).'">', false)
+            ->assertSee('<meta name="twitter:image" content="'.e($ogImage).'">', false);
+    }
+
+    public function test_plugin_show_falls_back_to_default_og_image_when_none_generated(): void
+    {
+        $plugin = Plugin::factory()->approved()->create([
+            'display_name' => 'No Image Plugin',
+            'og_image' => null,
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertDontSee('og-images/plugins/')
+            ->assertSee(config('seotools.opengraph.defaults.images.0'));
+    }
+
+    public function test_plugin_show_falls_back_to_generated_description(): void
+    {
+        $plugin = Plugin::factory()->approved()->create([
+            'display_name' => 'No Description Plugin',
+            'description' => null,
+        ]);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('No Description Plugin is a plugin for NativePHP Mobile.');
+    }
+
+    public function test_plugin_license_sets_seo_meta(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'display_name' => 'Paid Plugin',
+            'description' => 'A premium plugin.',
+            'license_html' => '<p>License terms</p>',
+        ]);
+
+        PluginPrice::factory()->regular()->create([
+            'plugin_id' => $plugin->id,
+            'amount' => 2999,
+        ]);
+
+        $this->get(route('plugins.license', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('<title>Paid Plugin - License - NativePHP</title>', false)
+            ->assertSee('<meta property="og:title" content="Paid Plugin">', false);
+    }
+}

--- a/tests/Feature/PluginSyncServiceTest.php
+++ b/tests/Feature/PluginSyncServiceTest.php
@@ -6,11 +6,19 @@ use App\Models\Plugin;
 use App\Services\PluginSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class PluginSyncServiceTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
 
     public function test_sync_extracts_mobile_min_version_from_composer_data(): void
     {


### PR DESCRIPTION
## Summary

Plugin listing pages had no per-plugin `<title>` or OpenGraph/Twitter tags, so social shares fell back to the generic site card. This adds proper SEO metadata and a generated OG image for every plugin, mirroring how blog posts already work.

## What changed

- **SEO meta on plugin pages** — `PluginDirectoryController` now sets the title, description, and OpenGraph/Twitter tags on both the plugin show and license pages (following the existing `ShowBlogController` pattern).
- **Generated OG images via TheOg** — a queued `GeneratePluginOgImage` job renders an image to the public disk and stores its URL on a new `plugins.og_image` column. It's dispatched from `PluginSyncService::sync()` (the single content pipeline — webhooks, the customer create flow, and the `SyncPlugin` job) and from Filament `EditPlugin::afterSave()`, so images stay fresh. The `OgImageService` was refactored to share its rendering between articles and plugins; the article path is unchanged.
- **Plugin detail "pills"** — `PluginOgLayout` renders the plugin version, required `nativephp/mobile` constraint, and iOS/Android **minimum** versions (shown with a `+`, e.g. `iOS 18.2+`) as rounded pill badges. Intervention has no rounded-rectangle primitive, so `PillBox` composes a stadium shape from a rectangle + a circle at each end.
- **Backfill command** — `php artisan plugins:generate-og-images [--missing]` generates images synchronously for existing plugins (no queue worker required).
- **Cleanup** — deleting a plugin removes its generated OG image.

## Why

Shared plugin links (Slack, X, etc.) now show a branded, per-plugin card with the plugin's name, description, and platform/version support instead of a generic fallback.

## Testing

- New `PluginShowSeoMetaTest` (title + OG/Twitter meta, generated-image usage, default fallback, license page).
- New `PluginOgImageTest` (job renders + stores the image, sync dispatches the job, delete cleanup, pill label composition incl. the `+` minimum behavior, backfill command).
- `PluginSyncServiceTest` updated to fake the queue so it stays a focused unit test.

> [!NOTE]
> Existing plugins won't have an image until their next sync/edit or a run of `plugins:generate-og-images`. Generation is queued, so a worker (Horizon) must be processing the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)