### PR TITLE
Let admins preview unpublished course content in the dashboard

### DIFF
--- a/app/Livewire/Customer/Course/Index.php
+++ b/app/Livewire/Customer/Course/Index.php
@@ -16,14 +16,21 @@ use Livewire\Component;
 class Index extends Component
 {
     #[Computed]
+    public function isAdmin(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
+    }
+
+    #[Computed]
     public function course(): ?Course
     {
-        return Course::where('is_published', true)
+        return Course::query()
+            ->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))
             ->with(['modules' => function ($query) {
-                $query->where('is_published', true)
+                $query->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))
                     ->orderBy('sort_order')
                     ->with(['lessons' => function ($query) {
-                        $query->where('is_published', true)->orderBy('sort_order');
+                        $query->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))->orderBy('sort_order');
                     }]);
             }])
             ->first();

--- a/app/Livewire/Customer/Course/LessonShow.php
+++ b/app/Livewire/Customer/Course/LessonShow.php
@@ -6,6 +6,7 @@ use App\Models\Course;
 use App\Models\CourseLesson;
 use App\Models\LessonProgress;
 use App\Models\Product;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -19,19 +20,27 @@ class LessonShow extends Component
     {
         $this->lesson = $lesson->load('module.course');
 
-        if (! $this->lesson->is_free && ! $this->hasPurchased) {
+        abort_unless($this->lesson->is_published || $this->isAdmin, 404);
+
+        if (! $this->lesson->is_free && ! $this->hasPurchased && ! $this->isAdmin) {
             abort(403, 'You need Pro access to view this lesson.');
         }
+    }
+
+    #[Computed]
+    public function isAdmin(): bool
+    {
+        return auth()->user()?->isAdmin() ?? false;
     }
 
     #[Computed]
     public function course(): Course
     {
         return $this->lesson->module->course->load(['modules' => function ($query) {
-            $query->where('is_published', true)
+            $query->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))
                 ->orderBy('sort_order')
                 ->with(['lessons' => function ($query) {
-                    $query->where('is_published', true)->orderBy('sort_order');
+                    $query->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))->orderBy('sort_order');
                 }]);
         }]);
     }
@@ -42,6 +51,17 @@ class LessonShow extends Component
         $product = Product::where('slug', 'nativephp-masterclass')->first();
 
         return $product && $product->isOwnedBy(auth()->user());
+    }
+
+    /**
+     * @return Collection<int, CourseLesson>
+     */
+    #[Computed]
+    public function moduleLessons(): Collection
+    {
+        return $this->lesson->module->lessons()
+            ->when(! $this->isAdmin, fn ($query) => $query->where('is_published', true))
+            ->get();
     }
 
     #[Computed]

--- a/resources/views/livewire/customer/course.blade.php
+++ b/resources/views/livewire/customer/course.blade.php
@@ -1,9 +1,8 @@
 <div>
-    @if ($this->hasPurchased)
-        {{-- Purchased: Show course content --}}
+    @if ($this->hasPurchased || $this->isAdmin)
+        {{-- Purchased (or admin preview): Show course content --}}
         <div class="mb-6">
-            <flux:heading size="xl">Course</flux:heading>
-            <flux:text>The NativePHP Masterclass</flux:text>
+            <flux:heading size="xl">The NativePHP Masterclass</flux:heading>
         </div>
 
         @if ($this->course)
@@ -55,6 +54,9 @@
                                     @else
                                         <flux:badge variant="pill" color="violet" size="sm">Pro</flux:badge>
                                     @endif
+                                    @if (! $module->is_published)
+                                        <flux:badge variant="pill" color="amber" size="sm">Draft</flux:badge>
+                                    @endif
                                 </div>
                                 @if ($module->description)
                                     <flux:text class="text-sm mt-1">{{ $module->description }}</flux:text>
@@ -79,6 +81,9 @@
                                                 {{ $lesson->title }}
                                             </a>
                                         </div>
+                                        @if (! $lesson->is_published)
+                                            <flux:badge variant="pill" color="amber" size="sm">Draft</flux:badge>
+                                        @endif
                                         @if ($lesson->duration_in_seconds)
                                             <flux:text class="text-xs shrink-0">{{ gmdate('i:s', $lesson->duration_in_seconds) }}</flux:text>
                                         @endif

--- a/resources/views/livewire/customer/course/lesson-show.blade.php
+++ b/resources/views/livewire/customer/course/lesson-show.blade.php
@@ -29,6 +29,9 @@
                     @else
                         <flux:badge variant="pill" color="violet" size="sm">Pro</flux:badge>
                     @endif
+                    @if (! $lesson->is_published)
+                        <flux:badge variant="pill" color="amber" size="sm">Draft</flux:badge>
+                    @endif
                     <flux:text class="text-xs">{{ $lesson->module->title }}</flux:text>
                 </div>
                 <flux:heading size="lg">{{ $lesson->title }}</flux:heading>
@@ -69,17 +72,16 @@
     </div>
 
     {{-- Other lessons in this module --}}
-    @php $moduleLessons = $lesson->module->lessons()->where('is_published', true)->orderBy('sort_order')->get(); @endphp
-    @if ($moduleLessons->count() > 1)
+    @if ($this->moduleLessons->count() > 1)
         <div class="mt-8 rounded-lg border border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5">
             <div class="p-4 border-b border-zinc-200 dark:border-white/10">
                 <flux:heading size="sm">{{ $lesson->module->title }}</flux:heading>
             </div>
