### PR TITLE
Update Vibes prospectus contact email to support@nativephp.com

### DIFF
--- a/resources/views/the-vibes-prospectus.blade.php
+++ b/resources/views/the-vibes-prospectus.blade.php
@@ -247,7 +247,7 @@
 
                 <p class="text-xs font-bold uppercase tracking-wide text-violet-500 dark:text-violet-400">Email</p>
                 <p class="mb-4">
-                    <a href="mailto:sponsors@nativephp.com" class="text-gray-700 hover:text-violet-500 dark:text-gray-300 dark:hover:text-violet-400">sponsors@nativephp.com</a>
+                    <a href="mailto:support@nativephp.com" class="text-gray-700 hover:text-violet-500 dark:text-gray-300 dark:hover:text-violet-400">support@nativephp.com</a>
                 </p>
 
                 <p class="text-xs font-bold uppercase tracking-wide text-violet-500 dark:text-violet-400">Event Page</p>


### PR DESCRIPTION
## What

Changes the contact email on the Vibes prospectus page (`/the-vibes-prospectus`) from `sponsors@nativephp.com` to `support@nativephp.com`.

Both the `mailto:` link and the visible link text are updated in `resources/views/the-vibes-prospectus.blade.php`.

## Why

Prospectus enquiries should route to the `support@` inbox rather than the `sponsors@` address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)