### PR TITLE
Document label and enum alignment values for EDGE components

### DIFF
--- a/resources/views/docs/mobile/4/edge-components/icon.md
+++ b/resources/views/docs/mobile/4/edge-components/icon.md
@@ -44,7 +44,7 @@ to work on both platforms, see the [Icon name reference](#icon-name-reference) b
 
 @verbatim
 ```blade
-<native:row :gap="16" :align-items="1">
+<native:row :gap="16" align-items="center">
     <native:icon class="text-theme-primary" name="home" :size="24" />
     <native:icon class="text-theme-primary" name="search" :size="24" />
     <native:icon class="text-theme-primary" name="settings" :size="24" />
@@ -57,7 +57,7 @@ to work on both platforms, see the [Icon name reference](#icon-name-reference) b
 
 @verbatim
 ```blade
-<native:row :gap="8" :align-items="1">
+<native:row :gap="8" align-items="center">
     <native:icon name="check" :size="20" color="#22C55E" />
     <native:text class="text-base" color="#22C55E">Verified</native:text>
 </native:row>

--- a/resources/views/docs/mobile/4/edge-components/layout.md
+++ b/resources/views/docs/mobile/4/edge-components/layout.md
@@ -119,15 +119,9 @@ for "fill the remaining space along the parent's main axis."
 
 ## Alignment
 
-Alignment values are integers that map to standard flex alignment:
-
-| Value | Meaning |
-|-------|---------|
-| `0` | start |
-| `1` | center |
-| `2` | end |
-| `3` | stretch |
-| `4` | baseline |
+Alignment attributes accept a **readable label**, a backing **enum**, or the raw **integer** — all three resolve to
+the same value the native layout reads. Labels read best in Blade; enums give you autocomplete and type-safety when
+building elements fluently in PHP.
 
 @verbatim
 ```blade static
@@ -137,22 +131,49 @@ Alignment values are integers that map to standard flex alignment:
 </native:column>
 
 {{-- Cross-axis alignment (horizontal in a column) --}}
-<native:column :align-items="1">
+<native:column align-items="center">
     <native:text>Centered text</native:text>
 </native:column>
 
 {{-- Main-axis distribution --}}
-<native:row :justify-content="3">
+<native:row justify-content="space-between">
     <native:text>Left</native:text>
     <native:text>Right</native:text>
 </native:row>
 ```
 @endverbatim
 
-- `align-items` - Cross-axis alignment for children (int, 0-4)
-- `justify-content` - Main-axis distribution (int, 0=start, 1=center, 2=end, 3=space-between, 4=space-around, 5=space-evenly)
-- `align-self` - Override parent's `align-items` for this element (int, 0-4)
+- `align-items` - Cross-axis alignment for children — `start`, `center`, `end`, `stretch`
+- `justify-content` - Main-axis distribution — `start`, `center`, `end`, `space-between`, `space-around`, `space-evenly`
+- `align-self` - Override the parent's `align-items` for this element — `start`, `center`, `end`, `stretch`
 - `center` - Shorthand: sets both `align-items` and `justify-content` to center (boolean)
+
+### Underlying values
+
+Labels map to these integers, which still work if you prefer them (`align-items="1"`):
+
+| Integer | `align-items` / `align-self` | `justify-content` |
+|---------|------------------------------|-------------------|
+| `0` | start | start |
+| `1` | center | center |
+| `2` | end | end |
+| `3` | stretch | space-between |
+| `4` | — | space-around |
+| `5` | — | space-evenly |
+
+### In PHP
+
+When you build elements fluently, pass a label, an enum case, or an integer. The enums live in
+`Native\Mobile\Edge\Enums` — `AlignItems`, `AlignSelf`, `JustifyContent`, and `TextAlign`:
+
+```php
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Enums\AlignItems;
+
+Column::make()
+    ->alignItems(AlignItems::Center)     // enum — autocompletes, type-checked
+    ->justifyContent('space-between');   // label string — also fine
+```
 
 <aside>
 

--- a/resources/views/docs/mobile/4/edge-components/row.md
+++ b/resources/views/docs/mobile/4/edge-components/row.md
@@ -81,11 +81,12 @@ Everything else from the shared list applies the same as on any element (`w-*`, 
 ```php
 use Native\Mobile\Edge\Elements\Row;
 use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\Enums\AlignItems;
 
 Row::make(
     Text::make('Left'),
     Text::make('Right'),
-)->gap(8)->alignItems(1);
+)->gap(8)->alignItems(AlignItems::Center);
 ```
 
 - `make(Element ...$children)` - Create a row with children. Layout / style fluent methods are inherited from the

--- a/resources/views/docs/mobile/4/edge-components/text.md
+++ b/resources/views/docs/mobile/4/edge-components/text.md
@@ -31,7 +31,7 @@ All [shared layout and style attributes](layout) are supported, plus:
 
     Values outside 1-7 are clamped to the nearest supported weight.
 - `color` - Text color as hex string (optional, default: `#000000`)
-- `text-align` - Alignment: `0`=start, `1`=center, `2`=end (optional, int, default: `0`)
+- `text-align` - Alignment: `left`, `center`, or `right` — a label, a `TextAlign` case, or the integer `0`/`1`/`2` (optional, default: `left`)
 - `max-lines` - Maximum lines before truncating with ellipsis (optional, int)
 - `font-style` - `0`=normal, `1`=italic (optional, int)
 - `font-family` - Typeface: `0`=sans, `1`=serif, `2`=mono (optional, int)
@@ -306,12 +306,13 @@ to the native renderer.
 
 ```php
 use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\Enums\TextAlign;
 
 Text::make('Hello')
     ->fontSize(18)
     ->fontWeight(6)
     ->color('#1E293B')
-    ->textAlign(1)
+    ->textAlign(TextAlign::Center)
     ->maxLines(2);
 ```
 
@@ -323,6 +324,6 @@ Text::make('Hello')
 - `fontStyle(int $style)` - `0`=normal, `1`=italic
 - `italic()` - Shortcut for `fontStyle(1)`
 - `color(string $hex)` - Text color
-- `textAlign(int $align)` - `0`=start, `1`=center, `2`=end
+- `textAlign(int|string|TextAlign $align)` - `left`/`center`/`right`, a `TextAlign` case, or `0`/`1`/`2`
 - `maxLines(int $lines)` - Truncate after N lines
 - `selectable(bool $on = true)` - Make the subtree selectable (mirrors `select-text` / `select-none`)


### PR DESCRIPTION
## What

Updates the mobile v4 EDGE component docs to reflect that alignment attributes now accept a **readable label**, a backing **enum**, or the raw **integer** — all three resolve to the same native value.

- **layout.md** — Replaces the integer-only alignment table with an explanation of the label / enum / integer options. Adds an "Underlying values" reference table (kept for anyone using the raw integers) and an "In PHP" section showing the `Native\Mobile\Edge\Enums` enums (`AlignItems`, `AlignSelf`, `JustifyContent`, `TextAlign`) used fluently.
- **text.md** — Documents `text-align` as `left`/`center`/`right` (label, `TextAlign` case, or `0`/`1`/`2`) and updates the `textAlign()` signature to `int|string|TextAlign`.
- **row.md** — Example now uses `AlignItems::Center` instead of the magic number `1`.
- **icon.md** — Blade examples use `align-items="center"` instead of `:align-items="1"`.

## Why

The previous docs only showed opaque integer values (`:align-items="1"`, `:justify-content="3"`), which are hard to read and easy to get wrong. Surfacing the label and enum options makes the examples self-documenting while keeping the integer mapping available for reference.

Docs-only change; no application code touched.