### PR TITLE
Add Jump compatibility indicators for plugins and EDGE docs

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -121,6 +121,10 @@ class PluginResource extends Resource
 
                         Forms\Components\Toggle::make('is_active')
                             ->label('Active'),
+
+                        Forms\Components\Toggle::make('works_in_jump')
+                            ->label('Works in Jump')
+                            ->helperText('Show a badge indicating this plugin runs in the Jump preview app (i.e. it ships no custom native code)'),
                     ]),
 
                 Schemas\Components\Section::make('Review Checks')
@@ -312,6 +316,10 @@ class PluginResource extends Resource
                     ->label('Active')
                     ->sortable(),
 
+                Tables\Columns\ToggleColumn::make('works_in_jump')
+                    ->label('Jump')
+                    ->sortable(),
+
                 Tables\Columns\IconColumn::make('reviewed_at')
                     ->label('Reviewed')
                     ->boolean()
@@ -346,6 +354,8 @@ class PluginResource extends Resource
                 Tables\Filters\TernaryFilter::make('featured'),
                 Tables\Filters\TernaryFilter::make('is_active')
                     ->label('Active'),
+                Tables\Filters\TernaryFilter::make('works_in_jump')
+                    ->label('Works in Jump'),
             ])
             ->actions([
                 Actions\ActionGroup::make([

--- a/app/Http/Controllers/ApplinksController.php
+++ b/app/Http/Controllers/ApplinksController.php
@@ -2,21 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Support\JumpApp;
+
 class ApplinksController extends Controller
 {
-    /**
-     * Jump's iOS app identity: <TeamID>.<BundleID>.
-     */
-    private const IOS_APP_ID = 'J68WFCX458.com.bifrosttech.jump';
-
-    /**
-     * Jump's Android package + the SHA-256 of its Play app-signing cert.
-     * These are public identifiers, not secrets.
-     */
-    private const ANDROID_PACKAGE = 'com.bifrosttech.jump';
-
-    private const ANDROID_SHA256 = 'D8:31:4E:55:E5:FF:06:17:D8:49:EA:3B:1F:BF:6C:58:B3:8D:AD:2C:30:CA:13:D2:CA:42:B0:85:B4:7D:CB:38';
-
     /**
      * URL path prefixes that open in Jump.
      *
@@ -46,9 +35,9 @@ class ApplinksController extends Controller
                 ],
                 'target' => [
                     'namespace' => 'android_app',
-                    'package_name' => self::ANDROID_PACKAGE,
+                    'package_name' => JumpApp::ANDROID_PACKAGE,
                     'sha256_cert_fingerprints' => [
-                        self::ANDROID_SHA256,
+                        JumpApp::ANDROID_SHA256,
                     ],
                 ],
             ],
@@ -76,13 +65,13 @@ class ApplinksController extends Controller
             'applinks' => [
                 'details' => [
                     [
-                        'appIDs' => [self::IOS_APP_ID],
+                        'appIDs' => [JumpApp::IOS_APP_ID],
                         'components' => $components,
                     ],
                 ],
             ],
             'webcredentials' => [
-                'apps' => [self::IOS_APP_ID],
+                'apps' => [JumpApp::IOS_APP_ID],
             ],
         ]);
     }

--- a/app/Http/Controllers/ShowDocumentationController.php
+++ b/app/Http/Controllers/ShowDocumentationController.php
@@ -6,6 +6,7 @@ use App\Services\DocsVersionService;
 use App\Support\CommonMark\CommonMark;
 use Artesaos\SEOTools\Facades\SEOMeta;
 use Artesaos\SEOTools\Facades\SEOTools;
+use Closure;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -24,16 +25,12 @@ class ShowDocumentationController extends Controller
 {
     public function __invoke(Request $request, string $platform, string $version, ?string $page = null)
     {
-        if (config('app.env') === 'local') {
-            Cache::flush();
-        }
-
         abort_unless(is_dir(resource_path('views/docs/'.$platform.'/'.$version)), 404);
 
         session(['viewing_docs_version' => $version]);
         session(['viewing_docs_platform' => $platform]);
 
-        $navigation = Cache::remember("docs_nav_{$platform}_{$version}", now()->addDay(),
+        $navigation = $this->cacheOrCompute("docs_nav_{$platform}_{$version}",
             fn () => $this->getNavigation($platform, $version)
         );
 
@@ -42,7 +39,7 @@ class ShowDocumentationController extends Controller
         }
 
         try {
-            $pageProperties = Cache::remember("docs_{$platform}_{$version}_{$page}", now()->addDay(),
+            $pageProperties = $this->cacheOrCompute("docs_{$platform}_{$version}_{$page}",
                 fn () => $this->getPageProperties($platform, $version, $page)
             );
         } catch (InvalidArgumentException $e) {
@@ -81,6 +78,19 @@ class ShowDocumentationController extends Controller
         SEOTools::twitter()->setDescription($description);
 
         return view('docs.index')->with($pageProperties);
+    }
+
+    /**
+     * Cache the callback's result for a day, or compute it fresh in local so
+     * docs edits show up immediately without clearing (or racing on) the cache.
+     */
+    private function cacheOrCompute(string $key, Closure $callback): mixed
+    {
+        if (config('app.env') === 'local') {
+            return $callback();
+        }
+
+        return Cache::remember($key, now()->addDay(), $callback);
     }
 
     public function serveRawMarkdown(Request $request, string $platform, string $version, string $page)

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -295,6 +295,11 @@ class Plugin extends Model
         return $this->is_official ?? false;
     }
 
+    public function worksInJump(): bool
+    {
+        return $this->works_in_jump ?? false;
+    }
+
     public function isSatisSynced(): bool
     {
         return $this->satis_synced_at !== null;
@@ -729,6 +734,7 @@ class Plugin extends Model
             'featured' => 'boolean',
             'is_active' => 'boolean',
             'is_official' => 'boolean',
+            'works_in_jump' => 'boolean',
             'composer_data' => 'array',
             'nativephp_data' => 'array',
             'last_synced_at' => 'datetime',

--- a/app/Support/JumpApp.php
+++ b/app/Support/JumpApp.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Support;
+
+use App\Http\Controllers\ApplinksController;
+
+/**
+ * Public identity of Bifrost's Jump preview app.
+ *
+ * Single source of truth for the app's store URLs and platform identifiers,
+ * shared by the deep-link association files ({@see ApplinksController})
+ * and the docs "open in Jump" UI. These are public identifiers, not secrets.
+ */
+final class JumpApp
+{
+    /**
+     * Jump's iOS app identity: <TeamID>.<BundleID>.
+     */
+    public const IOS_APP_ID = 'J68WFCX458.com.bifrosttech.jump';
+
+    public const IOS_APP_STORE_URL = 'https://apps.apple.com/us/app/bifrost-jump/id6757173334';
+
+    public const ANDROID_PACKAGE = 'com.bifrosttech.jump';
+
+    /**
+     * SHA-256 of Jump's Play app-signing cert (public, not a secret).
+     */
+    public const ANDROID_SHA256 = 'D8:31:4E:55:E5:FF:06:17:D8:49:EA:3B:1F:BF:6C:58:B3:8D:AD:2C:30:CA:13:D2:CA:42:B0:85:B4:7D:CB:38';
+
+    public const ANDROID_PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.bifrosttech.jump';
+
+    /**
+     * The only domain whose deep links open in Jump.
+     */
+    public const CANONICAL_DOMAIN = 'https://nativephp.com';
+
+    /**
+     * Marks a visit as originating from a scanned QR code.
+     */
+    public const QR_PARAM = 'jump=qr';
+
+    /**
+     * Build the scannable deep link for a docs page.
+     *
+     * Deliberately pinned to the canonical domain rather than the current host:
+     * Jump only claims links for nativephp.com (see {@see ApplinksController}),
+     * and a phone can't resolve a local or preview hostname anyway — so a QR
+     * built from url() would be unscannable everywhere except production.
+     */
+    public static function docsDeepLink(string $path): string
+    {
+        return self::CANONICAL_DOMAIN.'/'.ltrim($path, '/').'?'.self::QR_PARAM;
+    }
+}

--- a/app/Support/QrCode.php
+++ b/app/Support/QrCode.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support;
+
+use chillerlan\QRCode\Common\EccLevel;
+use chillerlan\QRCode\Output\QROutputInterface;
+use chillerlan\QRCode\QRCode as QRCodeGenerator;
+use chillerlan\QRCode\QROptions;
+
+/**
+ * Thin wrapper around chillerlan/php-qrcode (available via filament/filament)
+ * that renders scannable, inline SVG QR codes.
+ */
+class QrCode
+{
+    /**
+     * Render the given data as inline SVG markup.
+     *
+     * Dark modules are filled with #000, so the SVG must be placed on a light
+     * background (a white container) to stay scannable in both colour schemes.
+     */
+    public static function svg(string $data): string
+    {
+        $options = new QROptions([
+            'outputType' => QROutputInterface::MARKUP_SVG,
+            'outputBase64' => false,
+            'eccLevel' => EccLevel::M,
+            'addQuietzone' => true,
+            'quietzoneSize' => 2,
+            'drawLightModules' => false,
+            'svgAddXmlHeader' => false,
+            'cssClass' => 'jump-qr',
+        ]);
+
+        $svg = (new QRCodeGenerator($options))->render($data);
+
+        // chillerlan emits a viewBox-only <svg> (no width/height) so it can scale;
+        // pin it to fill its container as a crisp square.
+        return str_replace('<svg ', '<svg style="display:block;width:100%;height:auto" ', $svg);
+    }
+}

--- a/database/factories/PluginFactory.php
+++ b/database/factories/PluginFactory.php
@@ -183,6 +183,13 @@ class PluginFactory extends Factory
         ]);
     }
 
+    public function worksInJump(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'works_in_jump' => true,
+        ]);
+    }
+
     public function free(): static
     {
         return $this->state(fn (array $attributes) => [

--- a/database/migrations/2026_07_24_112852_add_works_in_jump_to_plugins_table.php
+++ b/database/migrations/2026_07_24_112852_add_works_in_jump_to_plugins_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->boolean('works_in_jump')->default(false)->after('mobile_min_version');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn('works_in_jump');
+        });
+    }
+};

