### PR TITLE
Move BeyondCode & Laradevs to sponsors; list current partners on /partners

### DIFF
--- a/resources/views/components/home/partners.blade.php
+++ b/resources/views/components/home/partners.blade.php
@@ -108,56 +108,6 @@
                 </x-slot>
             </x-home.featured-partner-card>
 
-            <x-home.featured-partner-card
-                partnerName="Laradevs"
-                tagline="Hire the best Laravel developers anywhere"
-                href="https://laradevs.com/?ref=nativephp"
-            >
-                <x-slot:logo>
-                    <x-sponsors.logos.laradevs
-                        class="text-black dark:text-white"
-                        aria-hidden="true"
-                    />
-                </x-slot>
-
-                <x-slot:description>
-                    Need a freelancer or engineer? Laradevs has you covered.
-                    Filter by skills, experience, location, availability,
-                    and pay.
-                </x-slot>
-            </x-home.featured-partner-card>
-
-            <x-home.featured-partner-card
-                partnerName="BeyondCode"
-                tagline="Essential tools for web developers"
-                href="https://beyondco.de/?utm_source=nativephp&utm_medium=logo&utm_campaign=nativephp"
-            >
-                <x-slot:logo>
-                    <img
-                        src="/img/sponsors/beyondcode.webp"
-                        class="block dark:hidden"
-                        loading="lazy"
-                        alt="BeyondCode logo - PHP development tools and packages"
-                        width="160"
-                        height="40"
-                    />
-                    <img
-                        src="/img/sponsors/beyondcode-dark.webp"
-                        class="hidden dark:block"
-                        loading="lazy"
-                        alt="BeyondCode logo - PHP development tools and packages"
-                        width="160"
-                        height="40"
-                    />
-                </x-slot>
-
-                <x-slot:description>
-                    From local full stack development to cutting-edge AI
-                    platforms, we provide the tools for building your next
-                    great app.
-                </x-slot>
-            </x-home.featured-partner-card>
-
             {{-- Partner CTA --}}
             <div
                 class="flex flex-col items-center gap-5 rounded-xl bg-gradient-to-tl from-[#d7ff83] to-[#ebeeb7] p-6 sm:flex-row lg:flex-col xl:flex-row dark:from-black dark:via-gray-950 dark:to-gray-800/50"

--- a/resources/views/components/home/sponsors.blade.php
+++ b/resources/views/components/home/sponsors.blade.php
@@ -6,6 +6,18 @@
             'image' => '/img/sponsors/artisan-build.webp',
             'imageDark' => '/img/sponsors/artisan-build-dark.webp',
         ],
+        [
+            'url' => 'https://beyondco.de/?utm_source=nativephp&utm_medium=logo&utm_campaign=nativephp',
+            'name' => 'BeyondCode',
+            'image' => '/img/sponsors/beyondcode.webp',
+            'imageDark' => '/img/sponsors/beyondcode-dark.webp',
+        ],
+        [
+            'url' => 'https://laradevs.com/?ref=nativephp',
+            'name' => 'Laradevs',
+            'component' => 'sponsors.logos.laradevs',
+            'class' => 'h-6 w-auto text-black dark:text-white',
+        ],
     ];
 @endphp
 
@@ -51,18 +63,26 @@
                     rel="noopener noreferrer sponsored"
                     class="opacity-70 transition duration-200 hover:opacity-100"
                 >
-                    <img
-                        src="{{ $sponsor['image'] }}"
-                        class="block h-6 w-auto dark:hidden"
-                        loading="lazy"
-                        alt="{{ $sponsor['name'] }} logo"
-                    />
-                    <img
-                        src="{{ $sponsor['imageDark'] }}"
-                        class="hidden h-6 w-auto dark:block"
-                        loading="lazy"
-                        alt="{{ $sponsor['name'] }} logo"
-                    />
+                    @if (isset($sponsor['component']))
+                        <x-dynamic-component
+                            :component="$sponsor['component']"
+                            :class="$sponsor['class'] ?? ''"
+                            aria-hidden="true"
+                        />
+                    @else
+                        <img
+                            src="{{ $sponsor['image'] }}"
+                            class="block h-6 w-auto dark:hidden"
+                            loading="lazy"
+                            alt="{{ $sponsor['name'] }} logo"
+                        />
+                        <img
+                            src="{{ $sponsor['imageDark'] }}"
+                            class="hidden h-6 w-auto dark:block"
+                            loading="lazy"
+                            alt="{{ $sponsor['name'] }} logo"
+                        />
+                    @endif
                 </a>
             @endforeach
 

