### PR TITLE
feat(blog): custom hero, OG and blog card images for articles

### DIFF
--- a/app/Filament/Forms/Components/ImageCropper.php
+++ b/app/Filament/Forms/Components/ImageCropper.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Filament\Forms\Components;
+
+use Closure;
+use Filament\Forms\Components\Field;
+
+class ImageCropper extends Field
+{
+    protected string $view = 'filament.forms.components.image-cropper';
+
+    protected string|Closure|null $imageUrl = null;
+
+    protected int|Closure $targetWidth = 1200;
+
+    protected int|Closure $targetHeight = 630;
+
+    protected bool|Closure $hasPendingImage = false;
+
+    /**
+     * The URL of the image the crop selection is made on.
+     */
+    public function imageUrl(string|Closure|null $url): static
+    {
+        $this->imageUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * The dimensions of the image that will be generated from the crop selection.
+     */
+    public function targetDimensions(int|Closure $width, int|Closure $height): static
+    {
+        $this->targetWidth = $width;
+        $this->targetHeight = $height;
+
+        return $this;
+    }
+
+    /**
+     * Whether the source image has been changed but not saved yet, meaning the
+     * crop selection can't be made until the record is saved.
+     */
+    public function hasPendingImage(bool|Closure $condition): static
+    {
+        $this->hasPendingImage = $condition;
+
+        return $this;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->evaluate($this->imageUrl);
+    }
+
+    public function getTargetWidth(): int
+    {
+        return $this->evaluate($this->targetWidth);
+    }
+
+    public function getTargetHeight(): int
+    {
+        return $this->evaluate($this->targetHeight);
+    }
+
+    public function getHasPendingImage(): bool
+    {
+        return (bool) $this->evaluate($this->hasPendingImage);
+    }
+}

--- a/app/Filament/Resources/ArticleResource.php
+++ b/app/Filament/Resources/ArticleResource.php
@@ -2,23 +2,30 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Forms\Components\ImageCropper;
 use App\Filament\Resources\ArticleResource\Actions\PreviewAction;
 use App\Filament\Resources\ArticleResource\Actions\PublishAction;
 use App\Filament\Resources\ArticleResource\Actions\UnpublishAction;
 use App\Filament\Resources\ArticleResource\Pages;
 use App\Models\Article;
+use App\Services\ArticleImageService;
 use Filament\Actions;
 use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class ArticleResource extends Resource
 {
@@ -30,10 +37,13 @@ class ArticleResource extends Resource
 
     protected static \BackedEnum|string|null $navigationIcon = 'heroicon-o-newspaper';
 
+    protected static ?string $navigationLabel = 'Blog';
+
+    protected static ?string $breadcrumb = 'Blog';
+
     public static function form(Schema $schema): Schema
     {
         return $schema
-            ->inlineLabel()
             ->columns(1)
             ->schema([
                 TextInput::make('title')
@@ -66,6 +76,46 @@ class ArticleResource extends Resource
                     ->required()
                     ->maxLength(400)
                     ->columnSpanFull(),
+
+                Section::make('Hero image')
+                    ->description('Shown at the top of the article and used to create the social sharing (OG) image and the blog card preview. When left empty, an OG image is generated automatically.')
+                    ->columns(1)
+                    ->schema([
+                        FileUpload::make('hero_image')
+                            ->label('Image')
+                            ->image()
+                            ->disk('public')
+                            ->directory('blog/heroes')
+                            ->maxSize(10240)
+                            ->rule(
+                                Rule::dimensions()
+                                    ->minWidth(ArticleImageService::OG_WIDTH)
+                                    ->minHeight(ArticleImageService::OG_HEIGHT)
+                            )
+                            ->live()
+                            ->helperText('At least '.ArticleImageService::OG_WIDTH.'×'.ArticleImageService::OG_HEIGHT.'px — upload the largest version you have; it will be scaled down if needed.'),
+
+                        ImageCropper::make('og_image_crop')
+                            ->label('Social (OG) image crop')
+                            ->targetDimensions(ArticleImageService::OG_WIDTH, ArticleImageService::OG_HEIGHT)
+                            ->imageUrl(fn (?Article $article) => $article?->getHeroImageUrl())
+                            ->hasPendingImage(fn (?Article $article, Get $get): bool => static::heroImageIsPending($article, $get))
+                            ->visible(fn (?Article $article) => filled($article?->hero_image)),
+
+                        ImageCropper::make('card_image_crop')
+                            ->label('Blog card crop')
+                            ->targetDimensions(ArticleImageService::CARD_WIDTH, ArticleImageService::CARD_HEIGHT)
+                            ->imageUrl(fn (?Article $article) => $article?->getHeroImageUrl())
+                            ->hasPendingImage(fn (?Article $article, Get $get): bool => static::heroImageIsPending($article, $get))
+                            ->visible(fn (?Article $article) => filled($article?->hero_image)),
+
+                        ImageCropper::make('header_image_crop')
+                            ->label('Article header crop')
+                            ->targetDimensions(ArticleImageService::HEADER_WIDTH, ArticleImageService::HEADER_HEIGHT)
+                            ->imageUrl(fn (?Article $article) => $article?->getHeroImageUrl())
+                            ->hasPendingImage(fn (?Article $article, Get $get): bool => static::heroImageIsPending($article, $get))
+                            ->visible(fn (?Article $article) => filled($article?->hero_image)),
+                    ]),
 
                 MarkdownEditor::make('content')
                     ->required()
@@ -111,6 +161,15 @@ class ArticleResource extends Resource
                 ]),
             ])
             ->defaultSort('published_at', 'desc');
+    }
+
+    /**
+     * Whether the hero image in the form state differs from the saved one,
+     * meaning crops can only be adjusted after saving.
+     */
+    protected static function heroImageIsPending(?Article $article, Get $get): bool
+    {
+        return ! in_array($article?->hero_image, Arr::wrap($get('hero_image')), true);
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/app/Filament/Resources/ArticleResource/Pages/CreateArticle.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\ArticleResource\Pages;
 
 use App\Filament\Resources\ArticleResource;
-use App\Services\OgImageService;
+use App\Services\ArticleImageService;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateArticle extends CreateRecord
@@ -12,13 +12,7 @@ class CreateArticle extends CreateRecord
 
     protected function afterCreate(): void
     {
-        $service = resolve(OgImageService::class);
-
-        $ogImageUrl = $service->generate($this->record);
-
-        $this->record->update([
-            'og_image' => $ogImageUrl,
-        ]);
+        resolve(ArticleImageService::class)->refreshImages($this->record);
     }
 
     protected function getRedirectUrl(): string

--- a/app/Filament/Resources/ArticleResource/Pages/EditArticle.php
+++ b/app/Filament/Resources/ArticleResource/Pages/EditArticle.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\ArticleResource\Pages;
 
 use App\Filament\Resources\ArticleResource;
-use App\Services\OgImageService;
+use App\Services\ArticleImageService;
 use Filament\Actions;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
@@ -14,16 +14,25 @@ class EditArticle extends EditRecord
 {
     protected static string $resource = ArticleResource::class;
 
+    /**
+     * When the hero image is replaced or removed, the stored crop selections
+     * relate to the old image, so reset them to the default.
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if (array_key_exists('hero_image', $data) && $data['hero_image'] !== $this->record->hero_image) {
+            $data['og_image_crop'] = null;
+            $data['card_image_crop'] = null;
+            $data['header_image_crop'] = null;
+        }
+
+        return $data;
+    }
+
     protected function afterSave(): void
     {
-        $service = resolve(OgImageService::class);
-
-        // Always regenerate the OG image on update to ensure it's current
-        $ogImageUrl = $service->generate($this->record);
-
-        $this->record->update([
-            'og_image' => $ogImageUrl,
-        ]);
+        // Always regenerate the OG and card images on update to ensure they're current
+        resolve(ArticleImageService::class)->refreshImages($this->record);
     }
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/ArticleResource/Pages/ListArticles.php
+++ b/app/Filament/Resources/ArticleResource/Pages/ListArticles.php
@@ -10,6 +10,8 @@ class ListArticles extends ListRecords
 {
     protected static string $resource = ArticleResource::class;
 
+    protected static ?string $title = 'Blog';
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\ArticleImageService;
 use DateTime;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -18,6 +19,12 @@ class Article extends Model
         'title',
         'excerpt',
         'og_image',
+        'hero_image',
+        'card_image',
+        'header_image',
+        'og_image_crop',
+        'card_image_crop',
+        'header_image_crop',
         'content',
         'published_at',
     ];
@@ -25,6 +32,15 @@ class Article extends Model
     public function getRouteKeyName()
     {
         return 'slug';
+    }
+
+    public function getHeroImageUrl(): ?string
+    {
+        if (! $this->hero_image) {
+            return null;
+        }
+
+        return asset('storage/'.$this->hero_image);
     }
 
     /*
@@ -98,12 +114,23 @@ class Article extends Model
                 $article->author_id = auth()->id();
             }
         });
+
+        static::updated(function (Article $article): void {
+            resolve(ArticleImageService::class)->pruneStaleImages($article);
+        });
+
+        static::deleting(function (Article $article): void {
+            resolve(ArticleImageService::class)->deleteImages($article);
+        });
     }
 
     protected function casts(): array
     {
         return [
             'published_at' => 'datetime',
+            'og_image_crop' => 'array',
+            'card_image_crop' => 'array',
+            'header_image_crop' => 'array',
         ];
     }
 }

--- a/app/Services/ArticleImageService.php
+++ b/app/Services/ArticleImageService.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Article;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\ImageManager;
+
+class ArticleImageService
+{
+    public const OG_WIDTH = 1200;
+
+    public const OG_HEIGHT = 630;
+
+    public const CARD_WIDTH = 1200;
+
+    public const CARD_HEIGHT = 450;
+
+    public const HEADER_WIDTH = 2048;
+
+    public const HEADER_HEIGHT = 1000;
+
+    public const HERO_MAX_WIDTH = 2400;
+
+    public function __construct(protected OgImageService $ogImageService) {}
+
+    /**
+     * Regenerate the article's OG and card images.
+     *
+     * When a hero image has been uploaded, the OG and card images are cropped
+     * from it using the stored crop selections. Otherwise the OG image is
+     * generated with TheOG and any card image is removed.
+     */
+    public function refreshImages(Article $article): void
+    {
+        if ($article->hero_image && Storage::disk('public')->exists($article->hero_image)) {
+            $this->scaleDownHero($article);
+
+            $article->update([
+                'og_image' => $this->generateCrop(
+                    $article,
+                    $article->og_image_crop,
+                    self::OG_WIDTH,
+                    self::OG_HEIGHT,
+                    'og-images/'.$article->slug.'.png',
+                ),
+                'card_image' => $this->generateCrop(
+                    $article,
+                    $article->card_image_crop,
+                    self::CARD_WIDTH,
+                    self::CARD_HEIGHT,
+                    'blog/cards/'.$article->slug.'.jpg',
+                ),
+                'header_image' => $this->generateCrop(
+                    $article,
+                    $article->header_image_crop,
+                    self::HEADER_WIDTH,
+                    self::HEADER_HEIGHT,
+                    'blog/headers/'.$article->slug.'.jpg',
+                ),
+            ]);
+
+            return;
+        }
+
+        $this->deleteDerivedImages($article);
+
+        $article->update([
+            'og_image' => $this->ogImageService->generate($article),
+            'card_image' => null,
+            'header_image' => null,
+        ]);
+    }
+
+    /**
+     * Delete image files that are no longer referenced after an update.
+     */
+    public function pruneStaleImages(Article $article): void
+    {
+        $disk = Storage::disk('public');
+
+        if ($article->wasChanged('hero_image') && ($previousHero = $article->getOriginal('hero_image'))) {
+            $disk->delete($previousHero);
+        }
+
+        if ($article->wasChanged('slug') && ($previousSlug = $article->getOriginal('slug'))) {
+            $disk->delete([
+                'og-images/'.$previousSlug.'.png',
+                'blog/cards/'.$previousSlug.'.jpg',
+                'blog/headers/'.$previousSlug.'.jpg',
+            ]);
+        }
+    }
+
+    /**
+     * Delete all image files belonging to the article.
+     */
+    public function deleteImages(Article $article): void
+    {
+        if ($article->hero_image) {
+            Storage::disk('public')->delete($article->hero_image);
+        }
+
+        $this->deleteDerivedImages($article);
+
+        $this->ogImageService->delete($article);
+    }
+
+    /**
+     * Scale the hero image down in place if it's larger than we'd ever render it.
+     */
+    protected function scaleDownHero(Article $article): void
+    {
+        $hero = ImageManager::gd()->read(Storage::disk('public')->path($article->hero_image));
+
+        if ($hero->width() > self::HERO_MAX_WIDTH) {
+            $hero->scaleDown(width: self::HERO_MAX_WIDTH)->save();
+        }
+    }
+
+    /**
+     * Crop a region out of the hero image and save it at the target size.
+     *
+     * @param  array{x: int, y: int, width: int, height: int}|null  $crop
+     */
+    protected function generateCrop(Article $article, ?array $crop, int $targetWidth, int $targetHeight, string $path): string
+    {
+        $disk = Storage::disk('public');
+
+        $directory = dirname($path);
+        if (! $disk->exists($directory)) {
+            $disk->makeDirectory($directory);
+        }
+
+        $hero = ImageManager::gd()->read($disk->path($article->hero_image));
+
+        $rect = $this->resolveCropRect($crop, $hero->width(), $hero->height(), $targetWidth / $targetHeight);
+
+        $options = str_ends_with($path, '.png') ? [] : ['quality' => 90];
+
+        $hero
+            ->crop($rect['width'], $rect['height'], $rect['x'], $rect['y'])
+            ->resize($targetWidth, $targetHeight)
+            ->blendTransparency('ffffff')
+            ->save($disk->path($path), ...$options);
+
+        return $disk->url($path);
+    }
+
+    /**
+     * Clamp a stored crop selection to the image bounds, or fall back to a
+     * centered crop of the largest possible area at the target aspect ratio.
+     *
+     * @return array{x: int, y: int, width: int, height: int}
+     */
+    protected function resolveCropRect(?array $crop, int $imageWidth, int $imageHeight, float $ratio): array
+    {
+        if ($this->isUsableCropRect($crop)) {
+            $width = min(max((int) $crop['width'], 10), $imageWidth);
+            $height = (int) round($width / $ratio);
+
+            if ($height > $imageHeight) {
+                $height = $imageHeight;
+                $width = (int) round($height * $ratio);
+            }
+
+            return [
+                'x' => min(max((int) $crop['x'], 0), $imageWidth - $width),
+                'y' => min(max((int) $crop['y'], 0), $imageHeight - $height),
+                'width' => $width,
+                'height' => $height,
+            ];
+        }
+
+        $width = min($imageWidth, (int) floor($imageHeight * $ratio));
+        $height = (int) floor($width / $ratio);
+
+        return [
+            'x' => (int) floor(($imageWidth - $width) / 2),
+            'y' => (int) floor(($imageHeight - $height) / 2),
+            'width' => $width,
+            'height' => $height,
+        ];
+    }
+
+    protected function isUsableCropRect(?array $crop): bool
+    {
+        return is_array($crop)
+            && isset($crop['x'], $crop['y'], $crop['width'], $crop['height'])
+            && is_numeric($crop['x'])
+            && is_numeric($crop['y'])
+            && is_numeric($crop['width'])
+            && is_numeric($crop['height'])
+            && (int) $crop['width'] > 0
+            && (int) $crop['height'] > 0;
+    }
+
+    protected function deleteDerivedImages(Article $article): void
+    {
+        Storage::disk('public')->delete([
+            'blog/cards/'.$article->slug.'.jpg',
+            'blog/headers/'.$article->slug.'.jpg',
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_111307_add_hero_image_to_articles_table.php
+++ b/database/migrations/2026_07_10_111307_add_hero_image_to_articles_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('hero_image')->nullable()->after('og_image');
+            $table->string('card_image')->nullable()->after('hero_image');
+            $table->json('og_image_crop')->nullable()->after('card_image');
+            $table->json('card_image_crop')->nullable()->after('og_image_crop');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn(['hero_image', 'card_image', 'og_image_crop', 'card_image_crop']);
+        });
+    }
+};

--- a/database/migrations/2026_07_10_155504_add_header_image_to_articles_table.php
+++ b/database/migrations/2026_07_10_155504_add_header_image_to_articles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('header_image')->nullable()->after('card_image');
+            $table->json('header_image_crop')->nullable()->after('card_image_crop');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn(['header_image', 'header_image_crop']);
+        });
+    }
+};