-            @foreach ($moduleLessons as $moduleLesson)
+            @foreach ($this->moduleLessons as $moduleLesson)
                 @php
                     $isCurrent = $moduleLesson->id === $lesson->id;
                     $isLessonComplete = in_array($moduleLesson->id, $this->completedLessonIds);
-                    $canAccess = $moduleLesson->is_free || $this->hasPurchased;
+                    $canAccess = $moduleLesson->is_free || $this->hasPurchased || $this->isAdmin;
                 @endphp
                 @if ($canAccess)
                     <a
@@ -96,6 +98,9 @@
                             @endif
                         </div>
                         <span class="{{ $isCurrent ? 'font-medium' : '' }}">{{ $moduleLesson->title }}</span>
+                        @if (! $moduleLesson->is_published)
+                            <flux:badge variant="pill" color="amber" size="sm">Draft</flux:badge>
+                        @endif
                         @if ($moduleLesson->duration_in_seconds)
                             <span class="ml-auto text-xs text-zinc-400 dark:text-zinc-500">{{ gmdate('i:s', $moduleLesson->duration_in_seconds) }}</span>
                         @endif

--- a/tests/Feature/CourseContentTest.php
+++ b/tests/Feature/CourseContentTest.php
@@ -170,6 +170,7 @@ class CourseContentTest extends TestCase
 
         Livewire::actingAs($user)
             ->test(Index::class)
+            ->assertSee('The NativePHP Masterclass')
             ->assertSee('Test Module')
             ->assertSee('Test Lesson');
     }
@@ -278,6 +279,101 @@ class CourseContentTest extends TestCase
             'course_lesson_id' => $lesson->id,
             'completed_at' => null,
         ]);
+    }
+
+    #[Test]
+    public function admin_sees_unpublished_course_content_in_dashboard(): void
+    {
+        config(['filament.users' => ['admin@test.com']]);
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+
+        $course = Course::factory()->create();
+        $module = CourseModule::factory()->create([
+            'course_id' => $course->id,
+            'title' => 'Hidden Module',
+        ]);
+        CourseLesson::factory()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Hidden Lesson',
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(Index::class)
+            ->assertSee('Hidden Module')
+            ->assertSee('Hidden Lesson')
+            ->assertSee('Draft');
+    }
+
+    #[Test]
+    public function non_admin_owner_does_not_see_unpublished_content_in_dashboard(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::where('slug', 'nativephp-masterclass')->first();
+        ProductLicense::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+        ]);
+
+        $course = Course::factory()->published()->create();
+        $liveModule = CourseModule::factory()->published()->create([
+            'course_id' => $course->id,
+            'title' => 'Live Module',
+        ]);
+        CourseLesson::factory()->create([
+            'course_module_id' => $liveModule->id,
+            'title' => 'Hidden Lesson',
+        ]);
+        CourseModule::factory()->create([
+            'course_id' => $course->id,
+            'title' => 'Hidden Module',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Live Module')
+            ->assertDontSee('Hidden Lesson')
+            ->assertDontSee('Hidden Module');
+    }
+
+    #[Test]
+    public function admin_can_view_unpublished_pro_lesson_without_purchase(): void
+    {
+        config(['filament.users' => ['admin@test.com']]);
+        $admin = User::factory()->create(['email' => 'admin@test.com']);
+
+        $course = Course::factory()->create();
+        $module = CourseModule::factory()->create(['course_id' => $course->id]);
+        $lesson = CourseLesson::factory()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+            'title' => 'Hidden Pro Lesson',
+        ]);
+
+        Livewire::actingAs($admin)
+            ->test(LessonShow::class, ['lesson' => $lesson])
+            ->assertSee('Hidden Pro Lesson')
+            ->assertSee('Draft');
+    }
+
+    #[Test]
+    public function unpublished_lesson_is_not_accessible_to_non_admins(): void
+    {
+        $user = User::factory()->create();
+        $product = Product::where('slug', 'nativephp-masterclass')->first();
+        ProductLicense::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+        ]);
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create(['course_id' => $course->id]);
+        $lesson = CourseLesson::factory()->create([
+            'course_module_id' => $module->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(LessonShow::class, ['lesson' => $lesson])
+            ->assertNotFound();
     }
 
     #[Test]


### PR DESCRIPTION
## What

Admins (per `FILAMENT_USERS`) can now see the full course content in the Dashboard → Course section regardless of published state:

- The course, its modules, and lessons are no longer filtered by `is_published` for admins — on the course index, the lesson page sidebar, and prev/next navigation.
- Admins bypass the purchase gate, so they can open any lesson (including Pro) to preview it.
- Unpublished items are marked with an amber **Draft** badge (module list, lesson header, and module sidebar) so it's clear what customers can't see yet.
- The dashboard course heading is now **The NativePHP Masterclass** (was "Course" with a subheading).

## Why

Course content is being produced and published incrementally. Admins need to preview draft modules and lessons in the real customer-facing UI before flipping them live.

## Also

- Unpublished lessons now return a 404 for non-admins. Previously anyone with the slug could load an unpublished lesson directly, even though it was hidden from the listing.

## Tests

4 new tests in `CourseContentTest` covering: admin sees unpublished content, non-admin owners still don't, admin can open an unpublished Pro lesson without purchase, and unpublished lessons 404 for non-admins. Full file (19 tests) plus `CoursePageTest` and `HomeCourseCardTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)