### PR TITLE
Fix: sync plugin name from composer.json on update

### DIFF
--- a/app/Services/PluginSyncService.php
+++ b/app/Services/PluginSyncService.php
@@ -65,7 +65,7 @@ class PluginSyncService
         ];
 
         if ($composerData) {
-            if (isset($composerData['name']) && ! $plugin->name) {
+            if (! empty($composerData['name']) && $composerData['name'] !== $plugin->name) {
                 $existing = Plugin::where('name', $composerData['name'])
                     ->where('id', '!=', $plugin->id)
                     ->exists();

--- a/tests/Feature/PluginSyncServiceTest.php
+++ b/tests/Feature/PluginSyncServiceTest.php
@@ -53,6 +53,95 @@ class PluginSyncServiceTest extends TestCase
         $this->assertEquals('^3.0.0', $plugin->fresh()->mobile_min_version);
     }
 
+    public function test_sync_updates_name_from_composer_when_name_changes(): void
+    {
+        $composerJson = json_encode([
+            'name' => 'acme/renamed-plugin',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/contents/composer.json' => Http::response([
+                'content' => base64_encode($composerJson),
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json' => Http::response([], 404),
+            'raw.githubusercontent.com/*' => Http::response('', 404),
+            'api.github.com/repos/acme/test-plugin/releases/latest' => Http::response([], 404),
+            'api.github.com/repos/acme/test-plugin/tags*' => Http::response([]),
+            'api.github.com/repos/acme/test-plugin/contents/LICENSE*' => Http::response([], 404),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/old-name',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        $service = new PluginSyncService;
+        $result = $service->sync($plugin);
+
+        $this->assertTrue($result);
+        $this->assertEquals('acme/renamed-plugin', $plugin->fresh()->name);
+    }
+
+    public function test_sync_sets_name_on_initial_sync_when_plugin_has_no_name(): void
+    {
+        $composerJson = json_encode([
+            'name' => 'acme/test-plugin',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/contents/composer.json' => Http::response([
+                'content' => base64_encode($composerJson),
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json' => Http::response([], 404),
+            'raw.githubusercontent.com/*' => Http::response('', 404),
+            'api.github.com/repos/acme/test-plugin/releases/latest' => Http::response([], 404),
+            'api.github.com/repos/acme/test-plugin/tags*' => Http::response([]),
+            'api.github.com/repos/acme/test-plugin/contents/LICENSE*' => Http::response([], 404),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => null,
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        $service = new PluginSyncService;
+        $result = $service->sync($plugin);
+
+        $this->assertTrue($result);
+        $this->assertEquals('acme/test-plugin', $plugin->fresh()->name);
+    }
+
+    public function test_sync_does_not_overwrite_name_when_taken_by_another_plugin(): void
+    {
+        $composerJson = json_encode([
+            'name' => 'acme/taken-name',
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/contents/composer.json' => Http::response([
+                'content' => base64_encode($composerJson),
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json' => Http::response([], 404),
+            'raw.githubusercontent.com/*' => Http::response('', 404),
+            'api.github.com/repos/acme/test-plugin/releases/latest' => Http::response([], 404),
+            'api.github.com/repos/acme/test-plugin/tags*' => Http::response([]),
+            'api.github.com/repos/acme/test-plugin/contents/LICENSE*' => Http::response([], 404),
+        ]);
+
+        Plugin::factory()->create(['name' => 'acme/taken-name']);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/original-name',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        $service = new PluginSyncService;
+        $result = $service->sync($plugin);
+
+        $this->assertTrue($result);
+        $this->assertEquals('acme/original-name', $plugin->fresh()->name);
+    }
+
     public function test_sync_sets_mobile_min_version_to_null_when_not_in_composer_data(): void
     {
         $composerJson = json_encode([


### PR DESCRIPTION
## Problem

When a plugin submission was updated (via GitHub `push`/`release` webhooks or an admin re-sync), the plugin's `name` was never refreshed from its `composer.json`. If a maintainer renamed their package, the database kept the old name.

## Cause

In `PluginSyncService::sync()`, the name-sync block was guarded by `! $plugin->name`:

```php
if (isset($composerData['name']) && ! $plugin->name) {
```

That guard only allowed the name to be set when a plugin had **no** name yet (i.e. at creation time). On every subsequent sync the plugin already had a name, so the block was skipped.

## Fix

Update the name whenever `composer.json`'s `name` differs from the stored value:

```php
if (! empty($composerData['name']) && $composerData['name'] !== $plugin->name) {
```

- Renames now flow through on update.
- The initial-creation flow still works (null name → differs → set).
- The existing uniqueness guard is preserved: a name already used by another plugin is not stolen (it logs a warning instead).
- Switched `isset()` → `! empty()` so a blank/missing `name` can't wipe an existing one.

## Tests

Added three feature tests to `PluginSyncServiceTest`:

- `test_sync_updates_name_from_composer_when_name_changes` — the core fix.
- `test_sync_sets_name_on_initial_sync_when_plugin_has_no_name` — protects the creation flow.
- `test_sync_does_not_overwrite_name_when_taken_by_another_plugin` — verifies the uniqueness guard.

All sync-related suites pass (55 tests). Pint is clean.

## Note

Changing a plugin's `name` also affects `is_official`, the Satis package name, and the vendor/package URL. This PR syncs the DB field only; re-registering/renaming the Satis package on rename would be a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)