--- a/resources/views/article.blade.php
+++ b/resources/views/article.blade.php
@@ -78,6 +78,26 @@
         {{-- Divider --}}
         <x-divider />
 
+        {{-- Header image --}}
+        @if ($article->header_image)
+            <img
+                x-init="
+                    () => {
+                        motion.inView($el, () => {
+                            gsap.fromTo(
+                                $el,
+                                { autoAlpha: 0, y: 5 },
+                                { autoAlpha: 1, y: 0, duration: 0.7, ease: 'power1.out' },
+                            )
+                        })
+                    }
+                "
+                src="{{ $article->header_image }}"
+                alt=""
+                class="mt-2 max-h-[500px] w-full rounded-2xl object-cover"
+            />
+        @endif
+
         <div class="mt-2 flex items-start gap-5">
             {{-- Content --}}
             <article

--- a/resources/views/blog.blade.php
+++ b/resources/views/blog.blade.php
@@ -103,6 +103,7 @@
                             :title="$article->title"
                             :url="route('article', $article)"
                             :date="$article->published_at"
+                            :image="$article->card_image"
                         >
                             {{ $article->excerpt }}
                         </x-blog.article-card>

--- a/resources/views/components/blog/article-card.blade.php
+++ b/resources/views/components/blog/article-card.blade.php
@@ -2,6 +2,7 @@
     'title' => '',
     'url' => '#',
     'date' => null,