--- a/resources/views/partners.blade.php
+++ b/resources/views/partners.blade.php
@@ -483,7 +483,7 @@
         </section>
 
         {{-- Call to Action Section --}}
-        <section class="mt-16 pb-24">
+        <section class="mt-16">
             <div
                 x-init="
                     () => {
@@ -609,6 +609,126 @@
                         </a>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        {{-- Our Partners Section --}}
+        <section class="mt-16 pb-24">
+            <h2
+                x-init="
+                    () => {
+                        motion.inView($el, (element) => {
+                            motion.animate(
+                                $el,
+                                {
+                                    opacity: [0, 1],
+                                    x: [-10, 0],
+                                },
+                                {
+                                    duration: 0.7,
+                                    ease: motion.easeOut,
+                                },
+                            )
+                        })
+                    }
+                "
+                class="text-center text-3xl font-semibold"
+            >
+                Meet Our Partners
+            </h2>
+            <p
+                class="mx-auto mt-4 max-w-2xl text-center text-gray-600 dark:text-zinc-400"
+            >
+                We're proud to partner with these exceptional teams who are
+                helping bring beautiful native apps to life with NativePHP.
+            </p>
+
+            <div
+                x-init="
+                    () => {
+                        motion.inView($el, (element) => {
+                            motion.animate(
+                                Array.from($el.children),
+                                {
+                                    y: [10, 0],
+                                    opacity: [0, 1],
+                                },
+                                {
+                                    duration: 0.7,
+                                    ease: motion.backOut,
+                                    delay: motion.stagger(0.1),
+                                },
+                            )
+                        })
+                    }
+                "
+                class="mt-8 grid grid-cols-1 gap-5 md:grid-cols-2"
+            >
+                <x-home.featured-partner-card
+                    partnerName="Nexcalia"
+                    tagline="Smart tools for scheduling & visitor management"
+                    href="https://www.nexcalia.com/?ref=nativephp"
+                >
+                    <x-slot:logo>
+                        <x-sponsors.logos.nexcalia
+                            class="text-black dark:text-white"
+                            aria-hidden="true"
+                        />
+                    </x-slot>
+
+                    <x-slot:description>
+                        From online booking to interactive kiosks, Nexcalia
+                        helps businesses streamline appointments and improve
+                        customer experiences.
+                    </x-slot>
+                </x-home.featured-partner-card>
+
+                <x-home.featured-partner-card
+                    partnerName="Web Mavens"
+                    tagline="Build Secure, Scalable Web Apps"
+                    href="https://www.webmavens.com/?ref=nativephp"
+                >
+                    <x-slot:logo>
+                        <x-sponsors.logos.webmavens
+                            class="dark:fill-white"
+                            aria-hidden="true"
+                        />
+                    </x-slot>
+
+                    <x-slot:description>
+                        Laravel Partners crafting secure, SOC 2–ready apps with NativePHP and modern web technologies.
+                        Trusted by healthcare and enterprise teams, and friendly to startups too.
+                    </x-slot>
+                </x-home.featured-partner-card>
+
+                <x-home.featured-partner-card
+                    partnerName="Synergi Tech"
+                    tagline="Bespoke software for complex infrastructure"
+                    href="https://synergitech.co.uk/partners/nativephp/"
+                >
+                    <x-slot:logo>
+                        <img
+                            src="/img/sponsors/synergi.svg"
+                            class="block dark:hidden"
+                            loading="lazy"
+                            alt="Synergi Tech logo"
+                            width="160"
+                            height="40"
+                        />
+                        <img
+                            src="/img/sponsors/synergi-dark.svg"
+                            class="hidden dark:block"
+                            loading="lazy"
+                            alt="Synergi Tech logo"
+                            width="160"
+                            height="40"
+                        />
+                    </x-slot>
+
+                    <x-slot:description>
+                        Synergi Tech are an established bespoke software development agency in the UK, specialising in business management and high-growth, complex infrastructure. Proud to partner with NativePHP.
+                    </x-slot>
+                </x-home.featured-partner-card>
             </div>
         </section>
     </div>

--- a/tests/Feature/SponsorsAndPartnersPlacementTest.php
+++ b/tests/Feature/SponsorsAndPartnersPlacementTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SponsorsAndPartnersPlacementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function the_partners_section_no_longer_lists_beyondcode_or_laradevs()
+    {
+        $this->blade('<x-home.partners />')
+            ->assertSee('Nexcalia')
+            ->assertSee('Web Mavens')
+            ->assertDontSee('Laradevs')
+            ->assertDontSee('BeyondCode')
+            ->assertDontSee('Need a freelancer or engineer?')
+            ->assertDontSee('From local full stack development');
+    }
+
+    #[Test]
+    public function the_sponsors_section_lists_beyondcode_and_laradevs_without_descriptions()
+    {
+        $this->blade('<x-home.sponsors />')
+            ->assertSee('Artisan Build')
+            ->assertSee('BeyondCode')
+            ->assertSee('Laradevs')
+            ->assertDontSee('Need a freelancer or engineer?')
+            ->assertDontSee('From local full stack development');
+    }
+
+    #[Test]
+    public function the_homepage_drops_the_partner_descriptions_for_beyondcode_and_laradevs()
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertDontSee('Need a freelancer or engineer?')
+            ->assertDontSee('From local full stack development');
+    }
+
+    #[Test]
+    public function the_partners_page_lists_the_current_partners()
+    {
+        $this->get(route('partners'))
+            ->assertOk()
+            ->assertSee('Meet Our Partners')
+            ->assertSee('Nexcalia')
+            ->assertSee('Web Mavens')
+            ->assertSee('Synergi Tech');
+    }
+}