--- a/resources/views/components/docs/jump-app-overlay.blade.php
+++ b/resources/views/components/docs/jump-app-overlay.blade.php
@@ -1,0 +1,101 @@
+{{--
+    Shown when a QR visitor lands here without the Jump app installed.
+
+    Must stay outside the desktop-only right sidebar: it is the phone — not the
+    desktop — that renders this, after the deep link falls back to the browser.
+--}}
+<div
+    x-cloak
+    x-data="{
+        show: new URLSearchParams(window.location.search).get('jump') === 'qr',
+        platform: (() => {
+            const ua = navigator.userAgent || '';
+            if (/iPad|iPhone|iPod/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) return 'ios';
+            if (/android/i.test(ua)) return 'android';
+            return 'unknown';
+        })(),
+        dismiss() { this.show = false; },
+    }"
+    x-show="show"
+    x-effect="document.documentElement.style.overflow = show ? 'hidden' : ''"
+    x-on:keydown.escape.window="dismiss()"
+    class="fixed inset-0 z-50 flex items-center justify-center p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="jump-overlay-title"
+>
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" x-on:click="dismiss()" aria-hidden="true"></div>
+
+    <div
+        x-show="show"
+        x-transition
+        class="relative w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-6 text-center shadow-xl dark:border-gray-700 dark:bg-slate-900"
+    >
+        <button
+            type="button"
+            x-on:click="dismiss()"
+            class="absolute right-4 top-4 text-gray-400 transition hover:text-gray-600 dark:hover:text-gray-200"
+            aria-label="Dismiss"
+        >
+            <x-heroicon-o-x-mark class="size-5" />
+        </button>
+
+        <div class="mx-auto grid size-12 place-items-center rounded-xl bg-indigo-100 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400">
+            <x-heroicon-o-bolt class="size-6" aria-hidden="true" />
+        </div>
+
+        <h2 id="jump-overlay-title" class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+            Get the Jump app
+        </h2>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            You'll need the free Jump app to preview this page on your device. Install it, then scan the code again.
+        </p>
+
+        <div class="mt-6 flex flex-col gap-3">
+            {{-- iOS: shown on Apple devices, or when the platform can't be detected. --}}
+            <a
+                x-show="platform === 'ios' || platform === 'unknown'"
+                href="{{ \App\Support\JumpApp::IOS_APP_STORE_URL }}"
+                target="_blank"
+                rel="noopener"
+                class="inline-flex items-center justify-center gap-3 rounded-xl bg-black px-5 py-2.5 text-white transition hover:bg-gray-800"
+            >
+                <svg viewBox="0 0 24 24" fill="currentColor" class="size-6 shrink-0" aria-hidden="true">
+                    <path d="M17.05 12.04c-.03-2.6 2.12-3.85 2.22-3.91-1.21-1.77-3.09-2.01-3.76-2.04-1.6-.16-3.12.94-3.93.94-.81 0-2.06-.92-3.39-.9-1.74.03-3.35 1.01-4.25 2.57-1.81 3.14-.46 7.79 1.3 10.34.86 1.25 1.88 2.65 3.22 2.6 1.29-.05 1.78-.83 3.34-.83 1.56 0 2 .83 3.37.81 1.39-.03 2.27-1.27 3.12-2.53.98-1.45 1.39-2.85 1.41-2.92-.03-.01-2.71-1.04-2.74-4.13M14.53 4.5c.72-.87 1.2-2.08 1.07-3.28-1.03.04-2.28.69-3.02 1.56-.66.77-1.24 2-1.08 3.18 1.15.09 2.32-.59 3.03-1.46"/>
+                </svg>
+                <span class="text-left leading-tight">
+                    <span class="block text-[10px] uppercase tracking-wide opacity-80">Download on the</span>
+                    <span class="-mt-0.5 block text-base font-semibold">App Store</span>
+                </span>
+            </a>
+
+            {{-- Android: shown on Android devices, or when the platform can't be detected. --}}
+            <a
+                x-show="platform === 'android' || platform === 'unknown'"
+                href="{{ \App\Support\JumpApp::ANDROID_PLAY_STORE_URL }}"
+                target="_blank"
+                rel="noopener"
+                class="inline-flex items-center justify-center gap-3 rounded-xl bg-black px-5 py-2.5 text-white transition hover:bg-gray-800"
+            >
+                <svg viewBox="0 0 24 24" class="size-6 shrink-0" aria-hidden="true">
+                    <path fill="#00d4ff" d="M3.6 2.3c-.3.3-.4.7-.4 1.2v17c0 .5.1.9.4 1.2l.1.1L13 12.6v-.2z"/>
+                    <path fill="#00f076" d="M16.1 15.7l-3.1-3.1v-.2l3.1-3.1.1.1 3.7 2.1c1 .6 1 1.6 0 2.2z"/>
+                    <path fill="#ff3a44" d="M16.2 15.8L13 12.6 3.6 22c.4.3.9.4 1.5 0z"/>
+                    <path fill="#ffc400" d="M3.6 2.3L13 11.7l3.2-3.2-11-6.2c-.6-.3-1.2-.3-1.6 0z"/>
+                </svg>
+                <span class="text-left leading-tight">
+                    <span class="block text-[10px] uppercase tracking-wide opacity-80">Get it on</span>
+                    <span class="-mt-0.5 block text-base font-semibold">Google Play</span>
+                </span>
+            </a>
+        </div>
+
+        <button
+            type="button"
+            x-on:click="dismiss()"
+            class="mt-4 text-xs font-medium text-gray-400 transition hover:text-gray-600 dark:hover:text-gray-300"
+        >
+            Already installed? Scan the code again.
+        </button>
+    </div>
+</div>

--- a/resources/views/components/docs/jump-preview.blade.php
+++ b/resources/views/components/docs/jump-preview.blade.php
@@ -1,0 +1,54 @@
+@props(['path'])
+
+@php
+    // Points at this page on nativephp.com with a marker query param. Jump claims
+    // /docs/* deep links there, so a device with the app opens it natively; a
+    // device without it falls back to the browser, where the marker triggers the
+    // <x-docs.jump-app-overlay> "get the app" prompt.
+    $deepLink = \App\Support\JumpApp::docsDeepLink($path);
+@endphp
+
+{{-- Lives in the right sidebar, which is itself desktop-only (hidden xl:flex) --}}
+<div
+    x-data="{ open: false }"
+    class="mt-4 max-w-52 rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-slate-800/50"
+>
+    <button
+        type="button"
+        x-on:click="open = !open"
+        :aria-expanded="open"
+        class="flex w-full items-center justify-between gap-2"
+    >
+        <span class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 dark:text-white">
+            <x-heroicon-o-bolt class="size-3.5 shrink-0 text-indigo-500" aria-hidden="true" />
+            Preview in Jump
+        </span>
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="2"
+            stroke="currentColor"
+            class="size-3.5 shrink-0 text-gray-400 transition-transform duration-200"
+            :class="{ 'rotate-180': open }"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+        </svg>
+    </button>
+
+    <div x-show="open" x-collapse x-cloak>
+        {{-- Dark QR modules need a light background in both colour schemes --}}
+        <div
+            role="img"
+            aria-label="Scan to open {{ $deepLink }} in the Jump app"
+            class="mt-3 rounded-lg bg-white p-1.5"
+        >
+            {!! \App\Support\QrCode::svg($deepLink) !!}
+        </div>
+
+        <p class="mt-2 text-[11px] leading-snug text-gray-500 dark:text-gray-400">
+            Scan with your phone to preview this component live.
+        </p>
+    </div>
+</div>

--- a/resources/views/components/docs/toc-and-sponsors.blade.php
+++ b/resources/views/components/docs/toc-and-sponsors.blade.php
@@ -1,6 +1,10 @@
 {{-- Copy as Markdown Button --}}
 <x-docs.copy-markdown-button />
 
+@isset($beforeAds)
+    {{ $beforeAds }}
+@endisset
+
 <div
     class="mt-3 max-w-52 border-t border-t-black/20 pt-5 dark:border-t-white/15"
 >

--- a/resources/views/components/plugin-card.blade.php
+++ b/resources/views/components/plugin-card.blade.php
@@ -20,19 +20,31 @@
                 <x-vaadin-plug class="size-6" />
             </div>
         @endif
-        @if ($plugin->isPaid() && $plugin->isOfficial() && auth()->user()?->hasUltraAccess())
-            <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                Included with Ultra
-            </span>
-        @elseif ($plugin->isPaid())
-            <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
-                Premium
-            </span>
-        @else
-            <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-                Free
-            </span>
-        @endif
+        <div class="flex flex-col items-end gap-1.5">
+            @if ($plugin->isPaid() && $plugin->isOfficial() && auth()->user()?->hasUltraAccess())
+                <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                    Included with Ultra
+                </span>
+            @elseif ($plugin->isPaid())
+                <span class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                    Premium
+                </span>
+            @else
+                <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                    Free
+                </span>
+            @endif
+
+            @if ($plugin->worksInJump())
+                <span
+                    class="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                    title="Runs in the Jump preview app without a native build"
+                >
+                    <x-heroicon-o-bolt class="size-3" aria-hidden="true" />
+                    Works in Jump
+                </span>
+            @endif
+        </div>
     </div>
 
     <div class="mt-4 flex-1">

--- a/resources/views/docs/index.blade.php
+++ b/resources/views/docs/index.blade.php
@@ -3,6 +3,13 @@
     <meta name="docsearch:version" content="{{ $version }}" />
 @endpush
 
+@php
+    // Jump previews EDGE components, which only exist in the Mobile v4 docs.
+    $showJumpPreview = $platform === 'mobile'
+        && (string) $version === '4'
+        && str_starts_with((string) request()->route('page'), 'edge-components/');
+@endphp
+
 <x-docs-layout>
     <x-slot name="sidebarLeft">
         {!! $navigation !!}
@@ -25,6 +32,13 @@
         @endif
 
         <x-docs.toc-and-sponsors :tableOfContents="$tableOfContents">
+            {{-- EDGE component pages can be previewed live in the Jump app --}}
+            @if ($showJumpPreview)
+                <x-slot:beforeAds>
+                    <x-docs.jump-preview :path="$pagePath" />
+                </x-slot:beforeAds>
+            @endif
+
             {{-- Ad rotation --}}
             <x-blog.ad-rotation
                 :ads="$platform === 'desktop' ? ['mobile', 'bifrost', 'ultra', 'vibes', 'masterclass'] : ['desktop', 'bifrost', 'devkit', 'ultra', 'vibes', 'masterclass']"
@@ -49,6 +63,12 @@
     </h1>
 
     <x-docs.separator class="mt-4" />
+
+    {{-- Prompts QR visitors who don't have Jump installed. Kept out of the
+         desktop-only sidebar, since it renders on the phone. --}}
+    @if ($showJumpPreview)
+        <x-docs.jump-app-overlay />
+    @endif
 
     {{-- Table of contents --}}
     <div class="xl:hidden pt-9 space-y-4">

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -95,6 +95,17 @@
                             {{ $plugin->description }}
                         </p>
                     @endif
+                    @if ($plugin->worksInJump())
+                        <div class="mt-3">
+                            <span
+                                class="inline-flex items-center gap-1.5 rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                                title="This plugin runs in the Jump preview app without a native build"
+                            >
+                                <x-heroicon-o-bolt class="size-3.5" aria-hidden="true" />
+                                Works in Jump
+                            </span>
+                        </div>
+                    @endif
                 </div>
             </div>
         </header>

--- a/tests/Feature/ApplinksTest.php
+++ b/tests/Feature/ApplinksTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\JumpApp;
+use Tests\TestCase;
+
+class ApplinksTest extends TestCase
+{
+    public function test_assetlinks_exposes_the_jump_android_identity(): void
+    {
+        $this->get('/.well-known/assetlinks.json')
+            ->assertStatus(200)
+            ->assertJsonFragment(['package_name' => JumpApp::ANDROID_PACKAGE])
+            ->assertJsonFragment(['sha256_cert_fingerprints' => [JumpApp::ANDROID_SHA256]]);
+    }
+
+    public function test_apple_app_site_association_exposes_the_jump_ios_identity(): void
+    {
+        $this->get('/.well-known/apple-app-site-association')
+            ->assertStatus(200)
+            ->assertJsonFragment(['appIDs' => [JumpApp::IOS_APP_ID]]);
+    }
+
+    public function test_apple_app_site_association_scopes_to_docs_deep_links(): void
+    {
+        $this->get('/.well-known/apple-app-site-association')
+            ->assertStatus(200)
+            ->assertJsonFragment(['/' => '/docs/*']);
+    }
+}

--- a/tests/Feature/Docs/DocsCachingTest.php
+++ b/tests/Feature/Docs/DocsCachingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Docs;
 use App\Features\ShowPlugins;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Laravel\Pennant\Feature;
 use Tests\TestCase;
 
@@ -17,6 +18,15 @@ class DocsCachingTest extends TestCase
         parent::setUp();
 
         Feature::define(ShowPlugins::class, true);
+
+        // These tests render full docs pages that contain fenced code blocks.
+        // Torchlight throws outside production when no token is configured (as
+        // in CI), so give it a token and fake the API to force its offline
+        // fallback — the pages render deterministically without a real token.
+        config(['torchlight.token' => 'test-token']);
+        Http::fake([
+            '*' => Http::response(['blocks' => []], 200),
+        ]);
     }
 
     public function test_local_docs_request_does_not_flush_the_entire_cache(): void

--- a/tests/Feature/Docs/DocsCachingTest.php
+++ b/tests/Feature/Docs/DocsCachingTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Docs;
+
+use App\Features\ShowPlugins;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class DocsCachingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_local_docs_request_does_not_flush_the_entire_cache(): void
+    {
+        config(['app.env' => 'local']);
+        Cache::put('unrelated-key', 'keep-me', now()->addHour());
+
+        $this->get('/docs/mobile/4/edge-components/stack')->assertStatus(200);
+
+        $this->assertSame('keep-me', Cache::get('unrelated-key'));
+    }
+
+    public function test_local_docs_request_does_not_cache_page_properties(): void
+    {
+        config(['app.env' => 'local']);
+
+        $this->get('/docs/mobile/4/edge-components/stack')->assertStatus(200);
+
+        $this->assertFalse(Cache::has('docs_mobile_4_edge-components/stack'));
+    }
+
+    public function test_non_local_docs_request_caches_page_properties(): void
+    {
+        config(['app.env' => 'production']);
+
+        $this->get('/docs/mobile/4/edge-components/stack')->assertStatus(200);
+
+        $this->assertTrue(Cache::has('docs_mobile_4_edge-components/stack'));
+    }
+}

--- a/tests/Feature/Docs/JumpPreviewTest.php
+++ b/tests/Feature/Docs/JumpPreviewTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature\Docs;
+
+use App\Features\ShowPlugins;
+use App\Support\JumpApp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class JumpPreviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_edge_component_page_shows_the_jump_qr_and_store_overlay(): void
+    {
+        $response = $this->get('/docs/mobile/4/edge-components/stack');
+
+        $response->assertStatus(200)
+            ->assertSee('Preview in Jump')
+            ->assertSee('Get the Jump app')
+            ->assertSee(JumpApp::IOS_APP_STORE_URL, false)
+            ->assertSee(JumpApp::ANDROID_PLAY_STORE_URL, false);
+    }
+
+    public function test_qr_deep_link_targets_this_page_with_the_marker_param(): void
+    {
+        $this->get('/docs/mobile/4/edge-components/badge')
+            ->assertStatus(200)
+            ->assertSee('edge-components/badge?jump=qr', false);
+    }
+
+    public function test_qr_deep_link_is_pinned_to_the_canonical_domain(): void
+    {
+        // Jump only claims deep links for nativephp.com, so the QR must encode
+        // that domain regardless of the host the docs are being served from.
+        $this->get('/docs/mobile/4/edge-components/badge')
+            ->assertStatus(200)
+            ->assertSee('https://nativephp.com/docs/mobile/4/edge-components/badge?jump=qr', false);
+    }
+
+    public function test_qr_card_renders_in_the_desktop_only_right_sidebar(): void
+    {
+        $html = $this->get('/docs/mobile/4/edge-components/stack')
+            ->assertStatus(200)
+            ->getContent();
+
+        // The right sidebar is the desktop-only region and follows </article>.
+        $this->assertGreaterThan(
+            strrpos($html, '</article>'),
+            strpos($html, 'Preview in Jump'),
+            'The QR card should render inside the right sidebar.'
+        );
+    }
+
+    public function test_qr_card_sits_between_the_copy_button_and_the_ads(): void
+    {
+        $html = $this->get('/docs/mobile/4/edge-components/stack')
+            ->assertStatus(200)
+            ->getContent();
+
+        $copyButton = strrpos($html, 'Copy as Markdown');
+        $qrCard = strpos($html, 'Preview in Jump');
+        $ads = strpos($html, 'Become a Partner', $qrCard);
+
+        $this->assertGreaterThan($copyButton, $qrCard, 'The QR card should follow the Copy as Markdown button.');
+        $this->assertGreaterThan($qrCard, $ads, 'The QR card should come before the ads.');
+    }
+
+    public function test_qr_card_is_collapsed_to_its_title_by_default(): void
+    {
+        $html = $this->get('/docs/mobile/4/edge-components/stack')
+            ->assertStatus(200)
+            ->getContent();
+
+        // The card occupies the sidebar slot between the copy button and the ads.
+        $start = strrpos($html, 'Copy as Markdown');
+        $end = strpos($html, 'Become a Partner', $start);
+        $cardMarkup = substr($html, $start, $end - $start);
+
+        $this->assertStringContainsString('Preview in Jump', $cardMarkup);
+        $this->assertStringContainsString('x-data="{ open: false }"', $cardMarkup);
+        $this->assertStringContainsString('open = !open', $cardMarkup);
+        $this->assertStringContainsString('x-collapse', $cardMarkup);
+    }
+
+    public function test_store_overlay_stays_outside_the_desktop_only_sidebar(): void
+    {
+        $html = $this->get('/docs/mobile/4/edge-components/stack')
+            ->assertStatus(200)
+            ->getContent();
+
+        // Phones render the overlay, so it must not be hidden with the sidebar.
+        $this->assertLessThan(
+            strrpos($html, '</article>'),
+            strpos($html, 'Get the Jump app'),
+            'The overlay should render in the always-visible article body.'
+        );
+    }
+
+    public function test_non_edge_docs_page_has_no_jump_preview(): void
+    {
+        $this->get('/docs/mobile/4/getting-started/introduction')
+            ->assertStatus(200)
+            ->assertDontSee('Preview in Jump')
+            ->assertDontSee('Get the Jump app')
+            ->assertDontSee('jump=qr', false);
+    }
+
+    /**
+     * EDGE sections also exist in Mobile v2 and v3, but Jump only previews v4.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function nonV4EdgePagesProvider(): array
+    {
+        return [
+            'mobile v2 edge components' => ['/docs/mobile/2/edge-components/bottom-nav'],
+            'mobile v3 edge components' => ['/docs/mobile/3/edge-components/bottom-nav'],
+        ];
+    }
+
+    #[DataProvider('nonV4EdgePagesProvider')]
+    public function test_older_mobile_edge_pages_have_no_jump_preview(string $url): void
+    {
+        $this->get($url)
+            ->assertStatus(200)
+            ->assertDontSee('Preview in Jump')
+            ->assertDontSee('Get the Jump app')
+            ->assertDontSee('jump=qr', false);
+    }
+
+    public function test_desktop_docs_have_no_jump_preview(): void
+    {
+        $this->get('/docs/desktop/2/the-basics/windows')
+            ->assertStatus(200)
+            ->assertDontSee('Preview in Jump')
+            ->assertDontSee('Get the Jump app')
+            ->assertDontSee('jump=qr', false);
+    }
+}

--- a/tests/Feature/Docs/JumpPreviewTest.php
+++ b/tests/Feature/Docs/JumpPreviewTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Docs;
 use App\Features\ShowPlugins;
 use App\Support\JumpApp;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
@@ -18,6 +19,15 @@ class JumpPreviewTest extends TestCase
         parent::setUp();
 
         Feature::define(ShowPlugins::class, true);
+
+        // These tests render full docs pages that contain fenced code blocks.
+        // Torchlight throws outside production when no token is configured (as
+        // in CI), so give it a token and fake the API to force its offline
+        // fallback — the pages render deterministically without a real token.
+        config(['torchlight.token' => 'test-token']);
+        Http::fake([
+            '*' => Http::response(['blocks' => []], 200),
+        ]);
     }
 
     public function test_edge_component_page_shows_the_jump_qr_and_store_overlay(): void

--- a/tests/Feature/PluginJumpIndicatorTest.php
+++ b/tests/Feature/PluginJumpIndicatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Livewire\PluginDirectory;
+use App\Models\Plugin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginJumpIndicatorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_works_in_jump_defaults_to_false(): void
+    {
+        $plugin = Plugin::factory()->create()->refresh();
+
+        $this->assertFalse($plugin->works_in_jump);
+        $this->assertFalse($plugin->worksInJump());
+    }
+
+    public function test_works_in_jump_helper_reflects_the_column(): void
+    {
+        $plugin = Plugin::factory()->worksInJump()->create();
+
+        $this->assertTrue($plugin->works_in_jump);
+        $this->assertTrue($plugin->worksInJump());
+    }
+
+    public function test_detail_page_shows_pill_when_plugin_works_in_jump(): void
+    {
+        $plugin = Plugin::factory()->approved()->worksInJump()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('Works in Jump');
+    }
+
+    public function test_detail_page_hides_pill_when_plugin_does_not_work_in_jump(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertDontSee('Works in Jump');
+    }
+
+    public function test_plugin_card_shows_badge_when_plugin_works_in_jump(): void
+    {
+        Plugin::factory()->approved()->worksInJump()->create();
+
+        Livewire::test(PluginDirectory::class)
+            ->assertSee('Works in Jump');
+    }
+
+    public function test_plugin_card_hides_badge_when_plugin_does_not_work_in_jump(): void
+    {
+        Plugin::factory()->approved()->create();
+
+        Livewire::test(PluginDirectory::class)
+            ->assertDontSee('Works in Jump');
+    }
+}

--- a/tests/Unit/Support/JumpAppTest.php
+++ b/tests/Unit/Support/JumpAppTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\JumpApp;
+use Tests\TestCase;
+
+class JumpAppTest extends TestCase
+{
+    public function test_docs_deep_link_uses_the_canonical_domain(): void
+    {
+        $link = JumpApp::docsDeepLink('docs/mobile/4/edge-components/stack');
+
+        $this->assertSame(
+            'https://nativephp.com/docs/mobile/4/edge-components/stack?jump=qr',
+            $link
+        );
+    }
+
+    public function test_docs_deep_link_tolerates_a_leading_slash(): void
+    {
+        $link = JumpApp::docsDeepLink('/docs/mobile/4/edge-components/badge');
+
+        $this->assertSame(
+            'https://nativephp.com/docs/mobile/4/edge-components/badge?jump=qr',
+            $link
+        );
+    }
+
+    public function test_docs_deep_link_ignores_the_configured_app_url(): void
+    {
+        config(['app.url' => 'https://keen-pony.test']);
+
+        $this->assertStringStartsWith(
+            'https://nativephp.com/',
+            JumpApp::docsDeepLink('docs/mobile/4/edge-components/stack')
+        );
+    }
+}

--- a/tests/Unit/Support/QrCodeTest.php
+++ b/tests/Unit/Support/QrCodeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\QrCode;
+use Tests\TestCase;
+
+class QrCodeTest extends TestCase
+{
+    public function test_it_renders_inline_svg_markup(): void
+    {
+        $svg = QrCode::svg('https://nativephp.com/docs/mobile/4/edge-components/stack?jump=qr');
+
+        $this->assertStringContainsString('<svg', $svg);
+        $this->assertStringContainsString('</svg>', $svg);
+    }
+
+    public function test_it_returns_raw_markup_not_a_base64_data_uri(): void
+    {
+        $svg = QrCode::svg('https://example.test');
+
+        $this->assertStringNotContainsString('data:image', $svg);
+    }
+
+    public function test_it_pins_the_svg_to_fill_its_container(): void
+    {
+        $svg = QrCode::svg('https://example.test');
+
+        $this->assertStringContainsString('width:100%', $svg);
+    }
+}


### PR DESCRIPTION
Surfaces [Jump](https://bifrost.nativephp.com/jump) — Bifrost's mobile preview app — in two places it was previously invisible.

## Plugins: "Works in Jump" pill

Jump is a pre-built binary containing only NativePHP's core native APIs, so a plugin shipping its own Kotlin/Swift bridge functions can't run in it. That's a judgment call rather than something reliably derivable from a manifest, so this adds a **manual** `works_in_jump` flag:

- Admin-controlled in Filament (form toggle, table toggle-column, ternary filter)
- Rendered as a pill on the plugin detail page and on marketplace cards
- Defaults to `false`; `worksInJump()` helper mirrors the existing `isOfficial()` / `isActive()` conventions

## Docs: scannable QR on EDGE component pages

Mobile v4 EDGE component pages now show a **collapsible QR card** in the right sidebar (between "Copy as Markdown" and the ads), encoding that page's docs URL plus a `?jump=qr` marker:

- **With Jump installed** — the OS routes the `/docs/*` deep link straight into the app (already claimed via the existing AASA/assetlinks files)
- **Without it** — the link falls back to the mobile browser, where the marker triggers a "Get the Jump app" overlay with **platform-detected** store buttons (App Store on iOS, Play on Android, both when undetectable)

Two deliberate details worth reviewing:

1. **The overlay lives outside the sidebar.** The right sidebar is `hidden xl:flex`, and the overlay is rendered by the *phone*, so putting it there would hide it exactly where it's needed.
2. **The QR is pinned to `nativephp.com`.** Jump only claims deep links for that domain, and a phone can't resolve a local/preview hostname — a QR built from `url()` would be unscannable outside production.

Scoped strictly to Mobile v4: EDGE sections also exist in Mobile v2 and v3, and this must not appear there.

## Incidental fixes

- **Extracted `App\Support\JumpApp`** — the deep-link association files and the docs UI now share one source of truth for Jump's bundle IDs and store URLs, instead of duplicating them across `ApplinksController` and docs markdown.
- **Fixed a `Cache::flush()` race** in `ShowDocumentationController`. It ran on *every* local docs request; concurrent requests could delete a hashed cache subdirectory mid-iteration, throwing `FilesystemIterator ... Failed to open directory` (hit while testing this branch). Local now bypasses the docs cache instead of flushing globally — same always-fresh-in-dev intent, no race, and no longer wipes unrelated cache entries.

## Testing

25 new tests across 6 files, all passing alongside the existing docs suite (56 total):

- QR generation and canonical-domain pinning (unit)
- Card/overlay rendering, sidebar placement ordering, collapsed-by-default markup
- Negative coverage: non-EDGE pages, Mobile v2/v3 EDGE pages, desktop docs
- Plugin pill visibility on the detail page and cards
- `ApplinksTest` locks the `JumpApp` extraction
- `DocsCachingTest` locks the cache-race fix

Also verified end-to-end against a live dev site: the rendered QR SVG is byte-identical to one generated from the canonical URL, confirming the actual scannable payload.

## Note for reviewers

The QR points at production `nativephp.com`, so scanning it before this merges will exercise the deep-link path but **not** the overlay — production has no `?jump=qr` handler until this ships. To try the overlay now, load an EDGE page locally with `?jump=qr` under device emulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)