### PR TITLE
docs(mobile/4): alert button styles (cancel + destructive)

### DIFF
--- a/resources/views/docs/mobile/4/the-basics/dialogs.md
+++ b/resources/views/docs/mobile/4/the-basics/dialogs.md
@@ -26,6 +26,25 @@ Dialog::alert('Hello', 'Welcome to the app!');
 Dialog::alert('Confirm', 'Are you sure?', ['Cancel', 'Delete']);
 ```
 
+### Button styles
+
+Any button can be an array with a `style` to get the platform's native treatment:
+
+```php
+Dialog::alert('Delete post?', 'This cannot be undone.', [
+    ['label' => 'Cancel', 'style' => 'cancel'],
+    ['label' => 'Delete', 'style' => 'destructive'],
+]);
+```
+
+| Style | Behavior |
+| --- | --- |
+| `default` | Standard button (same as passing a plain string) |
+| `cancel` | The dismissive action — bold and repositioned on iOS, placed in the conventional dismiss slot on Android |
+| `destructive` | Rendered in the platform's destructive/error color (red) |
+
+Plain strings and styled arrays mix freely in the same alert.
+
 `alert()` returns a `PendingAlert` you can configure fluently. If you don't call `->show()`, the alert displays
 automatically when the object goes out of scope.
 


### PR DESCRIPTION
Documents the new styled-button support in `Dialog::alert()` (shipping in nativephp/mobile): buttons can be plain strings or `['label' => ..., 'style' => ...]` arrays with `default` / `cancel` / `destructive` styles — destructive renders in the platform's error red, cancel gets iOS's bold/repositioned treatment and Android's conventional dismiss slot.

Adds a **Button styles** section to `docs/mobile/4/the-basics/dialogs.md` with an example and style table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)