### PR TITLE
Fix Stripe tax ID collection error on course checkout

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -153,6 +153,10 @@ Route::post('course/checkout', function (Request $request) {
         'metadata' => $metadata,
         'allow_promotion_codes' => true,
         'billing_address_collection' => 'required',
+        'customer_update' => [
+            'name' => 'auto',
+            'address' => 'auto',
+        ],
         'tax_id_collection' => ['enabled' => true],
         'invoice_creation' => [
             'enabled' => true,

--- a/tests/Feature/CoursePageTest.php
+++ b/tests/Feature/CoursePageTest.php
@@ -127,6 +127,10 @@ class CoursePageTest extends TestCase
         $this->assertStringContainsString(route('cart.success'), $capturedParams['success_url']);
         $this->assertStringContainsString('{CHECKOUT_SESSION_ID}', $capturedParams['success_url']);
 
+        $this->assertTrue($capturedParams['tax_id_collection']['enabled']);
+        $this->assertSame('auto', $capturedParams['customer_update']['address'] ?? null, 'Tax ID collection requires customer_update[address] = auto for existing customers');
+        $this->assertSame('auto', $capturedParams['customer_update']['name'] ?? null);
+
         Carbon::setTestNow();
     }
 


### PR DESCRIPTION
## Summary

Fixes #71 — `Stripe\Exception\InvalidRequestException: We could not find a valid address on the provided customer. To enable tax ID collection, please set customer_update[address] to auto.`

The `course.checkout` route creates/gets the user's Stripe customer and then calls Cashier's `$user->checkout()` with `tax_id_collection => ['enabled' => true]`. Because the user already has a Stripe customer, Cashier always passes that existing `customer` to the Checkout Session. Stripe then requires permission to write the checkout-collected billing address back onto the existing customer (needed to validate the tax ID) — i.e. `customer_update[address] = auto`.

Cashier only auto-fills `customer_update[name] = 'auto'` (`vendor/laravel/cashier/src/Checkout.php`), never `address`, so Stripe rejected the request and the checkout 500'd.

This was the **only** one of the app's four `tax_id_collection` checkout flows missing the setting — `CartController`, `LicenseRenewalController`, and `MobilePricing` all already pass `customer_update => ['name' => 'auto', 'address' => 'auto']`.

## Changes

- **`routes/web.php`** — add `customer_update => ['name' => 'auto', 'address' => 'auto']` to the course checkout options, matching the three existing flows.
- **`tests/Feature/CoursePageTest.php`** — assert `customer_update[address]`/`[name]` are `'auto'` and tax-ID collection is enabled. These assertions fail without the fix (Cashier sets `name` but not `address`).

The mocked Stripe client in the tests never hits the real API, which is why this bug never surfaced in the suite previously.

## Testing

- `php artisan test --compact tests/Feature/CoursePageTest.php` — 9 passed
- `vendor/bin/pint --dirty` — clean