+    'image' => null,
 ])
 
 <a
@@ -10,46 +11,58 @@
     aria-labelledby="article-title-{{ Str::slug($title) }}"
 >
     <article
-        class="group relative z-0 block overflow-hidden rounded-2xl bg-zinc-200/60 p-7 transition duration-300 hover:bg-violet-200/60 dark:bg-mirage dark:hover:bg-violet-500/10"
+        class="group relative z-0 block overflow-hidden rounded-2xl bg-zinc-200/60 transition duration-300 hover:bg-violet-200/60 dark:bg-mirage dark:hover:bg-violet-500/10"
     >
-        {{-- Header --}}
-        <div class="flex items-start justify-between gap-10">
-            <div>
-                {{-- Title --}}
-                <h3
-                    id="article-title-{{ Str::slug($title) }}"
-                    class="line-clamp-4 text-xl leading-relaxed font-semibold text-pretty"
-                >
-                    {{ $title }}
-                </h3>
-                {{-- Date --}}
-                @if ($date)
-                    @php
-                        $dateObject = \Carbon\Carbon::parse($date);
-                        $formattedDate = $dateObject->format('F j, Y');
-                    @endphp
+        {{-- Preview image --}}
+        @if ($image)
+            <img
+                src="{{ $image }}"
+                alt=""
+                class="h-48 w-full object-cover"
+                loading="lazy"
+            />
+        @endif
 
