### PR TITLE
fix(docs): escape example Blade expression in mobile v4 Text doc

### DIFF
--- a/resources/views/docs/mobile/4/edge-components/text.md
+++ b/resources/views/docs/mobile/4/edge-components/text.md
@@ -152,7 +152,7 @@ Use the `dark:` prefix with Tailwind classes or pass a dark-mode color override.
 
 <aside>
 
-Blade expressions like `{{ $variable }}` work inside text slots. The content is evaluated by PHP before being passed
+Blade expressions like `@{{ $variable }}` work inside text slots. The content is evaluated by PHP before being passed
 to the native renderer.
 
 </aside>

--- a/tests/Feature/DocumentationRenderingTest.php
+++ b/tests/Feature/DocumentationRenderingTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DocumentationRenderingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Doc pages contain fenced code blocks. Torchlight throws outside
+        // production when no token is configured (as in CI), so give it a token
+        // and fake the API to force its offline fallback.
+        config(['torchlight.token' => 'test-token']);
+        Http::fake([
+            '*' => Http::response(['blocks' => []], 200),
+        ]);
+    }
+
+    #[Test]
+    public function text_page_shows_example_blade_expression_literally_instead_of_evaluating_it(): void
+    {
+        $this->withoutVite()
+            ->get('/docs/mobile/4/edge-components/text')
+            ->assertOk()
+            ->assertSee('{{ $variable }}');
+    }
+
+    #[Test]
+    public function every_documentation_page_renders_without_evaluating_example_variables(): void
+    {
+        /** @var ViewFactory $factory */
+        $factory = resolve(ViewFactory::class);
+        $factory->addExtension('md', 'blade');
+
+        $base = resource_path('views/docs');
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $failures = [];
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'md' || str_starts_with($file->getBasename(), '_')) {
+                continue;
+            }
+
+            $view = 'docs/'.substr($file->getPathname(), strlen($base) + 1, -3);
+
+            try {
+                $factory->make($view, ['user' => null])->render();
+            } catch (\Throwable $e) {
+                $failures[$view] = $e->getMessage();
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $failures,
+            'Documentation pages must escape example Blade expressions with @{{ }} or @verbatim. '
+            .'These pages threw while rendering: '.json_encode($failures, JSON_PRETTY_PRINT),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The mobile v4 `Text` edge-component doc page (`/docs/mobile/4/edge-components/text`) was returning a **500** in production with `ErrorException: Undefined variable $variable`.

Documentation `.md` files are rendered **through the Blade engine before** markdown conversion (`ShowDocumentationController::getMarkdownView` maps `.md` → the `blade` engine). The "Dynamic content" `<aside>` contained an inline example in prose:

> Blade expressions like `` `{{ $variable }}` `` work inside text slots.

That `{{ $variable }}` was neither wrapped in `@verbatim` nor escaped, so Blade evaluated it as a real variable and threw. (Markdown backticks don't help — Blade runs first. The nearby `{{ $score }}` example was fine because it lives inside a `@verbatim` block.)

## Fix

Escape the inline expression with `@{{ }}` — the same convention already used elsewhere in the docs (e.g. `super-native/reactivity.md`). Blade now emits the literal `{{ $variable }}`, so the reader still sees the intended text and the page renders.

## Tests

`tests/Feature/DocumentationRenderingTest.php`:

- **Regression:** `GET /docs/mobile/4/edge-components/text` returns `200` and shows the literal `{{ $variable }}`.
- **Class-wide guard:** renders all 335 docs pages as Blade and asserts none throws — catching any other unescaped example expressions across the docs tree.

Both tests fail on the un-fixed doc (reproducing the exact `Undefined variable $variable` 500) and pass with the fix. Pint is clean.

Fixes #72