### PR TITLE
v4 docs: nested components + composable inline chrome

### DIFF
--- a/resources/views/docs/mobile/4/edge-components/bottom-nav.md
+++ b/resources/views/docs/mobile/4/edge-components/bottom-nav.md
@@ -3,11 +3,6 @@ title: Bottom Navigation
 order: 120
 ---
 
-> [!IMPORTANT]
-> **Prefer the [Layout model](../the-basics/layouts).** Declare your app's bottom tabs with the `TabBar`
-> builder in a `NativeLayout` class rather than placing `<native:bottom-nav>` in a screen. This page documents the
-> inline element, which still works but is no longer the recommended approach.
-
 ## Overview
 
 <div class="images-two-up not-prose">
@@ -18,7 +13,12 @@ order: 120
 
 </div>
 
-A bottom navigation bar with up to 5 items. Used for your app's primary navigation.
+A bottom navigation bar with up to 5 items — your app's primary navigation. Placing `<native:bottom-nav>` at the
+root of a screen's Blade **hoists it onto the real native chrome root** (a `TabView` on iOS, a `NavigationBar` in a
+`Scaffold` on Android), so you get the platform tab bar with Liquid Glass / Material You for free. It renders
+identically to the [`TabBar` builder](../the-basics/layouts#tabbar--the-bottom-tabs) a layout produces — inline is
+the tool when the tabs belong to *one* screen; a [layout](../the-basics/layouts) is the tool when many screens share
+the same tabs.
 
 One bar demonstrates the whole item API — an `active` tab, a `news` dot, and a `badge`:
 
@@ -50,15 +50,23 @@ One bar demonstrates the whole item API — an `active` tab, a `news` dot, and a
 ```
 @endverbatim
 
-The [Builder API](#builder-api) below produces this same bar from a layout class — the recommended home for it.
+## The override contract
+
+An inline bottom nav **wins over the layout's tab bar for that slot** — the layout's top bar (the *other* slot)
+still renders. An inline bar on a screen with **no layout at all** still produces native chrome. Every attribute is
+a Blade expression over your screen's state, so a badge count or active tab is **reactive** and re-renders when the
+underlying property changes. See [Inline overrides](../the-basics/layouts#inline-overrides).
 
 ## Props
 
 - `label-visibility` - `labeled`, `selected`, or `unlabeled` (optional, default: `labeled`)
-- `dark` - Force dark mode styling (optional)
+- `dark` - Force dark mode styling (optional, boolean)
 - `active-color` - Color of the active tab's icon and label. Hex string (optional)
 - `background-color` - Bar background color. Hex string. Wins over `dark`'s default (optional)
 - `text-color` - Color of inactive tab icons and labels. Hex string. Active tabs use `active-color` (optional)
+- `font-name` - Custom font for tab labels: a `resources/fonts/` token or [config alias](text#font-aliases--the-app-wide-default) (optional)
+- `minimize-on-scroll` - Shrink the bar as content scrolls (optional, boolean) [iOS 26+]
+- `custom` - Keep the bar in the content tree as an ordinary drawn element instead of hoisting it (optional, boolean). Still suppresses the layout's tab bar for that slot
 
 <aside>
 
@@ -70,20 +78,19 @@ above the indicator, mirroring iOS `UITabBar`.
 
 ## Children
 
-> [!IMPORTANT]
-> In the [Layout model](../the-basics/layouts#builder-reference) a bottom-nav item is a `Tab` — use that builder
-> rather than placing `<native:bottom-nav-item>` inline.
-
 A `<native:bottom-nav>` can contain up to 5 `<native:bottom-nav-item>` elements.
 
 ### Props
 
 - `id` - Unique identifier (required)
-- `icon` - A named [icon](icon#icon-name-reference) (required)
-- `label` - Accessibility label (required)
-- `url` - A URL to navigate to in the web view (required)
-- `active` - Highlight this item as active (optional, default: `false`)
+- `icon` - A named [icon](icon#icon-name-reference) — the cross-platform fallback (optional if a platform icon is given)
+- `ios-icon` / `android-icon` - Per-platform icon overrides: an enum case (`App\Icons\Ios`, `App\Icons\Android`, `App\Icons\AndroidOutlined`) or a raw symbol string. `ios` / `android` are accepted as shorthand (optional). See [Platform icons](#platform-icons)
+- `material-variant` - Material style hint for Android, e.g. `outlined` (optional). Set automatically by an `AndroidOutlined` enum case
+- `label` - Accessibility / display label (required)
+- `url` - A URL to navigate to when tapped (required). Tab taps **replace** — see below
+- `active` - Highlight this item as active (optional, default: `false`). An explicit `active` beats the automatic longest-prefix URL highlight
 - `badge` - Badge text/number, e.g. `"2"` — small red pill anchored top-right of the icon (optional)
+- `badge-color` - Badge color. Hex string (optional)
 - `news` - Show a small red dot anchored top-right of the icon. Mutually exclusive with `badge` (optional, default: `false`)
 
 <aside>
@@ -103,44 +110,48 @@ Here's `badge` on a tab item:
 
 </div>
 
-## Builder API
+### Active tab highlighting
 
-When a `<native:bottom-nav>` is supplied by a [layout](../the-basics/layouts), you build it fluently with the `TabBar`
-and `Tab` builders rather than writing it in Blade. This is the same bar as the [Overview](#overview) example:
+If no item is marked `active`, the framework auto-highlights the tab whose `url` is the longest prefix of the
+current screen's URI — so `/friends/42` lights the `/friends` tab. Set `:active="true"` on an item to force the
+highlight explicitly (a search-results screen reached from the Search tab, say); an explicit choice always wins over
+the prefix match.
 
-```php
-use Native\Mobile\Edge\Layouts\Builders\Tab;
-use Native\Mobile\Edge\Layouts\Builders\TabBar;
+### Platform icons
 
-TabBar::make()
-    ->labelVisibility('labeled')
-    ->activeColor('#0891b2')
-    ->add(Tab::link('Home',    '/home',    icon: 'home')->active())
-    ->add(Tab::link('Friends', '/friends', icon: 'person.3.fill')->news())
-    ->add(Tab::link('Profile', '/profile', icon: 'person')->badge('3'));
+`<native:bottom-nav-item>` resolves icons through the same contract as [`<native:icon>`](icon#typed-icon-enums): a
+shared `icon` string is the cross-platform fallback, and `:ios-icon` / `:android-icon` (or the `:ios` / `:android`
+shorthand) override it per platform. Each override accepts a generated enum case or a raw symbol string; an
+`AndroidOutlined` case carries its `material_variant` automatically.
+
+@verbatim
+```blade static
+@use('App\Icons\Ios')
+@use('App\Icons\AndroidOutlined')
+
+<native:bottom-nav>
+    <native:bottom-nav-item
+        id="home"
+        label="Home"
+        url="/home"
+        :ios="Ios::House"
+        :android="AndroidOutlined::Home"
+    />
+</native:bottom-nav>
 ```
+@endverbatim
 
-To force a dark bar regardless of the system theme, chain `->dark()` — or take full control with
-`->backgroundColor('#0F172A')->textColor('#94A3B8')`, which wins over `dark()`'s default.
+### Search tab
 
-### `TabBar` methods
+Mark one item with the boolean `search` attribute to make it present a native search field instead of navigating.
+The search corpus comes from the screen's `searchItems()` or `onSearchQuery()` methods; `search-placeholder` and
+`search-debounce-ms` (default `250`) tune the field. See [Search](../digging-deeper/search) for the full flow.
 
-- `make()` - Create a new builder
-- `dark(bool $dark = true)` - Force dark mode styling
-- `activeColor(string $color)` - Color of the active tab's icon and label
-- `backgroundColor(string $color)` - Bar background color (overrides `dark()`'s default)
-- `textColor(string $color)` - Color of inactive tab icons and labels
-- `labelVisibility(string $mode)` - `"labeled"`, `"selected"`, or `"unlabeled"`
-- `add(Tab $tab)` - Append a tab item
+## Builder alternative
 
-### `Tab` methods
-
-- `link(string $label, string $url, ?string $icon = null)` - Build a tab. The id defaults to the label slugified
-- `id(string $id)` - Override the auto-generated id
-- `icon(string $icon)` - A named [icon](icon#icon-name-reference)
-- `badge(string $badge, ?string $color = null)` - Show a numeric/text badge
-- `news(bool $news = true)` - Show a red dot indicator
-- `active(bool $active = true)` - Mark this tab as active
+When many screens share the same tabs, declare them once with the `TabBar` builder in a
+[layout](../the-basics/layouts) instead of repeating the inline element. The builder produces the exact same native
+chrome — see the [Builder reference](../the-basics/layouts#tabbar--the-bottom-tabs) for `TabBar` and `Tab`.
 
 ## Per-screen tab bar
 
@@ -164,14 +175,6 @@ class ChatThread extends NativeComponent
 }
 ```
 
-### `TabBarOptions` methods
-
-- `make()` - Create a new builder
-- `hidden(bool $hidden = true)` - Hide the tab bar on this screen — the pushed-detail pattern
-- `highlight(string $tabId)` - Force a tab id to render as active, even when the screen's URL doesn't match any tab (e.g. a search-results screen reached from the Search tab)
-- `activeColor(string $color)` - Color of the active tab's icon and label on this screen
-- `backgroundColor(string $color)` - Bar background color on this screen
-
 For the common "hide the tab bar on this detail screen" case, the shorter `protected bool $hidesTabBar = true;`
 property on the screen is equivalent to `TabBarOptions::make()->hidden()`. Use either; if both are set, the explicit
-builder wins.
+builder wins. See the [`TabBarOptions` reference](../the-basics/layouts#tabbar--the-bottom-tabs) in Layouts.

--- a/resources/views/docs/mobile/4/edge-components/fab.md
+++ b/resources/views/docs/mobile/4/edge-components/fab.md
@@ -1,0 +1,80 @@
+---
+title: Floating Action Button
+order: 222
+---
+
+## Overview
+
+A Material-style floating action button that floats above your screen's content, pinned to a bottom corner. On the
+wire a `<native:fab>` **is a [`pressable`](pressable)** — pre-styled as a FAB — so `@tap`, press feedback, and `url`
+navigation all behave exactly like any other pressable, on both platforms.
+
+@verbatim
+```blade
+<native:fab icon="add" @tap="createTask" />
+```
+@endverbatim
+
+`@tap` names a public method on your component. Give it a `label` to get an extended FAB (icon + text pill):
+
+@verbatim
+```blade
+<native:fab icon="edit" label="Compose" @tap="compose" />
+```
+@endverbatim
+
+<aside>
+
+A fab declared at the **top level** of your screen's Blade is hoisted out of the flex flow and floated above the
+whole content area — including scroll views — no matter where in the file you declared it. A fab nested deeper in
+the tree still renders, absolutely positioned within its nearest container. One top-level fab per screen is
+hoisted.
+
+</aside>
+
+## Props
+
+- `icon` - A named [icon](icon#icon-name-reference) — the cross-platform fallback (required for a visible fab unless a platform icon is given)
+- `ios-icon` / `android-icon` - Per-platform icon overrides: an enum case (`App\Icons\Ios`, `App\Icons\Android`, `App\Icons\AndroidOutlined`) or a raw symbol string. `ios` / `android` are accepted as shorthand (optional). Same contract as [`<native:icon>`](icon#typed-icon-enums)
+- `label` - Text label → renders as an extended FAB (optional)
+- `url` - Navigate on tap, when no `@tap` handler is set (optional)
+- `size` - `small`, `regular` (default), or `large` (optional)
+- `position` - Horizontal corner: `end` (default) or `start` (optional)
+- `bottom-offset` - Distance from the container bottom in dp (optional, default: `16`)
+- `edge-offset` - Distance from the side edge in dp (optional, default: `16`)
+- `corner-radius` - Override the default circular radius (optional)
+- `container-color` - Background color. Hex string (optional, default: the theme `primary` token)
+- `content-color` - Icon and label color. Hex string (optional, default: the theme `on-primary` token)
+- `elevation` - Shadow elevation (optional, default: `6`)
+
+By default the fab picks up your [theme tokens](../digging-deeper/theming) — `primary` for the container and
+`on-primary` for its content — so it re-skins with the rest of the app. Only reach for `container-color` /
+`content-color` when a fab genuinely shouldn't follow the theme.
+
+## Platform icons
+
+@verbatim
+```blade
+@use('App\Icons\Ios')
+@use('App\Icons\Android')
+
+<native:fab :ios-icon="Ios::Plus" :android-icon="Android::Add" @tap="createTask" />
+```
+@endverbatim
+
+An enum-only fab (no shared `icon`) is fine — each platform resolves its own case.
+
+## Positioning
+
+@verbatim
+```blade static
+{{-- Bottom-left, lifted clear of a bottom bar --}}
+<native:fab icon="mic" position="start" bottom-offset="88" @tap="record" />
+```
+@endverbatim
+
+## Chrome, not layout
+
+The fab is **inline-only chrome** — there is no layout builder for it. It composes freely with the rest of the
+chrome system: an inline [`<native:top-bar>`](top-bar) or a layout's [`TabBar`](../the-basics/layouts) render
+around it, and the fab floats above the screen's content either way.

--- a/resources/views/docs/mobile/4/edge-components/side-nav.md
+++ b/resources/views/docs/mobile/4/edge-components/side-nav.md
@@ -4,9 +4,11 @@ order: 370
 ---
 
 > [!IMPORTANT]
-> **Prefer the [Layout model](../the-basics/layouts#drawer-navigation).** Provide a slide-out drawer with the
-> `Drawer` builder from a `NativeLayout` rather than placing `<native:side-nav>` in a screen. This page documents
-> the inline element, which still works but is no longer the recommended approach.
+> **Use the [Drawer layout](../the-basics/layouts#drawer-navigation).** Unlike the other inline chrome elements
+> ([`top-bar`](top-bar), [`bottom-nav`](bottom-nav), [`fab`](fab)), an inline `<native:side-nav>` currently has
+> **no built-in drawer host**: the element compiles and is hoisted onto the chrome root, but nothing consumes it
+> yet, so it renders nothing on either platform. Provide drawers with the `Drawer` builder in a `NativeLayout` —
+> its contents are any Blade view. The element reference below is kept for when the inline drawer host lands.
 
 ## Overview
 

--- a/resources/views/docs/mobile/4/edge-components/top-bar.md
+++ b/resources/views/docs/mobile/4/edge-components/top-bar.md
@@ -3,11 +3,6 @@ title: Top Bar
 order: 450
 ---
 
-> [!IMPORTANT]
-> **Prefer the [Layout model](../the-basics/layouts).** Declare your app's top bar with the `NavBar`
-> builder in a `NativeLayout` class rather than placing `<native:top-bar>` in a screen. This page documents the
-> inline element, which still works but is no longer the recommended approach.
-
 ## Overview
 <div class="images-two-up not-prose">
 
@@ -17,7 +12,12 @@ order: 450
 
 </div>
 
-A top bar with title, subtitle, and action buttons. This renders at the top of the screen.
+A top bar with title, subtitle, and action buttons. Placing `<native:top-bar>` at the root of a screen's Blade is a
+first-class way to give that screen its own bar — the element **hoists onto the real native chrome root** (a
+`NavigationStack` on iOS, a `Scaffold` toolbar on Android), so you get edge-swipe back, predictive back, large
+titles, and Liquid Glass / Material You for free. It renders identically to the [`NavBar` builder](../the-basics/layouts#navbar--the-top-bar)
+a layout produces — inline is the tool when the bar belongs to *one* screen; a [layout](../the-basics/layouts) is the
+tool when many screens share it.
 
 @verbatim
 ```blade static
@@ -26,7 +26,7 @@ A top bar with title, subtitle, and action buttons. This renders at the top of t
         id="search"
         label="Search"
         icon="search"
-        :url="route('search')"
+        @tap="openSearch"
     />
     <native:top-bar-action
         id="settings"
@@ -38,14 +38,47 @@ A top bar with title, subtitle, and action buttons. This renders at the top of t
 ```
 @endverbatim
 
+## The override contract
+
+An inline top bar **wins over the layout's top bar for that slot** — the layout's tab bar (the *other* slot) still
+renders. This lets a single screen customize its title bar without dropping its layout. An inline bar on a screen
+with **no layout at all** still produces native chrome. See [Inline overrides](../the-basics/layouts#inline-overrides).
+
+Every attribute is a Blade expression evaluated against your screen's state, so the bar is **reactive**: bind a
+subtitle, swap an action icon, or flip a title and it re-renders when the underlying property changes.
+
+@verbatim
+```blade static
+@php $unread = 3; @endphp
+
+<native:top-bar :title="$unread ? 'Inbox' : 'All caught up'" :subtitle="$unread.' unread'" />
+```
+@endverbatim
+
+<aside>
+
+`<native:top-bar>` is hoisted out of the content flow, so it can sit anywhere at the root of your Blade — the
+framework lifts it onto the chrome root regardless of where you declared it. Only **one** top bar per screen is
+hoisted; a second is left in the tree.
+
+</aside>
+
 ## Props
 
-- `title` - The title text (required)
-- `subtitle` - A small line under the title (optional)
-- `show-navigation-icon` - Show the back chevron (optional, default: `true`)
-- `background-color` - Background color. Hex string (optional)
-- `text-color` - Title and icon color. Also flows to `<native:top-bar-action>` icons (optional)
-- `elevation` - Hairline thickness at the bottom of the bar in dp (optional)
+- `title` - The title text (optional, string)
+- `subtitle` - A small line under the title (optional, string)
+- `back` - Show the back chevron (optional, boolean). Alias of `show-navigation-icon`
+- `show-navigation-icon` - Show the back chevron (optional, boolean)
+- `background-color` - Bar background color. Hex string (optional)
+- `text-color` - Title and icon color. Also the default tint for `<native:top-bar-action>` icons (optional)
+- `font-name` - Custom font for the title/subtitle: a `resources/fonts/` token or [config alias](text#font-aliases--the-app-wide-default) (optional)
+- `display-mode` - Title display mode: `inline`, `large`, or `automatic` (optional, default: `inline`)
+- `scroll-behavior` - How the bar reacts to content scrolling: `collapse`, `pinned`, or `enterAlways` (optional)
+- `elevation` - Hairline thickness at the bottom of the bar in dp (optional, int)
+- `search-placeholder` - Placeholder for an attached native search field (optional). See [Search](../digging-deeper/search)
+- `search-on-query` - Screen method invoked as the search text changes (optional)
+- `search-debounce-ms` - Debounce for `search-on-query` in milliseconds (optional, default: `300`)
+- `custom` - Keep the bar in the content tree as an ordinary drawn element instead of hoisting it (optional, boolean). See [Custom bars](#custom-bars)
 
 <aside>
 
@@ -56,72 +89,79 @@ by sibling content in a flex column, so a hairline is used instead. Set to `0` t
 
 ## Children
 
-A `<native:top-bar>` can contain up to 10 `<native:top-bar-action>` elements. These are displayed on the trailing
-edge of the bar.
+A `<native:top-bar>` can contain up to 10 `<native:top-bar-action>` elements, displayed on the trailing edge.
 
 On Android, the first 3 actions are shown as icon buttons; additional actions collapse into an overflow menu (⋮).
 On iOS, if more than 5 actions are provided, they collapse into an overflow menu.
 
 ### `<native:top-bar-action>` Props
 
-> [!IMPORTANT]
-> In the [Layout model](../the-basics/layouts#builder-reference) a top-bar action is a `NavAction` — use that
-> builder rather than placing `<native:top-bar-action>` inline.
-
 - `id` - Unique identifier (required)
-- `icon` - A named [icon](icon#icon-name-reference) (required)
-- `label` - Text label for the action. Used for accessibility and displayed in overflow menus (optional but recommended)
+- `icon` - A named [icon](icon#icon-name-reference) — the cross-platform fallback (optional if a platform icon is given)
+- `ios-icon` / `android-icon` - Per-platform icon overrides: an enum case (`App\Icons\Ios`, `App\Icons\Android`, `App\Icons\AndroidOutlined`) or a raw symbol string. `ios` / `android` are accepted as shorthand (optional). See [Platform icons](#platform-icons)
+- `material-variant` - Material style hint for Android, e.g. `outlined` (optional). Set automatically when you use an `AndroidOutlined` enum case
+- `label` - Text label. Used for accessibility and displayed in overflow menus (optional but recommended)
 - `url` - A URL to navigate to when tapped (optional)
+- `destructive` - Render in the destructive (red) tint (optional, boolean)
 
 <aside>
 
-Any `url` that doesn't match a registered native route will exit to the web view and load that URL there.
+Any `url` that doesn't match a registered native route will exit to the web view and load that URL there. To call a
+method on your screen instead of navigating, use `@tap="methodName"`.
 
 </aside>
 
-## Builder API
+### Platform icons
 
-When a `<native:top-bar>` is supplied by a [layout](../the-basics/layouts), you build it fluently with the `NavBar`
-and `NavAction` builders rather than writing it in Blade.
+`<native:top-bar-action>` resolves icons through the same contract as [`<native:icon>`](icon#typed-icon-enums): a
+shared `icon` string is the cross-platform fallback, and `:ios-icon` / `:android-icon` (or the `:ios` / `:android`
+shorthand) override it per platform. Each override accepts a generated enum case or a raw symbol string; an
+`AndroidOutlined` case carries its `material_variant` automatically.
 
-```php
-use Native\Mobile\Edge\Layouts\Builders\NavAction;
-use Native\Mobile\Edge\Layouts\Builders\NavBar;
+@verbatim
+```blade static
+@use('App\Icons\Ios')
+@use('App\Icons\AndroidOutlined')
 
-NavBar::make()
-    ->title('SyncUp')
-    ->subtitle('All caught up')
-    ->back()
-    ->backgroundColor('#0891b2')
-    ->textColor('#FFFFFF')
-    ->elevation(8)
-    ->action(NavAction::make('search')->icon('search')->press('openSearch'));
+<native:top-bar title="Library">
+    <native:top-bar-action
+        id="favorite"
+        label="Favorite"
+        :ios="Ios::StarFill"
+        :android="AndroidOutlined::Star"
+        @tap="toggleFavorite"
+    />
+</native:top-bar>
 ```
+@endverbatim
 
-### `NavBar` methods
+On iOS the SF Symbol wins and no Material variant is emitted; on Android the Material glyph (plus any outlined
+variant) wins; when the platform can't be determined the shared `icon` string is used verbatim.
 
-- `make()` - Create a new builder
-- `title(?string $title)` - Title text
-- `subtitle(?string $subtitle)` - Small line under the title
-- `back(bool $show = true)` - Show the back chevron
-- `backgroundColor(string $color)` - Bar background color
-- `textColor(string $color)` - Title and icon tint
-- `elevation(int $px)` - Hairline thickness at the bottom of the bar
-- `action(NavAction $action)` - Append a trailing action
+## Custom bars
 
-### `NavAction` methods
+Add the boolean `custom` attribute to keep a bar in the content tree as an ordinary drawn element — the escape hatch
+for a design the system bar can't express. It is **not** hoisted onto the native chrome root, but it *still*
+suppresses the layout's top bar for that slot, so you never get two bars.
 
-- `make(string $id)` - Create an action with a unique id
-- `icon(string $icon)` - A named [icon](icon#icon-name-reference)
-- `label(string $label)` - Accessibility / overflow-menu label
-- `url(string $url)` - A URL to navigate to when tapped
-- `press(string $method)` - A component method on the screen to invoke when tapped
-- `event(string $event)` - A native event name to dispatch (advanced)
+@verbatim
+```blade static
+<native:top-bar custom background-color="#0891b2">
+    {{-- Draw whatever you like; this bar renders inline, not as native chrome --}}
+</native:top-bar>
+```
+@endverbatim
+
+## Builder alternative
+
+When many screens share the same bar, declare it once with the `NavBar` builder in a [layout](../the-basics/layouts)
+instead of repeating the inline element. The builder produces the exact same native chrome — see the
+[Builder reference](../the-basics/layouts#builder-reference) for `NavBar`, `NavAction`, and `NavBarOptions`.
 
 ## Per-screen overrides
 
-Screens can override the title, colors, display behavior, and add actions on top of what their layout supplies by
-overriding `navigationOptions()`:
+A screen wrapped by a layout can override the title, colors, display behavior, and add actions on top of what its
+layout supplies by overriding `navigationOptions()` — without writing an inline bar:
 
 ```php
 use Native\Mobile\Edge\Layouts\Builders\NavAction;
@@ -144,45 +184,13 @@ class ItemDetail extends NativeComponent
 }
 ```
 
-### `NavBarOptions` methods
-
 Non-null fields override the layout's `NavBar`; null fields fall through. `action()` appends to whatever the layout
-already declared.
-
-- `make()` - Create a new builder
-- `hidden(bool $hidden = true)` - Hide the nav bar on this screen — the full-bleed / immersive pattern
-- `title(?string $title)` - Override the title text
-- `subtitle(?string $subtitle)` - Override the small line under the title
-- `back(bool $show = true)` - Show or hide the back chevron
-- `backgroundColor(string $color)` - Bar background color
-- `textColor(string $color)` - Title and icon tint
-- `elevation(int $px)` - Hairline thickness at the bottom of the bar
-- `displayMode(string $mode)` - Title display mode — `large`, `inline`, or `automatic`
-- `scrollBehavior(string $mode)` - How the bar reacts to content scrolling — `collapse`, `pinned`, or `enterAlways`
-- `searchBar(string $placeholder = '', ?string $onQuery = null, int $debounceMs = 300)` - Attach an inline native search field; text changes call the `$onQuery` method on the screen
-- `action(NavAction $action)` - Append a trailing action
+already declared. See the [`NavBarOptions` reference](../the-basics/layouts#navbar--the-top-bar) in Layouts.
 
 ### Hiding the nav bar on a screen
 
 Individual screens can opt out of their layout's nav bar entirely — the full-bleed pattern for photo viewers,
-onboarding flows, and video screens. This is the top-bar parallel to the tab bar's
-[`hidden()`](bottom-nav#per-screen-tab-bar):
-
-```php
-use Native\Mobile\Edge\Layouts\Builders\NavBarOptions;
-use Native\Mobile\Edge\NativeComponent;
-
-class PhotoViewer extends NativeComponent
-{
-    public function navigationOptions(): ?NavBarOptions
-    {
-        return NavBarOptions::make()->hidden();
-    }
-}
-```
-
-For this common case, the shorter `protected bool $hidesNavBar = true;` property on the screen is equivalent to
-`NavBarOptions::make()->hidden()`. Use either; if both are set, the explicit builder wins.
+onboarding flows, and video screens:
 
 ```php
 class PhotoViewer extends NativeComponent
@@ -190,6 +198,9 @@ class PhotoViewer extends NativeComponent
     protected bool $hidesNavBar = true;
 }
 ```
+
+This is equivalent to returning `NavBarOptions::make()->hidden()` from `navigationOptions()`; if both are set, the
+explicit builder wins. It's the top-bar parallel to the tab bar's [`hidden()`](bottom-nav#per-screen-tab-bar).
 
 Navigation keeps working while the bar is hidden — pushes, pops, and `@navigate` all behave normally. With the bar
 hidden the screen is full-bleed: on Android the content extends up to the very top edge, under the transparent

--- a/resources/views/docs/mobile/4/the-basics/layouts.md
+++ b/resources/views/docs/mobile/4/the-basics/layouts.md
@@ -5,12 +5,25 @@ order: 154
 
 ## Overview
 
-Layouts wrap the screens routed beneath them with shared chrome — a top nav bar, a bottom tab bar, or both — so
-individual screens stay focused on their content.
+Layouts are **optional**. They're the tool for chrome that's shared across *many* screens — a top nav bar, a bottom
+tab bar, or both — declared once so those screens stay focused on their content. When chrome belongs to a *single*
+screen, put it inline in that screen's Blade instead: a `<native:top-bar>`, `<native:bottom-nav>`, or
+[`<native:fab>`](../edge-components/fab) at the root of a screen renders the same real native chrome a layout produces,
+with no layout class required. See the [Top Bar](../edge-components/top-bar), [Bottom Navigation](../edge-components/bottom-nav),
+and [Floating Action Button](../edge-components/fab) pages for the inline elements.
 
 A `NativeLayout` class declares which chrome to render, and the framework automatically wraps every screen registered
 under that layout with the result. Push a detail screen onto a tabs section and the chrome swaps from "tabs" to "stack"
 automatically; pop back and it swaps back.
+
+<aside>
+
+**Which do I reach for?** Reuse across a set of screens → a layout. One screen with its own bar → inline chrome in
+that screen's Blade. The two compose: a screen under a layout can still place an inline bar to override *just that
+slot* for itself — see [Inline overrides](#inline-overrides). To reuse *content* (not chrome) across screens, reach
+for [nested components](nested-components) instead.
+
+</aside>
 
 ## Attaching a layout to a route
 
@@ -507,9 +520,10 @@ methods: `title`, `subtitle`, `back`, `backgroundColor`, `textColor`, `elevation
 
 ## Inline overrides
 
-A screen can put its own `<native:top-bar>` or `<native:bottom-nav>` at the root of its blade, and the framework
-will skip the layout-supplied chrome **for that slot only**. This is useful for one-off screens (e.g. a chat
-detail with a custom titled top bar) without dropping the layout entirely.
+Inline chrome and a layout compose. A screen can put its own [`<native:top-bar>`](../edge-components/top-bar) or
+[`<native:bottom-nav>`](../edge-components/bottom-nav) at the root of its Blade, and the framework skips the
+layout-supplied chrome **for that slot only** — the *other* slot still comes from the layout. This is the override
+contract for one-off screens (a chat detail with a custom titled top bar, say) without dropping the layout entirely.
 
 @verbatim
 ```blade
@@ -523,3 +537,18 @@ detail with a custom titled top bar) without dropping the layout entirely.
 </native:column>
 ```
 @endverbatim
+
+The same hoisting powers a screen with **no layout at all**: an inline bar alone still produces real native chrome
+(a `NavigationStack` / `TabView` on iOS, a `Scaffold` / `NavigationBar` on Android), with edge-swipe back, large
+titles, and Liquid Glass / Material You — identical to what the builders emit. The layout is only worth reaching for
+when several screens share the same bar. See each element's page for the full attribute surface:
+[Top Bar](../edge-components/top-bar), [Bottom Navigation](../edge-components/bottom-nav), and
+[Floating Action Button](../edge-components/fab).
+
+<aside>
+
+The `custom` attribute is the escape hatch: `<native:top-bar custom>` keeps the bar in the content tree as an
+ordinary drawn element (for a design a system bar can't express) while *still* suppressing the layout's bar for
+that slot.
+
+</aside>

--- a/resources/views/docs/mobile/4/the-basics/nested-components.md
+++ b/resources/views/docs/mobile/4/the-basics/nested-components.md
@@ -1,0 +1,209 @@
+---
+title: Nested Components
+order: 156
+---
+
+## Overview
+
+Any `NativeComponent` can mount other components as **children** — the unit of reuse for repeated UI: cards, rows,
+chips, list items. A child is a real component, not an include: it receives **props** that stay live as the parent
+re-renders, it keeps its **own state** between renders, its `@tap` and `native:model` bindings dispatch to *it*,
+and it talks back to its ancestors with **events**. If you know Livewire's nested components, this is that — for
+native views.
+
+```php
+namespace App\NativeComponents;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+class TaskCard extends NativeComponent
+{
+    // Props — assigned from the mounting tag's attributes.
+    public string $title = '';
+
+    // Own state — persists across parent re-renders.
+    public bool $done = false;
+
+    public function toggle(): void
+    {
+        $this->done = ! $this->done;
+
+        $this->emit('task-toggled', $this->title, $this->done);
+    }
+
+    public function render(): View
+    {
+        return view('native.task-card');
+    }
+}
+```
+
+@verbatim
+```blade static
+{{-- resources/views/native/task-card.blade.php --}}
+<native:column class="w-full rounded-2xl bg-theme-surface p-4 {{ $done ? 'opacity-60' : '' }}">
+    <native:pressable @tap="toggle">
+        <native:text class="text-base font-semibold text-theme-on-surface">{{ $title }}</native:text>
+    </native:pressable>
+</native:column>
+```
+@endverbatim
+
+Mount it from any screen (or from another child — nesting is recursive):
+
+@verbatim
+```blade static
+@foreach ($tasks as $task)
+    <native:task-card
+        :title="$task['title']"
+        key="task-{{ $task['id'] }}"
+        @task-toggled="onTaskToggled" />
+@endforeach
+```
+@endverbatim
+
+## Registering components
+
+Classes under `app/NativeComponents` register **automatically** as tags by their kebab-cased class name —
+`TaskCard` becomes `<native:task-card>`, `UserAvatarChip` becomes `<native:user-avatar-chip>`. That's the same
+directory `php artisan native:make` scaffolds into, so screens and children live side by side; any of them can be
+mounted as a child.
+
+Classes living elsewhere register explicitly (a service provider's `boot()` is the natural home):
+
+```php
+use Native\Mobile\Edge\ComponentRegistry;
+
+ComponentRegistry::components([
+    'user-card' => \App\Support\Cards\UserCard::class,
+]);
+```
+
+<aside>
+
+Registered **element** names always win over component tags — you can't shadow `<native:column>` with a component
+called `Column`.
+
+</aside>
+
+## Props
+
+Tag attributes assign to the child's matching public properties:
+
+- Attribute names map kebab → camelCase: `:task-id="$task['id']"` assigns `$taskId`.
+- `:prop="expression"` binds any Blade expression; plain attributes pass strings, coerced to the property's
+  scalar type (`level="3"` assigns `int 3` to `public int $level`).
+- Attributes with no matching public property are ignored.
+
+Props are re-assigned on **every** parent render, so they stay live: when the parent's data changes, the child
+re-renders with the fresh values. Everything *else* on the child is its own state — see below.
+
+## Own state and keys
+
+A child's non-prop public properties persist across parent re-renders — the `$done` flag above survives the
+parent updating `$tasks`, adding rows, or reordering the list. What ties state to "the same" child is its
+**identity**:
+
+- With a `key` attribute, identity follows the key. `key="task-@{{ $task['id'] }}"` means the card for task 7 keeps
+  its state wherever it moves in the list — through reorders, insertions, and removals.
+- Without a `key`, identity falls back to the tag name plus its occurrence position in the parent. On reorder,
+  state stays with the *position*, not the data — the classic list trap.
+
+> [!IMPORTANT]
+> Key list children by a **stable domain id** (`$task->id`), never the loop index. `$loop->index` *is* the
+> position, so it pins state to slots instead of data and behaves exactly like having no key at all.
+
+## Events up
+
+A child calls `$this->emit('event-name', ...$args)` and the event **bubbles to every ancestor**, two ways:
+
+**Tag bindings** — an `@event-name` attribute on the mounting tag maps the emit onto a parent method. Bound
+arguments come first, emit arguments are appended:
+
+@verbatim
+```blade static
+<native:task-card :title="$task['title']" @task-toggled="onTaskToggled('board')" />
+```
+@endverbatim
+
+```php
+// TaskCard emitted: $this->emit('task-toggled', $this->title, $this->done);
+public function onTaskToggled(string $source, string $title, bool $done): void
+{
+    // $source = 'board' (bound), then the emit args
+}
+```
+
+**`#[On]` listeners** — a string-form `#[On('event-name')]` method fires on *any* ancestor, however deep the
+emitter is. A grandchild's emit reaches the screen without the intermediate child forwarding anything:
+
+```php
+use Native\Mobile\Attributes\On;
+
+#[On('task-toggled')]
+public function onAnyTaskToggled(string $title, bool $done): void
+{
+    // ...
+}
+```
+
+<aside>
+
+String-form `#[On('...')]` (component events) and class-form `#[On(PhotoTaken::class)]` (native device events)
+are different mechanisms sharing one attribute. Class-form listeners stay on the screen — see
+[Events](events).
+
+</aside>
+
+## Lifecycle
+
+- `mount()` runs when a child's key first appears in the parent's tree.
+- `unmount()` runs when the key disappears — a removed list row gets its hook before the instance is dropped.
+- Children share the **screen's** run loop. A class-level `#[Poll]` on a child does not schedule timers; use
+  `native:poll` on an element inside the child's Blade instead — that rolls up into the screen's frame timers.
+
+## Inside a child
+
+Bindings in a child's view resolve against **that child instance**, not the screen:
+
+- `@tap="toggle"` calls the child's `toggle()`, with the child as `$this`.
+- `native:model="note"` syncs the child's `$note`, and fires the child's `updatedNote()` hook.
+- Navigation calls (`$this->navigate()`, `back()`, `replace()`) forward to the screen — a child can trigger
+  navigation without knowing where it's mounted.
+
+## No slot content
+
+Content between a component's tags is not supported and throws a clear exception — pass data through props:
+
+@verbatim
+```blade static
+{{-- Throws ComponentSlotNotSupportedException --}}
+<native:task-card>
+    <native:text>Nope</native:text>
+</native:task-card>
+
+{{-- Do this instead --}}
+<native:task-card :title="$task['title']" />
+```
+@endverbatim
+
+## Testing
+
+The [component test harness](../testing/introduction) drives children through the screen exactly as the device
+would: `tap('some-ref')` on a ref inside a child dispatches to the child's method, `input()` syncs the child's
+model, and the child's state persists across `set()`-triggered parent re-renders — assert on what the screen
+shows rather than reaching into child internals.
+
+```php
+Native::test(TaskBoard::class)
+    ->tap('toggle-7')                 // ref rendered inside the task-7 child
+    ->assertSee('1 done');            // tag binding updated the screen
+```
+
+## Children vs. everything else
+
+- **Repeated UI with behavior** (a card with its own tap handlers and state) → a nested component.
+- **Shared markup with no behavior** → a plain Blade `@@include` / `$this->partial()` still works and is cheaper.
+- **Chrome** (bars, fabs) → the [inline chrome elements](../edge-components/top-bar) or a
+  [layout](layouts) — chrome hoists onto the native chrome root, which components don't.


### PR DESCRIPTION
## Summary

Documents the two features that shipped in [mobile-air #227](https://github.com/NativePHP/mobile-air/pull/227) — nested child components and composable blade chrome — and reframes the chrome guidance accordingly.

- **New: `the-basics/nested-components.md`** (order 156, after Layouts) — the full child-component contract: auto-discovery of `app/NativeComponents` as tags + `ComponentRegistry::components()`, props down (kebab→camel, scalar coercion, live reassignment every parent render), own state with keyed identity (and the loop-index-as-key warning), `emit()` bubbling to `@event` tag bindings and string-form `#[On]` on any ancestor (with the class-form native-event distinction), `mount()`/`unmount()`, the `#[Poll]`-on-child caveat, child-scoped `@tap`/`native:model`, slot rejection, and testing notes.
- **New: `edge-components/fab.md`** (order 222) — attribute surface verified against the element (size/position/offsets/colors/elevation), hoist-above-content behavior, platform icon enums, theme-token defaults; noted as inline-only chrome (no builder).
- **Rewritten: `top-bar.md`, `bottom-nav.md`** — removed the "prefer the Layout model" banners; both pages now lead with inline chrome hoisting onto the real native chrome root (NavigationStack/TabView), reactive attributes, the inline-overrides-layout-per-slot contract, `custom` drawn bars, and `:ios-icon`/`:android-icon` platform enums. Builder and per-screen-override reference material kept.
- **Reframed: `the-basics/layouts.md`** — layouts are now the optional shared-chrome tool; new "Inline overrides" section documents the override contract, cross-linked from the element pages.
- **Updated: `side-nav.md`** — honest status: an inline `<native:side-nav>` compiles and hoists but has no built-in drawer host yet (renders nothing); points to the layout `Drawer`, element reference kept for when the host lands.

Runnable-example policy: fab basics use plain runnable fences (it's a styled pressable); chrome-hoisting and component-mounting examples are `blade static` — mounting examples pair a complete PHP class block with the blade so nothing pretends to run in Jump that can't.

## Testing

`DocumentationRenderingTest` (Blade-renders every docs page), `DocsSearchMetaTagsTest`, and the prerelease-version test all pass. Fixed one Blade-in-markdown escaping issue it caught (prose `@include` / `{{ }}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)