-                    <time
-                        datetime="{{ $date }}"
-                        class="shrink-0 text-xs opacity-50"
+        <div class="p-7">
+            {{-- Header --}}
+            <div class="flex items-start justify-between gap-10">
+                <div>
+                    {{-- Title --}}
+                    <h3
+                        id="article-title-{{ Str::slug($title) }}"
+                        class="line-clamp-4 text-xl leading-relaxed font-semibold text-pretty"
                     >
-                        {{ $formattedDate }}
-                    </time>
-                @endif
+                        {{ $title }}
+                    </h3>
+                    {{-- Date --}}
+                    @if ($date)
+                        @php
+                            $dateObject = \Carbon\Carbon::parse($date);
+                            $formattedDate = $dateObject->format('F j, Y');
+                        @endphp
+
+                        <time
+                            datetime="{{ $date }}"
+                            class="shrink-0 text-xs opacity-50"
+                        >
+                            {{ $formattedDate }}
+                        </time>
+                    @endif
+                </div>
+
+                {{-- Arrow --}}
+                <x-icons.right-arrow
+                    class="mt-2 -ml-5 size-3.5 shrink-0 transition duration-300 will-change-transform group-hover:translate-x-1"
+                    aria-hidden="true"
+                />
             </div>
 
-            {{-- Arrow --}}
-            <x-icons.right-arrow
-                class="mt-2 -ml-5 size-3.5 shrink-0 transition duration-300 will-change-transform group-hover:translate-x-1"
-                aria-hidden="true"
-            />
-        </div>
-
-        <div class="flex items-end justify-between gap-10 pt-5">
-            {{-- Content --}}
-            <p class="line-clamp-3 text-sm leading-relaxed  opacity-50">
-                {{ $slot }}
-            </p>
+            <div class="flex items-end justify-between gap-10 pt-5">
+                {{-- Content --}}
+                <p class="line-clamp-3 text-sm leading-relaxed  opacity-50">
+                    {{ $slot }}
+                </p>
+            </div>
         </div>
 
         {{-- Blur decoration --}}