### PR DESCRIPTION
## What changed

### Home page: BeyondCode & Laradevs moved from Partners → Sponsors
- Removed the **BeyondCode** and **Laradevs** featured partner cards (logo + tagline + description) from the home **"Partners get more"** section. Nexcalia, Web Mavens, Synergi Tech, and the Partner CTA remain.
- Added both brands to the home **"Sponsored by"** strip as logos only (no descriptions).
- Laradevs has no raster logo (only an SVG Blade component), so the sponsors template now renders `component`-based logos via `x-dynamic-component` alongside the existing `image`/`imageDark` path. The Laradevs SVG is sized `h-6 w-auto` with `text-black dark:text-white` to match the other logos in both themes.

### `/partners` page: current partners listed at the bottom
- Added a **"Meet Our Partners"** section at the bottom of the `/partners` page showing the current partners (**Nexcalia**, **Web Mavens**, **Synergi Tech**), reusing the existing `featured-partner-card` component and matching the layout/animation convention already used on the consulting page.
- Moved the `pb-24` bottom padding from the CTA section onto the new final section so it sits flush at the bottom.

## Why
BeyondCode and Laradevs are sponsors rather than program partners, so they belong in the logo-only "Sponsored by" strip. Surfacing the actual partners on the dedicated `/partners` page adds social proof where prospective partners will look.

## Tests
Added `tests/Feature/SponsorsAndPartnersPlacementTest.php`:
- Partners section no longer lists BeyondCode/Laradevs or their descriptions.
- Sponsors section lists Artisan Build, BeyondCode, and Laradevs without descriptions.
- Homepage drops the removed partner descriptions.
- `/partners` page lists the current partners.

All 4 tests pass; `vendor/bin/pint` passes.

## Notes
- The unrelated `package-lock.json` `name` change (a workspace-clone artifact) was intentionally left out of this PR.
- These three partners are now defined inline in three views (home, consulting, `/partners`) with intentionally different description lengths; kept inline to match existing convention rather than expand scope into a shared-source refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)