### PR TITLE
docs(mobile/v4): Architecture section — SuperNative white papers

### DIFF
--- a/resources/views/docs/mobile/4/architecture/_index.md
+++ b/resources/views/docs/mobile/4/architecture/_index.md
@@ -1,0 +1,4 @@
+---
+title: Architecture
+order: 80
+---

--- a/resources/views/docs/mobile/4/architecture/about-the-new-architecture.md
+++ b/resources/views/docs/mobile/4/architecture/about-the-new-architecture.md
@@ -1,0 +1,75 @@
+---
+title: About the New Architecture
+order: 10
+---
+
+Since v1, NativePHP for Mobile has run your Laravel app on the device itself — no server, no network round-trip. In
+v3 and earlier, your app's UI rendered as HTML inside a web view. That model is productive and familiar, and it's
+[still fully supported](../super-native/introduction#is-the-web-view-still-an-option). But it puts a browser between
+your app and the platform, and some things can only feel truly native when they *are* native.
+
+The new architecture — [SuperNative](../super-native/introduction) — removes that layer entirely. Your screens are
+real SwiftUI and Jetpack Compose views, created and updated directly by your PHP code. Here's why we built it, and
+what it changes.
+
+## Why a new architecture?
+
+### Truly native rendering
+
+A web view is a remarkable piece of engineering, but users can tell. Scroll physics, text rendering, transitions,
+context menus, dark mode, dynamic type, screen readers — every one of these is approximated in a browser and
+effortless in the platform's own UI framework.
+
+With the new architecture, an EDGE component like `<native:button>` isn't a styled `<div>` — it's the same button
+every other native app on that device uses. Accessibility, theming and platform conventions come along for free,
+because there's nothing between your UI and the operating system.
+
+### Shared memory, not serialization
+
+Frameworks that drive native UI from another language usually pay a toll at the border: state gets serialized to
+JSON, shipped across a bridge, and parsed on the other side — for every update.
+
+NativePHP doesn't have that border. Your PHP runtime is [embedded inside the app process](embedded-php), and the
+rendering layer communicates through **shared memory**. When your component re-renders, PHP writes a compact binary
+description of the screen directly into a buffer the native side reads from — no JSON, no sockets, no copies across
+a bridge. The native layer walks your PHP data structures directly, in the same process, in native code.
+
+The result: a state change in PHP reaches the screen in well under a frame.
+
+### Native-speed interaction
+
+Some things should never wait for application code — a drag should track your finger, an animation should never
+drop a frame. The new architecture has a dedicated lane for these:
+SharedValues live on the native side and are updated on the UI thread by gestures and animations at the display's
+full frame rate. PHP holds a handle and hears about the outcome; the
+per-frame work never crosses into PHP at all.
+
+You get Reanimated-style, gesture-driven motion — written in Blade.
+
+## What can you expect?
+
+Practically, the same development experience you already have, with a different result on screen:
+
+- **Same Laravel app.** Routes, controllers, Eloquent, validation, queues — nothing about your backend changes.
+  Screens are registered with `Route::native()` and driven by PHP component classes, Livewire-style.
+- **Same Blade.** You compose screens from [EDGE components](../edge-components/introduction) — declarative Blade
+  tags with Tailwind-style utility classes — and the framework turns them into SwiftUI and Compose.
+- **Native output.** Navigation stacks, tab bars, sheets, lists and gestures are the platform's own, in light and
+  dark mode, with the platform's accessibility support built in.
+- **Adopt at your pace.** The web view is still available as a component, so you can go all-native, all-web, or
+  migrate screen by screen.
+
+<aside>
+
+The new architecture makes a different *class* of app possible — it doesn't automatically make an existing web-view
+app faster. If your app is happy in the web view, it will keep working exactly as before.
+
+</aside>
+
+## Should you use it today?
+
+SuperNative is **the default** in v4: new apps render native screens from the very first route. It's in beta, so
+expect rapid iteration — and if you'd rather wait, [opting out](../super-native/introduction#is-the-web-view-still-an-option)
+is one route and one component.
+
+Ready to go deeper? Start with [The Renderer](renderer).

--- a/resources/views/docs/mobile/4/architecture/cross-platform-implementation.md
+++ b/resources/views/docs/mobile/4/architecture/cross-platform-implementation.md
@@ -1,0 +1,57 @@
+---
+title: Cross-Platform Implementation
+order: 40
+---
+
+NativePHP renders with each platform's own UI framework — SwiftUI on iOS, Jetpack Compose on Android — yet one
+Blade template produces the same screen on both. That consistency isn't achieved by testing hard; it's achieved by
+sharing the core.
+
+## One core, two thin shells
+
+Everything that defines *what* gets rendered lives in a single shared implementation, written in C and
+[compiled directly into the PHP runtime](embedded-php) that ships on both platforms:
+
+- walking your PHP element trees and encoding them into [frames](glossary#frame),
+- the binary [node](glossary#node) format itself — every field, in the same order, with the same meaning,
+- the skip-and-reuse logic described in [Subtree Reuse](subtree-reuse),
+- and the [event channel](glossary#wire-events) that carries interactions back to PHP.
+
+What remains per platform is deliberately thin: a reader that decodes frames and diffs trees, and a renderer that
+maps each node type to a SwiftUI view or a composable. Even those two layers are written as mirrors of each other
+— the same diffing rules, the same frame-coalescing behavior, the same enums for flexbox values, so
+`justify-content: center` is the identical byte on the wire and the identical concept on both screens.
+
+The practical consequence: when we fix a bug or land a performance improvement in the pipeline, both platforms get
+it simultaneously, because there's only one pipeline.
+
+## Native layout on both platforms
+
+Layout follows the same philosophy. Each node carries flexbox-style layout values, and each platform implements
+flexbox *inside its own layout system* — a pure-Swift `Layout` on iOS and a Compose `Layout` on Android, built to
+the same semantics. There's no shared C++ layout engine sitting apart from the UI framework: your components
+measure and place like any other SwiftUI or Compose view, which is exactly why safe areas, dynamic type and
+platform navigation transitions work naturally with them.
+
+iOS is the reference implementation for visual behavior; Android is held to it. Where the platforms disagree by
+default (text padding, stretch behavior, pixel-versus-point units), the Android renderer adapts so the same
+classes produce the same result.
+
+## Two seams, one boundary
+
+Rendering isn't the only traffic between PHP and native. Device features — camera, biometrics, geolocation,
+secure storage and everything the [plugin system](../plugins/introduction) exposes — travel over a separate,
+simpler seam: [bridge functions](../plugins/bridge-functions), a registry of named native functions PHP can call
+with JSON in and JSON out.
+
+The two seams are independent by design. The rendering path is a hot loop measured in microseconds, so it gets the
+binary shared-memory treatment; device APIs are occasional calls where clarity and extensibility matter more, so
+they get a friendly, pluggable interface. Plugin authors only ever touch the second one.
+
+## Failing loud, not weird
+
+A shared binary format is only safe if both sides agree on it, so the format carries an explicit **version
+number**. At startup, each native reader checks the version reported by the Element Runtime against the one it was
+compiled for; on mismatch it refuses to render rather than misinterpret bytes. Because the PHP runtime and the
+native shells [ship together in lockstep](embedded-php), the check should never fire in a real app — it exists so
+that if the impossible happens, you get one clear error instead of a subtly broken UI.

--- a/resources/views/docs/mobile/4/architecture/embedded-php.md
+++ b/resources/views/docs/mobile/4/architecture/embedded-php.md
@@ -1,0 +1,69 @@
+---
+title: Embedded PHP
+order: 70
+---
+
+There's no server in a NativePHP app — and no separate PHP process either. PHP ships *inside* your app as a
+library, compiled specifically for mobile devices and linked into the native application itself. This page
+explains what that build is, why we produce it ourselves, and how it reaches your project.
+
+## PHP as a library
+
+Standard PHP is built to sit behind a web server. Mobile PHP is built with the **embed SAPI**: instead of a
+`php` binary, the build produces a C library (`libphp`) that the Swift and Kotlin shells link against and call
+directly. When your app boots, it initializes the PHP engine in-process, loads your Laravel app from the bundled
+[app package](../getting-started/introduction), and keeps it resident as the
+[persistent runtime](threading-model#lifecycle-booted-once-kept-warm).
+
+Running in-process is what makes the rest of the architecture possible: shared memory only works when both sides
+share a process. It's also simply fast — there's no FastCGI, no sockets, no per-request process to spawn.
+
+NativePHP for Mobile currently bundles **PHP 8.4**, cross-compiled for iOS (device and simulator) and Android
+(ARM64), thread-safe, and tuned for embedding.
+
+## Built in lockstep with the framework
+
+The renderer's [wire format](glossary#frame) has two sides: the [Element Runtime](glossary#element-runtime) that
+writes it, and the native readers that decode it. The Element Runtime is a PHP **extension** — native code
+compiled into `libphp` itself, alongside the engine.
+
+That's why we build PHP ourselves, and why every release of `nativephp/mobile` pins exact binary builds: the PHP
+engine, the NativePHP extension inside it, and the Swift/Kotlin readers around it are produced and shipped
+**together**, from matching sources. Both sides of every boundary are always the same version — there is no
+"which PHP works with which framework release" matrix to manage. The wire format's
+[version handshake](cross-platform-implementation#failing-loud-not-weird) exists as a backstop, but lockstep
+shipping is what makes it a formality.
+
+The same extension also provides the [bridge functions](../plugins/bridge-functions) seam that device APIs and
+plugins are built on — one native extension, both boundaries.
+
+## What's inside
+
+The builds include the extensions a Laravel app expects, statically compiled along with their dependencies:
+bcmath, ctype, curl, dom, fileinfo, filter, intl, mbstring, openssl, pdo_sqlite, phar, session, simplexml,
+sockets, sodium, sqlite3, tokenizer, xml, xmlreader, xmlwriter, zip and zlib — plus the `nativephp` extension
+described above. SQLite is the bundled database, a CA certificate bundle is included so HTTPS works out of the
+box, and ICU is included so localization and `intl`-powered formatting behave properly on device.
+
+Everything is compiled from source for each platform — including OpenSSL, libxml2, SQLite and friends — so the
+builds have no dependencies on whatever libraries happen to exist on a given device.
+
+## How it reaches your app
+
+You never build any of this yourself. When you run:
+
+```shell
+php artisan native:install
+```
+
+the framework downloads the prebuilt PHP bundles matching your `nativephp/mobile` version and places them into the
+platform projects — static libraries for iOS, shared libraries for Android. `native:run` then compiles your app
+with PHP inside it, exactly like any other native dependency.
+
+<aside>
+
+These builds are compiled specifically for mobile targets and can't be used as a general-purpose PHP — your
+development machine keeps using its own PHP for `artisan`, tests and tooling. Just make sure your app code is
+happy on the bundled PHP version.
+
+</aside>

--- a/resources/views/docs/mobile/4/architecture/glossary.md
+++ b/resources/views/docs/mobile/4/architecture/glossary.md
@@ -1,0 +1,106 @@
+---
+title: Glossary
+order: 80
+---
+
+Definitions for the terms used throughout the Architecture section.
+
+## SuperNative
+
+The engine behind native rendering in NativePHP for Mobile v4. It spans everything described in this section:
+components, the render pipeline, the shared-memory boundary and the platform renderers.
+[About the New Architecture](about-the-new-architecture) is the best starting point.
+
+## EDGE (Element Definition and Generation Engine)
+
+The component language: the suite of `native:` Blade components — layout containers, typography, forms, navigation
+chrome, overlays — that screens are built from. EDGE templates compile down to [Elements](#element);
+the renderer only ever sees the resulting tree. See [EDGE Components](../edge-components/introduction).
+
+## Native Component
+
+The PHP class that drives a screen — the Livewire-style component you register with `Route::native()`. It holds
+the screen's state, renders the [Element Tree](#element-tree), and its methods are what event handlers like
+`@press` call.
+
+## Element
+
+A plain PHP object describing one piece of UI — a column, a text, a button — including its layout, style, props
+and handlers. Primitive elements are what appear in the Element Tree; higher-level EDGE components flatten into
+them during rendering.
+
+## Element Tree
+
+The tree of Elements produced by a Native Component's `render()` — the PHP-side description of the entire screen.
+The input to the [Publish phase](render-publish-mount#phase-2-publish).
+
+## Element Runtime
+
+The native code compiled into the [embedded PHP](embedded-php) runtime (as part of the `nativephp` extension) that
+implements the PHP side of rendering: encoding Element Trees into [frames](#frame), managing the shared memory
+region, and carrying [wire events](#wire-events) back to PHP.
+
+## Frame
+
+One published snapshot of the screen: the binary encoding of an Element Tree, written into shared memory as a
+sequence of [nodes](#node) plus their props. Frames are versioned, skipped when identical to their predecessor,
+and shrunk by [subtree reuse](subtree-reuse).
+
+## Node
+
+The fixed-layout binary record representing one Element inside a frame — its type, layout values, style values and
+references to its props and callbacks. Because every node has the same shape, the native readers can decode frames
+extremely quickly, and both platforms interpret every field identically.
+
+## Node Tree
+
+The native-side tree the readers decode from a frame and hand to the platform renderers. The previous Node Tree is
+what incoming frames are diffed against, and what reuse markers splice from.
+
+## Renderers
+
+The per-platform layer that maps each node type to real UI: SwiftUI views on iOS and composables on Android, each
+with a native flexbox implementation built on the platform's own `Layout` system. See
+[Cross-Platform Implementation](cross-platform-implementation).
+
+## Runloop
+
+The long-lived cycle that drives a native screen on the [PHP thread](threading-model): render → publish → wait for
+an event → dispatch it → repeat. A screen's runloop lives for as long as the screen does.
+
+## Persistent Runtime
+
+The embedded PHP instance that boots your Laravel app once at launch and stays resident for the app's lifetime.
+Separate runtimes exist for queue workers and plugin background work. See
+[Threading Model](threading-model#lifecycle-booted-once-kept-warm).
+
+## Callback ID
+
+The stable identifier assigned to an event handler (like `@press="refresh"`) during rendering. Nodes reference
+handlers by ID, native events carry the ID back, and PHP resolves it to your method. Stable IDs are also what let
+unchanged subtrees be [reused](subtree-reuse) even though they contain handlers.
+
+## Wire Events
+
+The ordered event channel from native to PHP: presses, text changes, toggles, scrolls, system back, lifecycle
+signals and plugin events all travel through it as compact binary messages, waking the runloop exactly when
+there's something for your code to do.
+
+## SharedValue
+
+A value that lives on the native side and is updated on the UI thread — by gestures or animations — at the
+display's full frame rate. PHP holds a handle, binds it to animatable props in Blade, and receives discrete events
+when something meaningful happens. The mechanism behind PHP-free interaction, described in
+[Render, Publish, and Mount](render-publish-mount#native-side-state-updates).
+
+## Bridge Functions
+
+The second, simpler PHP↔native seam: a registry of named native functions (camera, biometrics, geolocation, and
+everything plugins add) that PHP calls with JSON parameters. Independent from the rendering path — see
+[Cross-Platform Implementation](cross-platform-implementation#two-seams-one-boundary) and the
+[plugin docs](../plugins/bridge-functions).
+
+## Embed SAPI
+
+The PHP build mode that produces PHP as an embeddable C library instead of a standalone binary, allowing the
+native app to run PHP inside its own process. The foundation of [Embedded PHP](embedded-php).

--- a/resources/views/docs/mobile/4/architecture/overview.md
+++ b/resources/views/docs/mobile/4/architecture/overview.md
@@ -1,0 +1,44 @@
+---
+title: Architecture Overview
+order: 1
+---
+
+Welcome! This section is a look under the hood of [SuperNative](../super-native/introduction), the engine that powers
+native rendering in NativePHP for Mobile v4. It explains how your Blade templates become real SwiftUI and Jetpack
+Compose views, how state flows between PHP and the screen, and why the whole thing is fast.
+
+<aside>
+
+You **don't** need to read any of this to build apps with NativePHP. If you're here to ship an app, start with the
+[Quick Start](../getting-started/quick-start) and [The Basics](../the-basics/overview) instead. This section is for
+the curious — and for plugin authors and contributors who want to understand the machinery they're building on.
+
+</aside>
+
+These pages describe the internals as they exist today. SuperNative is in beta and moving quickly, so details may
+evolve — the concepts, however, are stable.
+
+## Table of Contents
+
+- [About the New Architecture](about-the-new-architecture) — why we rebuilt rendering from the ground up, and what
+  it means for your apps.
+
+### Rendering
+
+- [The Renderer](renderer) — the rendering system at the heart of SuperNative, and the goals that shaped it.
+- [Render, Publish, and Mount](render-publish-mount) — the three-phase pipeline that turns your PHP into pixels.
+- [Cross-Platform Implementation](cross-platform-implementation) — how one shared core keeps iOS and Android in
+  perfect agreement.
+- [Subtree Reuse](subtree-reuse) — the optimizations that make re-rendering cheap, automatically.
+- [Threading Model](threading-model) — which threads do what, and how your UI stays responsive.
+
+### Build Tools
+
+- [Embedded PHP](embedded-php) — how a full PHP runtime ends up inside your app, built in lockstep with the
+  framework.
+
+### Reference
+
+- [Glossary](glossary) — every term used in these pages, defined in one place.
+
+If anything here is unclear or you'd like more depth on a particular topic, we'd love to hear from you.

--- a/resources/views/docs/mobile/4/architecture/render-publish-mount.md
+++ b/resources/views/docs/mobile/4/architecture/render-publish-mount.md
@@ -1,0 +1,87 @@
+---
+title: Render, Publish, and Mount
+order: 30
+---
+
+The render pipeline is the sequence of steps that turns your PHP into pixels. It has three phases:
+
+1. **Render** — PHP builds an [Element Tree](glossary#element-tree) describing what the screen should look like.
+2. **Publish** — the [Element Runtime](glossary#element-runtime) encodes that tree into a binary
+   [frame](glossary#frame) in shared memory and signals the native side.
+3. **Mount** — the native side works out what changed and updates the SwiftUI or Compose view tree.
+
+The same pipeline runs for the first paint of a screen and for every update after it. Let's follow a concrete
+component through it.
+
+@verbatim
+```blade
+<native:screen>
+    <native:column class="p-4 gap-4">
+        <native:text class="text-2xl font-bold">{{ $title }}</native:text>
+        <native:button label="Refresh" @press="refresh" />
+    </native:column>
+</native:screen>
+```
+@endverbatim
+
+## Phase 1: Render
+
+When a screen starts — or when its state changes — the framework calls your component's `render()` method. Blade
+compiles the template, and each `native:` tag emits an **Element**: a plain PHP object describing one piece of UI.
+Utility classes like `p-4` and `text-2xl` are parsed into concrete layout and style values at this stage, and
+event handlers like `@press="refresh"` are registered and replaced with stable
+[callback IDs](glossary#callback-id).
+
+The result is the Element Tree — for our example: a screen containing a column containing a text and a button.
+Higher-level EDGE components you compose yourself flatten into these primitives; only primitive elements appear in
+the tree.
+
+## Phase 2: Publish
+
+The Element Tree is handed to the Element Runtime — native code living inside the PHP runtime. It walks the tree
+and writes each element into shared memory as a [node](glossary#node): a compact, fixed-layout binary record
+carrying the element's type, layout, style, and references to its props and handlers.
+
+Before signaling the other side, the runtime is ruthless about not doing unnecessary work:
+
+- If the new frame is **byte-for-byte identical** to the previous one, nothing is published at all.
+- If only part of the tree changed, unchanged subtrees are replaced by tiny **reuse markers** instead of being
+  re-encoded — see [Subtree Reuse](subtree-reuse).
+
+If anything did change, the runtime atomically bumps the frame version and wakes the native reader. All of this
+happens on the [PHP thread](threading-model), off the UI.
+
+## Phase 3: Mount
+
+On the native side, a dedicated reader thread picks up the frame, decodes the nodes, and **diffs** the result
+against the tree it rendered last time. Reuse markers are spliced from the previous tree without any decoding.
+The diffed tree is then handed to the main thread, where SwiftUI or Compose re-renders exactly the views whose
+nodes changed — everything else keeps its identity, its state and its in-flight animations.
+
+Layout happens here too, inside the platform's own layout pass: the flexbox values carried by each node
+(direction, gap, padding, flex grow…) drive a native `Layout` implementation on each platform, and the OS
+composites the result to the screen.
+
+## State updates
+
+Interaction runs the same pipeline in a loop. When someone taps our **Refresh** button:
+
+1. The native button fires a press event carrying its callback ID into the
+   [event channel](glossary#wire-events).
+2. The PHP thread — which was waiting for exactly this — wakes up, resolves the callback ID to your `refresh()`
+   method, and calls it.
+3. Your method mutates component state; the framework re-renders (**Phase 1**), publishes the new frame
+   (**Phase 2**), and the native side mounts the difference (**Phase 3**).
+
+Because callback IDs are stable across frames and unchanged subtrees are reused, an update that changes one line
+of text costs about as much as… changing one line of text.
+
+## Native-side state updates
+
+Some state changes never enter the pipeline at all. Scroll positions, drag offsets and
+[SharedValue](glossary#sharedvalue)-driven animations are owned by the native side and updated directly on the UI
+thread, frame by frame. PHP isn't consulted per frame — it receives a discrete event when something it cares
+about happens (a drag ends, a threshold is crossed) and can then run the normal three phases in response.
+
+This split is what keeps gestures glued to your finger even while your PHP code is busy doing something else —
+more on that in the [Threading Model](threading-model).

--- a/resources/views/docs/mobile/4/architecture/renderer.md
+++ b/resources/views/docs/mobile/4/architecture/renderer.md
@@ -1,0 +1,62 @@
+---
+title: The Renderer
+order: 20
+---
+
+The renderer is the machinery at the heart of SuperNative: everything involved in turning the
+[Element Tree](glossary#element-tree) your PHP code produces into native views on screen. It spans three layers
+that work as one:
+
+- The **[Element Runtime](glossary#element-runtime)** — native code compiled into the PHP runtime itself. It walks
+  your element tree, encodes it into a compact binary [frame](glossary#frame), and manages the shared memory both
+  sides communicate through.
+- The **native readers** — a small Swift and Kotlin layer on each platform that receives frames, works out what
+  changed since the last one, and hands the result to the UI.
+- The **platform renderers** — SwiftUI on iOS and Jetpack Compose on Android, which map each
+  [node](glossary#node) to a real platform view and lay everything out.
+
+The pipeline they form — render, publish, mount — has [its own page](render-publish-mount). This page covers the
+goals that shaped the design.
+
+## Motivations and benefits
+
+- **One process, zero serialization.** PHP and the UI live in the same process and share memory. Publishing a
+  frame means writing bytes into a buffer, not encoding JSON and shipping it over a bridge. The Element Runtime
+  reads your PHP arrays directly in native code, so even the encoding step is fast.
+
+- **The platform's own layout system.** Layout is implemented natively on each platform — a pure-Swift flexbox
+  built on SwiftUI's `Layout` protocol, and a matching Compose `Layout` on Android. There's no third-party layout
+  engine in the middle: your components participate in SwiftUI and Compose layout as first-class citizens, which
+  means platform features like safe areas, dynamic type and keyboard avoidance behave the way the OS intends.
+  Both implementations follow the same flexbox semantics, so `justify-center` means precisely the same thing on
+  both platforms.
+
+- **Only changes hit the screen.** The renderer is built around the idea that most frames look a lot like the
+  previous frame. Identical frames are skipped before they're even published; unchanged subtrees are
+  [reused rather than re-sent](subtree-reuse); and the native readers diff each incoming frame so the UI only
+  re-renders what actually changed.
+
+- **A versioned, type-safe wire format.** Every node crosses the boundary as a fixed-layout binary record, and the
+  format carries an explicit version number. At startup, the native readers check that version against the one
+  they were built for — a mismatch fails loudly and immediately rather than rendering garbage. Because
+  [PHP and the framework are built together](embedded-php), both sides of the boundary always speak the same
+  version in practice; the handshake is the backstop.
+
+- **Consistency across platforms by construction.** The encoding, diffing rules and event format are implemented
+  once, in [shared native code](cross-platform-implementation), and the per-platform layers are deliberately thin.
+  When we improve the pipeline, both platforms get the improvement at the same time.
+
+- **Interactions that don't wait for PHP.** Press feedback, gestures and [SharedValue](glossary#sharedvalue)-driven
+  animations are handled on the native side at full frame rate. PHP is woken for the things application code
+  actually cares about — a press, a committed drag, a text change — through a single ordered
+  [event channel](glossary#wire-events).
+
+## Where components come from
+
+The renderer doesn't know about Blade — it only ever sees element trees. The
+[EDGE](../edge-components/introduction) component layer (templates, Tailwind-style classes, slots, chrome like top
+bars and tab bars) compiles down to the same primitive elements whether you write Blade tags or build elements in
+PHP code. That separation is deliberate: the component language can grow rich while the wire format underneath
+stays small, stable and fast.
+
+Next: follow a screen through the pipeline in [Render, Publish, and Mount](render-publish-mount).

--- a/resources/views/docs/mobile/4/architecture/subtree-reuse.md
+++ b/resources/views/docs/mobile/4/architecture/subtree-reuse.md
@@ -1,0 +1,65 @@
+---
+title: Subtree Reuse
+order: 50
+---
+
+Declarative UI encourages a simple mental model: describe the whole screen, every time. Your component's
+`render()` doesn't compute a diff — it returns the full [Element Tree](glossary#element-tree), whether one
+character changed or everything did.
+
+Taken literally, that model would be wasteful: a ticking clock in a top bar would re-encode and re-render an
+entire screen once a second. Subtree reuse is the set of optimizations that keeps the simple mental model *and*
+the performance — and like the rest of the pipeline, it's automatic. You never opt in, and the rendered output is
+pixel-identical.
+
+## Three layers of "don't repeat yourself"
+
+**1. Whole-frame skip.** After encoding a [frame](glossary#frame), the
+[Element Runtime](glossary#element-runtime) compares it byte-for-byte against the previous one. Identical frames
+are dropped on the spot — the native side is never even woken. Idle re-renders (a poll that found nothing new, a
+handler that didn't change state) cost almost nothing.
+
+**2. Subtree reuse markers.** When a frame *does* change, most of it usually hasn't. During the render phase, every
+element computes a compact fingerprint of itself and its children — a content hash. At publish time, any subtree
+whose fingerprint matches the previous frame is written as a single tiny **reuse marker** instead of being
+re-encoded; its children don't appear in the frame at all. The native reader splices the corresponding subtree
+from the tree it already has, without decoding anything. A one-line text change publishes a handful of nodes, not
+a screen's worth.
+
+**3. Diffing at mount.** Whatever does arrive still gets diffed against the previous native tree before touching
+the UI, so SwiftUI and Compose re-render only the views whose nodes actually differ. Views that survive the diff
+keep their identity — along with their scroll positions, focus and running animations.
+
+## Helping the diff: keys
+
+Reuse works by matching nodes between frames, and matching needs identity. By default, elements are identified by
+their position in the tree, which is perfect for static structure. For dynamic lists, give elements a **key** —
+just like you would in Livewire or React:
+
+@verbatim
+```blade
+@foreach ($messages as $message)
+    <native:card :native:key="$message->id">
+        <native:text>{{ $message->body }}</native:text>
+    </native:card>
+@endforeach
+```
+@endverbatim
+
+With keys, inserting a message at the top of the list is understood as *one new card* rather than *every card
+changed* — the other subtrees match their fingerprints from the previous frame and travel as reuse markers.
+
+## Free, by design
+
+Fingerprinting happens as part of the normal render walk, the byte comparison as part of the normal publish, and
+the splice as part of the normal decode — there's no separate "optimization pass" burning cycles. And because all
+three layers live in the [shared core](cross-platform-implementation), iOS and Android benefit identically, on
+every frame, by default.
+
+<aside>
+
+There's one deliberate exception to "never resend": the runtime periodically forces a full frame, and always does
+so after navigation, reset or hot reload. That heartbeat guarantees the two sides can never drift apart — reuse is
+an optimization, never a source of truth.
+
+</aside>

--- a/resources/views/docs/mobile/4/architecture/threading-model.md
+++ b/resources/views/docs/mobile/4/architecture/threading-model.md
@@ -1,0 +1,69 @@
+---
+title: Threading Model
+order: 60
+---
+
+A native app feels native when the UI thread is never kept waiting. SuperNative achieves that by giving every kind
+of work its own lane and keeping the hand-offs between lanes tiny.
+
+## The three threads
+
+**The PHP thread.** All of your application code runs on a single dedicated thread that lives as long as your app
+does. It hosts the [persistent runtime](glossary#persistent-runtime) — PHP, Composer and Laravel are booted once,
+then kept warm. For each native screen, this thread runs the [runloop](glossary#runloop): render, publish, then
+sleep until an event arrives. Between events it costs nothing.
+
+**The reader thread.** Each platform has a background thread that receives published [frames](glossary#frame),
+decodes them, and diffs them against the previous tree. It also **coalesces**: if PHP publishes several frames
+while a diff is in progress, intermediate frames are dropped and only the newest is processed — the screen always
+jumps to the latest state instead of queueing through stale ones.
+
+**The UI thread.** The platform's main thread is the only one that touches views. It receives the diffed tree from
+the reader thread and lets SwiftUI or Compose re-render the changed parts. Because encoding, decoding and diffing
+all happened elsewhere, the UI thread's share of an update is as small as it can be.
+
+## How a typical update flows
+
+A tap lands on the UI thread → the press event is posted to the [event channel](glossary#wire-events) → the PHP
+thread wakes, runs your handler, re-renders and publishes → the reader thread diffs → the UI thread mounts the
+change. Four hand-offs, each passing a small, well-defined payload — and at no point does the UI thread wait on
+PHP.
+
+## When PHP isn't consulted at all
+
+Continuous interactions never make that trip per frame:
+
+- **Gestures and animations** driven by [SharedValues](glossary#sharedvalue) are evaluated directly on the UI
+  thread at the display's frame rate. A drag updates its SharedValue and every view bound to it, natively; PHP
+  receives one event when the gesture completes.
+- **Scrolling, press feedback and transitions** are the platform's own, running exactly where the platform runs
+  them.
+
+Your PHP code could be querying the database mid-drag and the drag wouldn't stutter — the lanes don't share a
+queue.
+
+## Background work
+
+Laravel queues run on their own embedded PHP instance — a separate **worker runtime** with its own thread,
+processing jobs with `queue:work` semantics. A heavy job can't block a button press, because it isn't sharing a
+runtime with the UI's PHP thread. Plugins can request additional short-lived runtimes for their own background
+work.
+
+## Lifecycle: booted once, kept warm
+
+Booting a framework is the expensive part, so SuperNative avoids ever doing it twice:
+
+- The persistent runtime boots on first launch and stays resident. Every screen, navigation and event reuses the
+  already-booted Laravel app.
+- On Android, where the OS routinely destroys and re-creates the activity (rotation, theme change, backgrounding),
+  the runtime is **parked** rather than torn down: the runloop is asked to exit via a shutdown event, PHP stays
+  booted, and the re-created activity re-attaches to it. Re-opening your app is a re-attach, not a re-boot.
+- Hot reload during development is the one case where the runtime is genuinely restarted — with your navigation
+  stack saved and restored around it.
+
+<aside>
+
+The PHP thread is singular on purpose. One writer, one ordered event queue, and atomic version counters on the
+shared region mean the two worlds stay consistent without your code ever thinking about locks.
+
+</aside>


### PR DESCRIPTION
## What's this?

A new **Architecture** docs section for Mobile v4 (`docs/mobile/4/architecture/`, sidebar order 80 — after Testing), in the spirit of [React Native's architecture docs](https://reactnative.dev/architecture/overview): conceptual white papers on how SuperNative works under the hood, aimed at the curious, plugin authors, and contributors — explicitly *not* required reading for building apps.

## Pages

| Page | Covers |
|---|---|
| Architecture Overview | Hub page + table of contents |
| About the New Architecture | Why we moved from the web view to native rendering; what to expect |
| The Renderer | The rendering system's three layers and the goals that shaped it |
| Render, Publish, and Mount | The three-phase pipeline from PHP to pixels, with a worked example |
| Cross-Platform Implementation | The shared core, thin platform shells, the two PHP↔native seams, fail-loud versioning |
| Subtree Reuse | Whole-frame skip, reuse markers, diffing, and `:native:key` |
| Threading Model | PHP thread / reader thread / UI thread, SharedValue lanes, park-and-reuse lifecycle |
| Embedded PHP | The lockstep custom PHP builds (embed SAPI, bundled extensions, `native:install`) |
| Glossary | Every term used in the section, defined in one place |

## Notes

- Facts verified against the actual sources (`mobile-air`, the native shells, `build-scripts`) — describes the current Element Runtime, not the legacy pipeline.
- Follows existing docs conventions: `title`/`order` frontmatter, `<aside>` callouts, `@verbatim` Blade fences, relative links into SuperNative / EDGE / Plugins sections.
- Kept deliberately non-technical: concepts over byte counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)