### PR TITLE
feat(docs): App/Universal Links for Jump docs deep-linking

### DIFF
--- a/app/Http/Controllers/ApplinksController.php
+++ b/app/Http/Controllers/ApplinksController.php
@@ -4,52 +4,85 @@ namespace App\Http\Controllers;
 
 class ApplinksController extends Controller
 {
+    /**
+     * Jump's iOS app identity: <TeamID>.<BundleID>.
+     */
+    private const IOS_APP_ID = 'J68WFCX458.com.bifrosttech.jump';
+
+    /**
+     * Jump's Android package + the SHA-256 of its Play app-signing cert.
+     * These are public identifiers, not secrets.
+     */
+    private const ANDROID_PACKAGE = 'com.bifrosttech.jump';
+
+    private const ANDROID_SHA256 = 'D8:31:4E:55:E5:FF:06:17:D8:49:EA:3B:1F:BF:6C:58:B3:8D:AD:2C:30:CA:13:D2:CA:42:B0:85:B4:7D:CB:38';
+
+    /**
+     * URL path prefixes that open in Jump.
+     *
+     * Only add a prefix here once Jump has a screen that can render it —
+     * an unhandled deep link drops the user on a broken state. Each entry
+     * added here needs a matching <data> intent-filter in Jump's Android
+     * manifest (iOS scopes via this file; Android scopes via the manifest).
+     */
+    private const LINK_PATHS = [
+        '/docs/*' => 'Open documentation pages in Jump',
+        // '/blog/*' => 'Open blog posts in Jump',   // add when Jump can render them
+    ];
+
+    /**
+     * Android App Links verification (served at /.well-known/assetlinks.json).
+     *
+     * Path scoping is declared in Jump's manifest intent-filter, not here —
+     * this file only asserts that the app may handle links for this domain.
+     */
     public function assetLinks()
     {
-        $array = [
+        return response()->json([
             [
                 'relation' => [
                     'delegate_permission/common.handle_all_urls',
+                    'delegate_permission/common.get_login_creds',
                 ],
                 'target' => [
                     'namespace' => 'android_app',
-                    'package_name' => config('nativephp.app_id'),
+                    'package_name' => self::ANDROID_PACKAGE,
                     'sha256_cert_fingerprints' => [
-                        config('services.certFingerprint'),
+                        self::ANDROID_SHA256,
                     ],
                 ],
             ],
-        ];
-
-        return response('[
-  {
-    "relation": [
-      "delegate_permission/common.handle_all_urls"
-    ],
-    "target": {
-      "namespace": "android_app",
-      "package_name": "com.nativephp.kitchensinkapp",
-      "sha256_cert_fingerprints": [
-        "D3:C4:F7:5E:B2:3C:95:90:89:BE:CB:47:0B:B2:9F:40:A5:22:6B:03:A3:C9:1D:B2:8B:B6:1F:06:87:C8:86:AA"
-      ]
-    }
-  }
-]', headers: ['Content-Type' => 'application/json']);
+        ]);
     }
 
+    /**
+     * iOS Universal Links (served at /.well-known/apple-app-site-association).
+     *
+     * Claims only the LINK_PATHS prefixes; the rest of nativephp.com stays in
+     * the browser. webcredentials is domain-wide for password autofill.
+     */
     public function appSiteAssociation()
     {
+        $components = [];
+
+        foreach (self::LINK_PATHS as $pattern => $comment) {
+            $components[] = [
+                '/' => $pattern,
+                'comment' => $comment,
+            ];
+        }
+
         return response()->json([
             'applinks' => [
                 'details' => [
                     [
-                        'appIDs' => [config('services.apple.app_id')],
-                        'paths' => ['*'],
+                        'appIDs' => [self::IOS_APP_ID],
+                        'components' => $components,
                     ],
                 ],
             ],
             'webcredentials' => [
-                'apps' => [config('services.apple.webcredentials')],
+                'apps' => [self::IOS_APP_ID],
             ],
         ]);
     }

--- a/app/Services/DocsSearchService.php
+++ b/app/Services/DocsSearchService.php
@@ -232,18 +232,30 @@ class DocsSearchService
 
     protected function stripBladeComponents(string $content): string
     {
-        // Remove <x-component>...</x-component> tags
-        $content = preg_replace('/<x-[^>]+>[\s\S]*?<\/x-[^>]+>/s', '', $content);
-        // Remove self-closing <x-component /> tags
-        $content = preg_replace('/<x-[^\/]+\/>/s', '', $content);
-        // Remove {{ }} blade echoes
-        $content = preg_replace('/\{\{.*?\}\}/s', '', $content);
-        // Remove {!! !!} unescaped echoes
-        $content = preg_replace('/\{!![\s\S]*?!!\}/s', '', $content);
-        // Remove @directives
-        $content = preg_replace('/@\w+(\([^)]*\))?/', '', $content);
+        // Fenced code blocks are preserved verbatim: they document the component
+        // API itself (<native:*> tags, @press/@change directives, {{ }} bindings),
+        // and Jump renders them as live examples. Only prose is cleaned — stripping
+        // directives from a code block turns `@press="save"` into `="save"`.
+        $segments = preg_split('/(```[\s\S]*?```)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
 
-        return $content;
+        foreach ($segments as $i => $segment) {
+            if (str_starts_with($segment, '```')) {
+                continue; // code block — leave untouched
+            }
+            // Remove <x-component>...</x-component> tags
+            $segment = preg_replace('/<x-[^>]+>[\s\S]*?<\/x-[^>]+>/s', '', $segment);
+            // Remove self-closing <x-component /> tags
+            $segment = preg_replace('/<x-[^\/]+\/>/s', '', $segment);
+            // Remove {{ }} blade echoes
+            $segment = preg_replace('/\{\{.*?\}\}/s', '', $segment);
+            // Remove {!! !!} unescaped echoes
+            $segment = preg_replace('/\{!![\s\S]*?!!\}/s', '', $segment);
+            // Remove @directives (@verbatim wrappers, @php, etc.)
+            $segment = preg_replace('/@\w+(\([^)]*\))?/', '', $segment);
+            $segments[$i] = $segment;
+        }
+
+        return implode('', $segments);
     }
 
     protected function extractHeadings(string $content): array

--- a/routes/web.php
+++ b/routes/web.php
@@ -443,6 +443,7 @@ Route::middleware('signed')->group(function (): void {
 });
 
 Route::get('.well-known/assetlinks.json', [ApplinksController::class, 'assetLinks']);
+Route::get('.well-known/apple-app-site-association', [ApplinksController::class, 'appSiteAssociation']);
 
 Route::post('webhooks/plugins/{secret}', PluginWebhookController::class)->name('webhooks.plugins');
 


### PR DESCRIPTION
Adds the server-side pieces so `nativephp.com/docs` pages open in the **Jump** app, and fixes native-component examples served over the MCP API.

## What's here

**Deep-link verification (Jump app)**
- New route + method serving `/.well-known/apple-app-site-association` (iOS Universal Links), scoped to `/docs/*` and Jump's appID `J68WFCX458.com.bifrosttech.jump`. The rest of the site stays in the browser.
- Rewrote `/.well-known/assetlinks.json` (Android App Links) for the Jump app — `com.bifrosttech.jump` + its release signing SHA-256.
- ⚠️ **Drops the old KitchenSink `assetlinks` entry** (was hard-coded, reported as no longer used). If anything still relies on KitchenSink App Links verification, flag it.

**MCP content fix**
- `DocsSearchService::stripBladeComponents` was running over the whole page, stripping `@press` / `@change` / `{{ }}` / `@verbatim` from **inside code blocks** — corrupting the documented native-component API in every example the MCP API serves (e.g. `<native:button @press="save" />` became `<native:button ="save" />`). Now it preserves fenced code verbatim and only cleans prose. Fixes example code for both v3 and v4 consumers (incl. Jump's in-app docs).

## Scope of `paths`
iOS AASA is driven by a `LINK_PATHS` allowlist (currently `/docs/*`). Adding a future section is a one-line change there plus a matching Android manifest entry in the app — only claim paths the app can actually render.

## Verified locally
- Both `.well-known` endpoints return `200` + `application/json`.
- Button example now returns `<native:button label="Get Started" @press="handleStart" />` intact.

## Not included
- QR generation on the docs site (intentionally deferred).
- The Jump app-side changes (resolver, version selector, live examples) live in the app repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)