--- a/resources/views/filament/forms/components/image-cropper.blade.php
+++ b/resources/views/filament/forms/components/image-cropper.blade.php
@@ -1,0 +1,246 @@
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+>
+    @php
+        $imageUrl = $getImageUrl();
+        $targetWidth = $getTargetWidth();
+        $targetHeight = $getTargetHeight();
+
+        $noteStyles = 'border-radius: 0.5rem; background: rgba(127, 127, 127, 0.08); padding: 1.5rem 1rem; text-align: center; font-size: 0.875rem; color: #6b7280;';
+        $handleStyles = 'position: absolute; width: 0.875rem; height: 0.875rem; border-radius: 9999px; background: #fff; box-shadow: 0 0 0 1px #9ca3af, 0 1px 2px rgba(0, 0, 0, 0.3); touch-action: none;';
+    @endphp
+
+    @if ($getHasPendingImage())
+        <div style="{{ $noteStyles }}">
+            The hero image has changed. Save the article, then adjust this
+            crop.
+        </div>
+    @elseif (! $imageUrl)
+        <div style="{{ $noteStyles }}">
+            Upload a hero image to select a crop.
+        </div>
+    @else
+        <div
+            x-data="{
+                state: $wire.$entangle(@js($getStatePath())),
+                ratio: @js($targetWidth) / @js($targetHeight),
+                naturalWidth: 0,
+                naturalHeight: 0,
+                crop: null,
+                drag: null,
+
+                init() {
+                    if (this.$refs.image.complete && this.$refs.image.naturalWidth) {
+                        this.setup()
+                    }
+                },
+
+                setup() {
+                    this.naturalWidth = this.$refs.image.naturalWidth
+                    this.naturalHeight = this.$refs.image.naturalHeight
+                    this.crop = this.restoredCrop() ?? this.defaultCrop()
+                    this.commit()
+                },
+
+                restoredCrop() {
+                    const saved = this.state
+
+                    if (! saved || typeof saved !== 'object' || ! (saved.width > 0) || ! (saved.height > 0)) {
+                        return null
+                    }
+
+                    let width = Math.min(Math.max(saved.width, this.minWidth()), this.naturalWidth)
+                    let height = width / this.ratio
+
+                    if (height > this.naturalHeight) {
+                        height = this.naturalHeight
+                        width = height * this.ratio
+                    }
+
+                    return {
+                        x: Math.min(Math.max(saved.x ?? 0, 0), this.naturalWidth - width),
+                        y: Math.min(Math.max(saved.y ?? 0, 0), this.naturalHeight - height),
+                        width,
+                        height,
+                    }
+                },
+
+                defaultCrop() {
+                    const width = Math.min(this.naturalWidth, this.naturalHeight * this.ratio)
+                    const height = width / this.ratio
+
+                    return {
+                        x: (this.naturalWidth - width) / 2,
+                        y: (this.naturalHeight - height) / 2,
+                        width,
+                        height,
+                    }
+                },
+
+                minWidth() {
+                    return Math.min(this.naturalWidth, Math.max(this.naturalWidth * 0.1, 60))
+                },
+
+                commit() {
+                    if (! this.crop) return
+
+                    this.state = {
+                        x: Math.round(this.crop.x),
+                        y: Math.round(this.crop.y),
+                        width: Math.round(this.crop.width),
+                        height: Math.round(this.crop.height),
+                    }
+                },
+
+                resetCrop() {
+                    this.crop = this.defaultCrop()
+                    this.commit()
+                },
+
+                displayScale() {
+                    return this.naturalWidth / this.$refs.image.getBoundingClientRect().width
+                },
+
+                startDrag(event, mode) {
+                    if (! this.crop) return
+
+                    this.drag = {
+                        mode,
+                        pointerX: event.clientX,
+                        pointerY: event.clientY,
+                        start: { ...this.crop },
+                        scale: this.displayScale(),
+                    }
+                },
+
+                onDrag(event) {
+                    if (! this.drag) return
+
+                    event.preventDefault()
+
+                    const dx = (event.clientX - this.drag.pointerX) * this.drag.scale
+                    const dy = (event.clientY - this.drag.pointerY) * this.drag.scale
+
+                    this.drag.mode === 'move' ? this.moveTo(dx, dy) : this.resizeTo(dx, dy)
+                },
+
+                moveTo(dx, dy) {
+                    const start = this.drag.start
+
+                    this.crop.x = Math.min(Math.max(start.x + dx, 0), this.naturalWidth - this.crop.width)
+                    this.crop.y = Math.min(Math.max(start.y + dy, 0), this.naturalHeight - this.crop.height)
+                },
+
+                resizeTo(dx, dy) {
+                    const handle = this.drag.mode
+                    const start = this.drag.start
+
+                    const anchorX = handle.includes('w') ? start.x + start.width : start.x
+                    const anchorY = handle.includes('n') ? start.y + start.height : start.y
+
+                    const widthFromX = start.width + (handle.includes('e') ? dx : -dx)
+                    const widthFromY = (start.height + (handle.includes('s') ? dy : -dy)) * this.ratio
+
+                    let width =
+                        Math.abs(widthFromX - start.width) >= Math.abs(widthFromY - start.width)
+                            ? widthFromX
+                            : widthFromY
+
+                    const maxWidth = Math.min(
+                        handle.includes('e') ? this.naturalWidth - anchorX : anchorX,
+                        (handle.includes('s') ? this.naturalHeight - anchorY : anchorY) * this.ratio,
+                    )
+
+                    width = Math.min(Math.max(width, this.minWidth()), maxWidth)
+                    const height = width / this.ratio
+
+                    this.crop = {
+                        x: handle.includes('e') ? anchorX : anchorX - width,
+                        y: handle.includes('s') ? anchorY : anchorY - height,
+                        width,
+                        height,
+                    }
+                },
+
+                endDrag() {
+                    if (! this.drag) return
+
+                    this.drag = null
+                    this.commit()
+                },
+
+                cropStyle() {
+                    if (! this.crop || ! this.naturalWidth) {
+                        return { display: 'none' }
+                    }
+
+                    return {
+                        display: 'block',
+                        left: `${(this.crop.x / this.naturalWidth) * 100}%`,
+                        top: `${(this.crop.y / this.naturalHeight) * 100}%`,
+                        width: `${(this.crop.width / this.naturalWidth) * 100}%`,
+                        height: `${(this.crop.height / this.naturalHeight) * 100}%`,
+                    }
+                },
+            }"
+            x-on:pointermove.window="onDrag($event)"
+            x-on:pointerup.window="endDrag()"
+            x-on:pointercancel.window="endDrag()"
+            {{ $getExtraAttributeBag() }}
+        >
+            <div
+                style="position: relative; display: inline-block; max-width: 100%; overflow: hidden; border-radius: 0.5rem; vertical-align: top; line-height: 0;"
+            >
+                <img
+                    x-ref="image"
+                    src="{{ $imageUrl }}"
+                    alt="Crop selection source"
+                    style="display: block; max-height: 24rem; width: auto; max-width: 100%; user-select: none;"
+                    draggable="false"
+                    x-on:load="setup()"
+                />
+
+                <div
+                    style="position: absolute; cursor: move; touch-action: none; border: 2px solid #fff; box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.55);"
+                    :style="cropStyle()"
+                    x-on:pointerdown.prevent="startDrag($event, 'move')"
+                >
+                    <span
+                        style="{{ $handleStyles }} top: -0.4375rem; left: -0.4375rem; cursor: nwse-resize;"
+                        x-on:pointerdown.stop.prevent="startDrag($event, 'nw')"
+                    ></span>
+                    <span
+                        style="{{ $handleStyles }} top: -0.4375rem; right: -0.4375rem; cursor: nesw-resize;"
+                        x-on:pointerdown.stop.prevent="startDrag($event, 'ne')"
+                    ></span>
+                    <span
+                        style="{{ $handleStyles }} bottom: -0.4375rem; left: -0.4375rem; cursor: nesw-resize;"
+                        x-on:pointerdown.stop.prevent="startDrag($event, 'sw')"
+                    ></span>
+                    <span
+                        style="{{ $handleStyles }} bottom: -0.4375rem; right: -0.4375rem; cursor: nwse-resize;"
+                        x-on:pointerdown.stop.prevent="startDrag($event, 'se')"
+                    ></span>
+                </div>
+            </div>
+
+            <div
+                style="margin-top: 0.5rem; display: flex; align-items: center; justify-content: space-between; gap: 1rem; font-size: 0.75rem; color: #6b7280;"
+            >
+                <span>
+                    Drag to reposition, drag a corner to resize. Output:
+                    {{ $targetWidth }}&times;{{ $targetHeight }}px.
+                </span>
+
+                <button
+                    type="button"
+                    style="flex-shrink: 0; font-weight: 500; color: #8b5cf6; text-decoration: underline; cursor: pointer;"
+                    x-on:click.prevent="resetCrop()"
+                >
+                    Reset crop
+                </button>
+            </div>
+        </div>
+    @endif
+</x-dynamic-component>

--- a/tests/Feature/ArticleImagesTest.php
+++ b/tests/Feature/ArticleImagesTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\ArticleResource\Pages\EditArticle;
+use App\Models\Article;
+use App\Models\User;
+use App\Services\ArticleImageService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Geometry\Factories\RectangleFactory;
+use Intervention\Image\ImageManager;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ArticleImagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('public');
+    }
+
+    /**
+     * Write a hero image to the public disk: the left half red, the right half blue.
+     */
+    protected function createHeroImage(string $path, int $width = 1600, int $height = 800): void
+    {
+        Storage::disk('public')->makeDirectory(dirname($path));
+
+        ImageManager::gd()
+            ->create($width, $height)
+            ->fill('ff0000')
+            ->drawRectangle((int) ($width / 2), 0, function (RectangleFactory $rectangle) use ($width, $height): void {
+                $rectangle->size((int) ($width / 2), $height);
+                $rectangle->background('0000ff');
+            })
+            ->save(Storage::disk('public')->path($path));
+    }
+
+    protected function articleWithHero(array $attributes = []): Article
+    {
+        $article = Article::factory()->published()->create([
+            'hero_image' => 'blog/heroes/test-hero.png',
+            ...$attributes,
+        ]);
+
+        $this->createHeroImage('blog/heroes/test-hero.png');
+
+        return $article;
+    }
+
+    public function test_refresh_images_generates_og_card_and_header_crops_from_the_hero(): void
+    {
+        $article = $this->articleWithHero();
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $article->refresh();
+
+        Storage::disk('public')->assertExists("og-images/{$article->slug}.png");
+        Storage::disk('public')->assertExists("blog/cards/{$article->slug}.jpg");
+        Storage::disk('public')->assertExists("blog/headers/{$article->slug}.jpg");
+
+        $this->assertStringEndsWith("og-images/{$article->slug}.png", $article->og_image);
+        $this->assertStringEndsWith("blog/cards/{$article->slug}.jpg", $article->card_image);
+        $this->assertStringEndsWith("blog/headers/{$article->slug}.jpg", $article->header_image);
+
+        $ogImage = ImageManager::gd()->read(Storage::disk('public')->path("og-images/{$article->slug}.png"));
+        $this->assertSame(ArticleImageService::OG_WIDTH, $ogImage->width());
+        $this->assertSame(ArticleImageService::OG_HEIGHT, $ogImage->height());
+
+        $cardImage = ImageManager::gd()->read(Storage::disk('public')->path("blog/cards/{$article->slug}.jpg"));
+        $this->assertSame(ArticleImageService::CARD_WIDTH, $cardImage->width());
+        $this->assertSame(ArticleImageService::CARD_HEIGHT, $cardImage->height());
+
+        $headerImage = ImageManager::gd()->read(Storage::disk('public')->path("blog/headers/{$article->slug}.jpg"));
+        $this->assertSame(ArticleImageService::HEADER_WIDTH, $headerImage->width());
+        $this->assertSame(ArticleImageService::HEADER_HEIGHT, $headerImage->height());
+    }
+
+    public function test_refresh_images_honours_the_stored_crop_selections(): void
+    {
+        $article = $this->articleWithHero([
+            // Entirely within the left (red) half of the 1600x800 hero
+            'og_image_crop' => ['x' => 0, 'y' => 0, 'width' => 762, 'height' => 400],
+        ]);
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $ogImage = ImageManager::gd()->read(Storage::disk('public')->path("og-images/{$article->slug}.png"));
+
+        $this->assertSame('ff0000', $ogImage->pickColor(600, 315)->toHex());
+        $this->assertSame('ff0000', $ogImage->pickColor(1190, 315)->toHex());
+    }
+
+    public function test_refresh_images_clamps_out_of_bounds_crop_selections(): void
+    {
+        $article = $this->articleWithHero([
+            'og_image_crop' => ['x' => 5000, 'y' => 5000, 'width' => 9000, 'height' => 9000],
+        ]);
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $ogImage = ImageManager::gd()->read(Storage::disk('public')->path("og-images/{$article->slug}.png"));
+
+        $this->assertSame(ArticleImageService::OG_WIDTH, $ogImage->width());
+        $this->assertSame(ArticleImageService::OG_HEIGHT, $ogImage->height());
+    }
+
+    public function test_oversized_hero_images_are_scaled_down(): void
+    {
+        $article = Article::factory()->published()->create([
+            'hero_image' => 'blog/heroes/huge-hero.png',
+        ]);
+
+        $this->createHeroImage('blog/heroes/huge-hero.png', 2500, 1000);
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $hero = ImageManager::gd()->read(Storage::disk('public')->path('blog/heroes/huge-hero.png'));
+
+        $this->assertSame(ArticleImageService::HERO_MAX_WIDTH, $hero->width());
+        $this->assertSame((int) (ArticleImageService::HERO_MAX_WIDTH * 1000 / 2500), $hero->height());
+    }
+
+    public function test_refresh_images_generates_an_og_image_when_there_is_no_hero(): void
+    {
+        $article = Article::factory()->published()->create();
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $article->refresh();
+
+        Storage::disk('public')->assertExists("og-images/{$article->slug}.png");
+        $this->assertStringEndsWith("og-images/{$article->slug}.png", $article->og_image);
+        $this->assertNull($article->card_image);
+        $this->assertNull($article->header_image);
+    }
+
+    public function test_replacing_the_hero_image_deletes_the_old_file(): void
+    {
+        $article = $this->articleWithHero();
+
+        $this->createHeroImage('blog/heroes/new-hero.png');
+
+        $article->update(['hero_image' => 'blog/heroes/new-hero.png']);
+
+        Storage::disk('public')->assertMissing('blog/heroes/test-hero.png');
+        Storage::disk('public')->assertExists('blog/heroes/new-hero.png');
+    }
+
+    public function test_changing_the_slug_deletes_stale_generated_images(): void
+    {
+        $article = $this->articleWithHero(['slug' => 'old-slug', 'published_at' => null]);
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        Storage::disk('public')->assertExists('og-images/old-slug.png');
+        Storage::disk('public')->assertExists('blog/cards/old-slug.jpg');
+        Storage::disk('public')->assertExists('blog/headers/old-slug.jpg');
+
+        $article->update(['slug' => 'new-slug']);
+
+        Storage::disk('public')->assertMissing('og-images/old-slug.png');
+        Storage::disk('public')->assertMissing('blog/cards/old-slug.jpg');
+        Storage::disk('public')->assertMissing('blog/headers/old-slug.jpg');
+    }
+
+    public function test_deleting_an_article_deletes_its_images(): void
+    {
+        $article = $this->articleWithHero();
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        Storage::disk('public')->assertExists('blog/heroes/test-hero.png');
+        Storage::disk('public')->assertExists("og-images/{$article->slug}.png");
+        Storage::disk('public')->assertExists("blog/cards/{$article->slug}.jpg");
+        Storage::disk('public')->assertExists("blog/headers/{$article->slug}.jpg");
+
+        $slug = $article->slug;
+
+        $article->delete();
+
+        Storage::disk('public')->assertMissing('blog/heroes/test-hero.png');
+        Storage::disk('public')->assertMissing("og-images/{$slug}.png");
+        Storage::disk('public')->assertMissing("blog/cards/{$slug}.jpg");
+        Storage::disk('public')->assertMissing("blog/headers/{$slug}.jpg");
+    }
+
+    public function test_blog_index_shows_the_card_image(): void
+    {
+        Article::factory()->published()->create([
+            'card_image' => '/storage/blog/cards/test-article.jpg',
+        ]);
+
+        $this->get(route('blog'))
+            ->assertOk()
+            ->assertSee('/storage/blog/cards/test-article.jpg');
+    }
+
+    public function test_article_page_shows_the_header_image(): void
+    {
+        $article = $this->articleWithHero();
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        $this->get(route('article', $article))
+            ->assertOk()
+            ->assertSee("storage/blog/headers/{$article->slug}.jpg");
+    }
+
+    public function test_article_page_has_no_header_markup_without_a_hero_image(): void
+    {
+        $article = Article::factory()->published()->create();
+
+        $this->get(route('article', $article))
+            ->assertOk()
+            ->assertDontSee('storage/blog/headers');
+    }
+
+    public function test_saving_an_article_with_a_hero_generates_the_custom_images(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $article = $this->articleWithHero(['published_at' => null]);
+
+        Livewire::actingAs($admin)
+            ->test(EditArticle::class, ['record' => $article->id])
+            ->fillForm(['title' => 'Updated title'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $article->refresh();
+
+        Storage::disk('public')->assertExists("blog/cards/{$article->slug}.jpg");
+        Storage::disk('public')->assertExists("blog/headers/{$article->slug}.jpg");
+        $this->assertStringEndsWith("og-images/{$article->slug}.png", $article->og_image);
+        $this->assertStringEndsWith("blog/cards/{$article->slug}.jpg", $article->card_image);
+        $this->assertStringEndsWith("blog/headers/{$article->slug}.jpg", $article->header_image);
+
+        // The OG image is cropped from the hero rather than generated by TheOG
+        $ogImage = ImageManager::gd()->read(Storage::disk('public')->path("og-images/{$article->slug}.png"));
+        $this->assertContains($ogImage->pickColor(10, 315)->toHex(), ['ff0000', '0000ff']);
+    }
+
+    public function test_removing_the_hero_resets_crops_and_reverts_to_generated_og_images(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $article = $this->articleWithHero([
+            'published_at' => null,
+            'og_image_crop' => ['x' => 0, 'y' => 0, 'width' => 762, 'height' => 400],
+            'card_image_crop' => ['x' => 0, 'y' => 0, 'width' => 900, 'height' => 338],
+            'header_image_crop' => ['x' => 0, 'y' => 0, 'width' => 1024, 'height' => 500],
+        ]);
+
+        resolve(ArticleImageService::class)->refreshImages($article);
+
+        Livewire::actingAs($admin)
+            ->test(EditArticle::class, ['record' => $article->id])
+            ->fillForm(['hero_image' => null])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $article->refresh();
+
+        $this->assertNull($article->hero_image);
+        $this->assertNull($article->og_image_crop);
+        $this->assertNull($article->card_image_crop);
+        $this->assertNull($article->header_image_crop);
+        $this->assertNull($article->card_image);
+        $this->assertNull($article->header_image);
+        $this->assertStringEndsWith("og-images/{$article->slug}.png", $article->og_image);
+
+        Storage::disk('public')->assertMissing('blog/heroes/test-hero.png');
+        Storage::disk('public')->assertMissing("blog/cards/{$article->slug}.jpg");
+        Storage::disk('public')->assertMissing("blog/headers/{$article->slug}.jpg");
+        Storage::disk('public')->assertExists("og-images/{$article->slug}.png");
+    }
+}


### PR DESCRIPTION
## What

Articles can now have a custom hero image uploaded in the admin. From that single upload, three derivatives are generated, each with its own admin-adjustable crop:

- **Social (OG) image** — 1200×630 (TheOG's dimensions), written to the same `og-images/{slug}.png` path, so it replaces the TheOG-generated image in `og:image`/Twitter meta while a hero exists. Remove the hero and the article reverts to TheOG generation.
- **Blog card preview** — 1200×450, rendered flush at the top of `/blog` cards (≤200px tall, clipped by the card's rounded corners).
- **Article header** — 2048×1000 (2× retina), rendered at the top of the article page at up to 500px tall.

Also renames the admin **Articles** section to **Blog** (nav label, breadcrumb, list title — no class renames) and stacks the article form labels instead of inline.

## How

- **`ImageCropper` Filament field** (`app/Filament/Forms/Components/ImageCropper.php` + blade): a dependency-free Alpine crop tool — aspect-locked drag/resize selection box storing `{x, y, width, height}` rects as JSON. Crops are non-destructive and re-adjustable at any time without re-uploading. The [Croppie plugin](https://filamentphp.com/plugins/michaeld555-croppie) was considered but it requires Filament ^3.2 (this app is on v5) and only supports destructive upload-time crops, one file per field.
- **`ArticleImageService`**: scales oversized heroes down in place (max 2400px wide), generates the three crops via Intervention Image (already a direct dependency), clamps/centers invalid or missing crop rects, and handles file cleanup when the hero is replaced, the slug changes, the hero is removed, or the article is deleted.
- Uploads validated to min 1200×630. Crop selections appear after saving (create redirects to edit); replacing the hero resets crops to centered defaults.

## Testing

- 13 feature tests covering derivative generation/dimensions, crop selection + clamping, hero downscaling, TheOG fallback, file lifecycle, page rendering, and the Filament save flows.
- Full suite green: 1199 tests. Note: the full suite needs `memory_limit` > 128M (peaks ~259MB) — this is pre-existing (confirmed on a clean `main` worktree), Herd's default CLI limit fails partway through the suite either way.
- Verified end to end in the browser: cropper init/restore math, UI save → regenerated OG image reflecting the selected crop (pixel-checked), card/header/`og:image` rendering, and deletion cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)