### PR TITLE
Show the course curriculum to users who haven't purchased

### DIFF
--- a/app/Livewire/Customer/Course/Index.php
+++ b/app/Livewire/Customer/Course/Index.php
@@ -3,9 +3,12 @@
 namespace App\Livewire\Customer\Course;
 
 use App\Models\Course;
+use App\Models\CourseLesson;
+use App\Models\CourseModule;
 use App\Models\LessonProgress;
 use App\Models\Product;
 use App\Models\ProductPrice;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
@@ -116,5 +119,41 @@ class Index extends Component
     public function completedCount(): int
     {
         return count($this->completedLessonIds);
+    }
+
+    /**
+     * Published modules with at least one published lesson.
+     *
+     * Drives the pre-purchase curriculum outline, which lists every lesson —
+     * locked or not — so non-purchasers can see the whole course.
+     *
+     * Keys are preserved so the view can number each module by its real position
+     * in the course rather than its position within this filtered subset.
+     *
+     * @return Collection<int, CourseModule>
+     */
+    #[Computed]
+    public function outlineModules(): Collection
+    {
+        if (! $this->course) {
+            return collect();
+        }
+
+        return $this->course->modules
+            ->filter(fn (CourseModule $module): bool => $module->is_published
+                && $module->lessons->contains(fn (CourseLesson $lesson): bool => $lesson->is_published));
+    }
+
+    #[Computed]
+    public function hasFreeLessons(): bool
+    {
+        return $this->outlineModules
+            ->flatMap(fn (CourseModule $module) => $module->lessons)
+            ->contains(fn (CourseLesson $lesson): bool => $this->isFreePreviewLesson($lesson));
+    }
+
+    public function isFreePreviewLesson(CourseLesson $lesson): bool
+    {
+        return $lesson->is_free && $lesson->is_published;
     }
 }

--- a/app/Livewire/Customer/Course/LessonShow.php
+++ b/app/Livewire/Customer/Course/LessonShow.php
@@ -31,7 +31,11 @@ class LessonShow extends Component
         abort_unless($this->isAdmin || ($this->lesson->is_published && $this->lesson->module->is_published), 404);
 
         if (! $this->lesson->is_free && ! $this->hasPurchased && ! $this->isAdmin) {
-            abort(403, 'You need Pro access to view this lesson.');
+            session()->flash('message', 'That lesson is part of the full course. Purchase the Masterclass to unlock it.');
+
+            $this->redirect(route('customer.course.index'), navigate: true);
+
+            return;
         }
 
         $this->skipIntroOutro = session()->has(self::VIDEO_PLAYED_SESSION_KEY);

--- a/resources/views/livewire/customer/course.blade.php
+++ b/resources/views/livewire/customer/course.blade.php
@@ -99,7 +99,7 @@
         @endif
     @else
         {{-- Not purchased: Full-width marketing/purchase page --}}
-        <div class="course-fullbleed">
+        <div class="course-fullbleed pb-6 lg:pb-8">
             {{-- Hero --}}
             <div class="relative overflow-hidden bg-gradient-to-b from-violet-50 to-white px-6 py-16 sm:px-12 sm:py-20 dark:from-zinc-900 dark:to-zinc-950">
                 {{-- Background glow --}}
@@ -109,9 +109,9 @@
                 <div class="relative z-10 mx-auto max-w-2xl text-center">
                     <span class="inline-flex items-center gap-2 rounded-md bg-violet-500/10 px-3 py-1 text-xs font-bold uppercase tracking-widest text-violet-600 ring-1 ring-violet-500/20 dark:text-violet-400">
                         @if ($this->priceIncreased)
-                            New Course
+                            Masterclass
                         @else
-                            New Course &mdash; Early Bird
+                            Masterclass &mdash; Early Bird
                         @endif
                     </span>
 
@@ -179,7 +179,7 @@
             </div>
 
             {{-- What's Included --}}
-            <div class="mx-auto mt-8 grid max-w-7xl gap-4 px-6 pb-6 sm:grid-cols-2 lg:grid-cols-4 lg:px-8 lg:pb-8">
+            <div class="mx-auto mt-8 grid max-w-7xl gap-4 px-6 sm:grid-cols-2 lg:grid-cols-4 lg:px-8">
                 <div class="rounded-xl border border-zinc-200 bg-white p-5 dark:border-white/10 dark:bg-white/5">
                     <div class="flex size-9 items-center justify-center rounded-lg bg-violet-100 dark:bg-violet-500/15">
                         <x-heroicon-s-device-phone-mobile class="size-4 text-violet-600 dark:text-violet-400" />
@@ -212,6 +212,93 @@
                     <p class="mt-1 text-xs text-zinc-600 dark:text-zinc-400">One-time payment. All current and future content.</p>
                 </div>
             </div>
+
+            {{-- Locked lesson notice --}}
+            @if (session('message'))
+                <div class="mx-auto mt-8 max-w-7xl px-6 lg:px-8">
+                    <flux:callout variant="secondary" icon="lock-closed">
+                        <flux:callout.text>{{ session('message') }}</flux:callout.text>
+                    </flux:callout>
+                </div>
+            @endif
+
+            {{-- Course curriculum --}}
+            @if ($this->outlineModules->isNotEmpty())
+                <div class="mx-auto mt-8 max-w-7xl px-6 lg:px-8">
+                    <div class="flex items-center gap-3">
+                        <flux:heading size="lg">Course curriculum</flux:heading>
+                        @if ($this->hasFreeLessons)
+                            <flux:badge variant="pill" color="emerald" size="sm">Free lessons included</flux:badge>
+                        @endif
+                    </div>
+                    <flux:text class="mt-1 text-sm">
+                        @if ($this->hasFreeLessons)
+                            Start with the lessons you can watch right now &mdash; everything else unlocks when you get the course.
+                        @else
+                            Every lesson unlocks when you get the course.
+                        @endif
+                    </flux:text>
+
+                    <div class="mt-4 space-y-4">
+                        @foreach ($this->outlineModules as $moduleIndex => $module)
+                            @php
+                                $publishedLessons = $module->lessons->where('is_published', true);
+                                $moduleHasFreeLesson = $publishedLessons->contains(fn ($moduleLesson) => $this->isFreePreviewLesson($moduleLesson));
+                            @endphp
+                            <div wire:key="outline-module-{{ $module->id }}" class="rounded-lg border border-zinc-200 bg-white dark:border-white/10 dark:bg-white/5">
+                                <div class="flex items-center gap-4 p-4">
+                                    <div class="flex size-10 shrink-0 items-center justify-center rounded-lg text-sm font-bold {{ $moduleHasFreeLesson ? 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/50 dark:text-emerald-400' : 'bg-zinc-100 text-zinc-500 dark:bg-white/5 dark:text-zinc-500' }}">
+                                        {{ str_pad($moduleIndex + 1, 2, '0', STR_PAD_LEFT) }}
+                                    </div>
+                                    <div class="min-w-0 flex-1">
+                                        <flux:heading size="sm">{{ $module->title }}</flux:heading>
+                                        @if ($module->description)
+                                            <flux:text class="mt-1 text-sm">{{ $module->description }}</flux:text>
+                                        @endif
+                                    </div>
+                                </div>
+
+                                <div class="border-t border-zinc-200 dark:border-white/10">
+                                    @foreach ($publishedLessons as $lesson)
+                                        @php
+                                            $isPreviewable = $this->isFreePreviewLesson($lesson);
+                                        @endphp
+                                        <div wire:key="outline-lesson-{{ $lesson->id }}" class="flex items-center gap-3 px-4 py-3 {{ ! $loop->last ? 'border-b border-zinc-100 dark:border-white/5' : '' }}">
+                                            {{-- Fixed-width slot keeps titles aligned whether or not a lock is shown --}}
+                                            <div class="flex size-4 shrink-0 items-center justify-center">
+                                                @unless ($isPreviewable)
+                                                    <flux:tooltip content="Buy the course to unlock all lessons">
+                                                        <button
+                                                            type="button"
+                                                            class="cursor-help text-zinc-400 dark:text-zinc-500"
+                                                            aria-label="Buy the course to unlock all lessons"
+                                                        >
+                                                            <x-heroicon-m-lock-closed class="size-4" />
+                                                        </button>
+                                                    </flux:tooltip>
+                                                @endunless
+                                            </div>
+                                            <div class="min-w-0 flex-1">
+                                                @if ($isPreviewable)
+                                                    <a href="{{ route('customer.course.lesson', $lesson) }}" wire:navigate class="text-sm font-medium transition-colors hover:text-emerald-600 dark:hover:text-emerald-400">
+                                                        {{ $lesson->title }}
+                                                    </a>
+                                                @else
+                                                    <span class="text-sm font-medium text-zinc-400 dark:text-zinc-500">{{ $lesson->title }}</span>
+                                                @endif
+                                            </div>
+                                            @if ($lesson->duration_in_seconds)
+                                                <flux:text class="shrink-0 text-xs">{{ gmdate('i:s', $lesson->duration_in_seconds) }}</flux:text>
+                                            @endif
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
         </div>
     @endif
 </div>

--- a/resources/views/livewire/customer/course/lesson-show.blade.php
+++ b/resources/views/livewire/customer/course/lesson-show.blade.php
@@ -98,17 +98,21 @@
                                 $isDraft = ! $outlineLesson->is_published;
                                 $isLessonComplete = in_array($outlineLesson->id, $this->completedLessonIds);
                                 $canAccess = $outlineLesson->is_free || $this->hasPurchased || $this->isAdmin;
-                                $isClickable = $this->isAdmin || (! $isDraft && $canAccess);
-                                $isLocked = ! $isClickable && ! $isDraft;
+                                $isLocked = ! $canAccess && ! $isDraft;
+                                $isClickable = $this->isAdmin || ! $isDraft;
                             @endphp
                             @if ($isClickable)
+                                {{-- Locked lessons stay clickable: they redirect to the course page with an explanation --}}
                                 <a
                                     href="{{ route('customer.course.lesson', $outlineLesson) }}"
-                                    wire:navigate
+                                    @unless ($isLocked) wire:navigate @endunless
                                     wire:key="outline-lesson-{{ $outlineLesson->id }}"
                                     @if ($isCurrent) aria-current="page" @endif
-                                    class="flex items-center gap-3 px-4 py-2 text-sm transition-colors {{ $isCurrent ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300' : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-white/5' }}"
+                                    class="flex items-center gap-3 px-4 py-2 text-sm transition-colors {{ $isCurrent ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300' : ($isLocked ? 'text-zinc-400 hover:bg-zinc-50 dark:text-zinc-600 dark:hover:bg-white/5' : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-white/5') }}"
                                 >
+                                    @if ($isLocked)
+                                        <x-heroicon-m-lock-closed class="size-4 shrink-0" />
+                                    @endif
                                     <span class="min-w-0 flex-1 truncate {{ $isCurrent ? 'font-medium' : '' }} {{ $isLessonComplete ? 'line-through' : '' }}" title="{{ $outlineLesson->title }}">{{ $outlineLesson->title }}</span>
                                     @if ($isDraft)
                                         <flux:badge variant="pill" color="amber" size="sm">Coming Soon</flux:badge>
@@ -119,9 +123,6 @@
                                 </a>
                             @else
                                 <div wire:key="outline-lesson-{{ $outlineLesson->id }}" class="flex items-center gap-3 px-4 py-2 text-sm text-zinc-400 dark:text-zinc-600">
-                                    @if ($isLocked)
-                                        <x-heroicon-m-lock-closed class="size-4 shrink-0" />
-                                    @endif
                                     <span class="min-w-0 flex-1 truncate {{ $isLessonComplete ? 'line-through' : '' }}" title="{{ $outlineLesson->title }}">{{ $outlineLesson->title }}</span>
                                     @if ($isDraft)
                                         <flux:badge variant="pill" color="amber" size="sm">Coming Soon</flux:badge>

--- a/tests/Feature/CourseContentTest.php
+++ b/tests/Feature/CourseContentTest.php
@@ -82,6 +82,8 @@ class CourseContentTest extends TestCase
             ->test(Index::class)
             ->assertSee('Build native apps')
             ->assertSee('Get Early Bird Access')
+            ->assertSee('Masterclass &mdash; Early Bird', escape: false)
+            ->assertDontSee('New Course')
             ->assertSee('$199');
 
         Carbon::setTestNow();
@@ -101,6 +103,9 @@ class CourseContentTest extends TestCase
             ->test(Index::class)
             ->assertSee('$299')
             ->assertSee('Get Access')
+            ->assertSee('Masterclass')
+            ->assertDontSee('New Course')
+            ->assertDontSee('Early Bird')
             ->assertDontSee('Get Early Bird Access');
 
         Carbon::setTestNow();
@@ -176,6 +181,233 @@ class CourseContentTest extends TestCase
     }
 
     #[Test]
+    public function course_dashboard_lists_the_curriculum_for_non_owners(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Getting Started',
+        ]);
+        $lesson = CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Installing NativePHP',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Course curriculum')
+            ->assertSee('Free lessons included')
+            ->assertSee('Getting Started')
+            ->assertSee('Installing NativePHP')
+            ->assertSee(route('customer.course.lesson', $lesson), escape: false);
+    }
+
+    #[Test]
+    public function course_dashboard_lists_paid_only_modules_for_non_owners(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create([
+            'course_id' => $course->id,
+            'title' => 'Paid Only Module',
+        ]);
+        $lesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+            'title' => 'Paid Only Lesson',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Course curriculum')
+            ->assertSee('Paid Only Module')
+            ->assertSee('Paid Only Lesson')
+            ->assertSee('Every lesson unlocks when you get the course.')
+            ->assertDontSee('Free lessons included')
+            ->assertDontSee(route('customer.course.lesson', $lesson), escape: false);
+    }
+
+    #[Test]
+    public function locked_lessons_show_a_lock_with_an_unlock_prompt(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create(['course_id' => $course->id]);
+        CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+            'title' => 'Locked Lesson',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Locked Lesson')
+            ->assertSee('Buy the course to unlock all lessons')
+            ->assertSeeHtml('data-flux-tooltip');
+    }
+
+    #[Test]
+    public function free_lessons_are_not_labelled_with_a_free_pill(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create(['course_id' => $course->id]);
+        CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Watchable Lesson',
+        ]);
+
+        $html = Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Watchable Lesson')
+            ->html();
+
+        $this->assertDoesNotMatchRegularExpression('/<[^>]*badge[^>]*>\s*Free\s*</i', $html);
+    }
+
+    #[Test]
+    public function course_dashboard_excludes_unpublished_lessons_from_the_curriculum(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Partly Released Module',
+        ]);
+        CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Released Lesson',
+        ]);
+        CourseLesson::factory()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Unreleased Lesson',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Partly Released Module')
+            ->assertSee('Released Lesson')
+            ->assertDontSee('Unreleased Lesson');
+    }
+
+    #[Test]
+    public function course_dashboard_excludes_modules_with_no_published_lessons(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Empty Module',
+        ]);
+        CourseLesson::factory()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Unreleased Lesson',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertDontSee('Course curriculum')
+            ->assertDontSee('Empty Module')
+            ->assertDontSee('Unreleased Lesson');
+    }
+
+    #[Test]
+    public function course_dashboard_excludes_unpublished_modules_from_the_curriculum(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Draft Module',
+        ]);
+        CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Lesson In Draft Module',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertDontSee('Course curriculum')
+            ->assertDontSee('Draft Module')
+            ->assertDontSee('Lesson In Draft Module');
+    }
+
+    #[Test]
+    public function curriculum_modules_keep_their_real_position_in_the_course(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+
+        foreach ([1, 2] as $sortOrder) {
+            $paidModule = CourseModule::factory()->published()->create([
+                'course_id' => $course->id,
+                'sort_order' => $sortOrder,
+            ]);
+            CourseLesson::factory()->published()->create([
+                'course_module_id' => $paidModule->id,
+                'is_free' => false,
+            ]);
+        }
+
+        $freeModule = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Third Module Is Free',
+            'sort_order' => 3,
+        ]);
+        CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $freeModule->id,
+        ]);
+
+        $outlineModules = Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Third Module Is Free')
+            ->instance()
+            ->outlineModules();
+
+        $this->assertSame([0, 1, 2], array_keys($outlineModules->all()));
+        $this->assertSame($freeModule->id, $outlineModules->last()->id);
+    }
+
+    #[Test]
+    public function course_dashboard_locks_paid_lessons_inside_a_free_module_for_non_owners(): void
+    {
+        $user = User::factory()->create();
+
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Mixed Module',
+        ]);
+        $freeLesson = CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Free Intro Lesson',
+            'sort_order' => 1,
+        ]);
+        $paidLesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+            'title' => 'Paid Deep Dive Lesson',
+            'sort_order' => 2,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Index::class)
+            ->assertSee('Free Intro Lesson')
+            ->assertSee('Paid Deep Dive Lesson')
+            ->assertSee(route('customer.course.lesson', $freeLesson), escape: false)
+            ->assertDontSee(route('customer.course.lesson', $paidLesson), escape: false);
+    }
+
+    #[Test]
     public function free_lesson_is_accessible_without_purchase(): void
     {
         $user = User::factory()->create();
@@ -192,7 +424,7 @@ class CourseContentTest extends TestCase
     }
 
     #[Test]
-    public function pro_lesson_is_blocked_without_purchase(): void
+    public function paid_lesson_redirects_to_the_course_page_without_purchase(): void
     {
         $user = User::factory()->create();
         $course = Course::factory()->published()->create();
@@ -204,7 +436,164 @@ class CourseContentTest extends TestCase
 
         Livewire::actingAs($user)
             ->test(LessonShow::class, ['lesson' => $lesson])
-            ->assertForbidden();
+            ->assertRedirect(route('customer.course.index'));
+
+        $this->assertSame(
+            'That lesson is part of the full course. Purchase the Masterclass to unlock it.',
+            session('message'),
+        );
+    }
+
+    #[Test]
+    public function paid_lesson_redirect_explains_itself_on_the_course_page(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create(['course_id' => $course->id]);
+        $lesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+        ]);
+
+        $this->withoutVite()
+            ->actingAs($user)
+            ->get(route('customer.course.lesson', $lesson))
+            ->assertRedirect(route('customer.course.index'));
+
+        $this->withoutVite()
+            ->actingAs($user)
+            ->get(route('customer.course.index'))
+            ->assertOk()
+            ->assertSee('That lesson is part of the full course. Purchase the Masterclass to unlock it.', escape: false)
+            ->assertSee('Build native apps');
+    }
+
+    #[Test]
+    public function locked_lessons_in_the_lesson_sidebar_are_clickable(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create(['course_id' => $course->id]);
+        $freeLesson = CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Watchable Lesson',
+            'sort_order' => 1,
+        ]);
+        $lockedLesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+            'title' => 'Locked Sidebar Lesson',
+            'sort_order' => 2,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(LessonShow::class, ['lesson' => $freeLesson])
+            ->assertSee('Locked Sidebar Lesson')
+            ->assertSee(route('customer.course.lesson', $lockedLesson), escape: false);
+    }
+
+    #[Test]
+    public function draft_lessons_in_the_lesson_sidebar_stay_unclickable(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create(['course_id' => $course->id]);
+        $freeLesson = CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Watchable Lesson',
+            'sort_order' => 1,
+        ]);
+        $draftLesson = CourseLesson::factory()->free()->create([
+            'course_module_id' => $module->id,
+            'title' => 'Draft Sidebar Lesson',
+            'sort_order' => 2,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(LessonShow::class, ['lesson' => $freeLesson])
+            ->assertSee('Draft Sidebar Lesson')
+            ->assertSee('Coming Soon')
+            ->assertDontSee(route('customer.course.lesson', $draftLesson), escape: false);
+    }
+
+    #[Test]
+    public function purchase_page_orders_hero_features_notice_then_curriculum(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->free()->create([
+            'course_id' => $course->id,
+            'title' => 'Getting Started',
+        ]);
+        CourseLesson::factory()->published()->free()->create([
+            'course_module_id' => $module->id,
+        ]);
+        $lockedLesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+        ]);
+
+        $this->withoutVite()
+            ->actingAs($user)
+            ->get(route('customer.course.lesson', $lockedLesson))
+            ->assertRedirect(route('customer.course.index'));
+
+        $html = $this->withoutVite()
+            ->actingAs($user)
+            ->get(route('customer.course.index'))
+            ->assertOk()
+            ->getContent();
+
+        $hero = strpos($html, 'Build native apps');
+        $features = strpos($html, 'Zero to Published');
+        $notice = strpos($html, 'Purchase the Masterclass to unlock it.');
+        $curriculum = strpos($html, 'Course curriculum');
+
+        $this->assertNotFalse($hero);
+        $this->assertNotFalse($features);
+        $this->assertNotFalse($notice);
+        $this->assertNotFalse($curriculum);
+
+        $this->assertLessThan($features, $hero, 'Hero should come before the feature cards');
+        $this->assertLessThan($notice, $features, 'Feature cards should come before the locked-lesson notice');
+        $this->assertLessThan($curriculum, $notice, 'Locked-lesson notice should come before the curriculum');
+    }
+
+    #[Test]
+    public function paid_lesson_no_longer_returns_a_dead_end_403(): void
+    {
+        config(['app.debug' => false]);
+
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create(['course_id' => $course->id]);
+        $lesson = CourseLesson::factory()->published()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+        ]);
+
+        $this->withoutVite()
+            ->actingAs($user)
+            ->get(route('customer.course.lesson', $lesson))
+            ->assertStatus(302)
+            ->assertRedirect(route('customer.course.index'))
+            ->assertDontSee('You need Pro access to view this lesson.');
+    }
+
+    #[Test]
+    public function unpublished_lesson_still_returns_404_without_purchase(): void
+    {
+        $user = User::factory()->create();
+        $course = Course::factory()->published()->create();
+        $module = CourseModule::factory()->published()->create(['course_id' => $course->id]);
+        $lesson = CourseLesson::factory()->create([
+            'course_module_id' => $module->id,
+            'is_free' => false,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(LessonShow::class, ['lesson' => $lesson])
+            ->assertNotFound();
     }
 
     #[Test]


### PR DESCRIPTION
## Why

Free course modules were never visible on the course dashboard. `customer/course.blade.php` gated its whole body on `@if ($this->hasPurchased || $this->isAdmin)`, so non-purchasers got only the marketing page — no module listing existed in that branch, and `Course\Index` exposed nothing to render one. Free lessons *were* already reachable (`LessonShow::mount()` allows `is_free` without purchase), so the access plumbing worked; there was just no way to discover them.

Visiting a paid lesson without purchase was also a dead end: `abort(403, 'You need Pro access...')` with no `resources/views/errors/403.blade.php` in the project, so it fell through to Laravel's bare `errors::minimal` page — no layout, no branding, no link anywhere. The copy was misleading too: "Pro" means a *subscription* tier here (`policy_name` in `['max','pro','mini']`), but the masterclass is a one-time product purchase.

## What changed

**Curriculum outline for non-purchasers.** `Course\Index::outlineModules()` returns published modules with at least one published lesson. Every lesson is listed — free ones link out, the rest render a lock with a "Buy the course to unlock all lessons" tooltip. Collection keys are deliberately preserved so modules are numbered by real course position, not position within the filtered subset.

**Paid lessons redirect instead of 403ing.** `LessonShow::mount()` flashes an explanation and redirects to the course page, which already renders the pricing and CTA — turning a dead end into the page most likely to convert. The course page rendered no flash messages at all, so that markup was added.

**Locked sidebar lessons are clickable.** In `lesson-show.blade.php`, anything published is now a link and routes through the redirect above; drafts stay unclickable with "Coming Soon". `wire:navigate` is omitted on locked links so the 302-and-flash is a plain navigation.

**Layout.** The not-purchased page is ordered hero → feature cards → locked-lesson notice → curriculum. The notice sits inside the outline's `max-w-7xl` container: `app.css` strips the main container's padding via `[data-flux-main]:has(.course-fullbleed)`, so anything outside an inner container renders edge-to-edge. Bottom padding moved onto the `.course-fullbleed` wrapper so spacing holds when the curriculum block is absent.

**Copy.** Hero pill "New Course" → "Masterclass" (both the early-bird and post-deadline variants).

## Notes for review

- Module-level `is_free` remains unused for access control — gating is entirely lesson-level `is_free`. A module flagged free whose lessons aren't will show locked lessons. Left as-is; worth deciding whether that flag should drive access or be removed.
- The flash callout now lives inside the not-purchased branch, so `session('message')` no longer renders for purchasers/admins on this page. Harmless today (only the locked-lesson redirect sets it, which can't fire for them), but a constraint to be aware of.
- No `403.blade.php` was added — other `abort(403)` calls elsewhere still hit the bare vendor page.
- Not verified in a browser; the tooltip's hover behaviour in particular is untested by the suite.

## Tests

`tests/Feature/CourseContentTest.php`: 50 passing, up from 35. Covers the curriculum listing, both exclusion paths (unpublished lesson, unpublished module), paid-module inclusion, mixed free/paid modules, module numbering, the redirect and its flash end-to-end over HTTP, the redirect under `app.debug => false`, the 404 path for unpublished lessons, sidebar link behaviour for locked vs draft lessons, and section ordering.

79 passing across `CourseContentTest`, `CoursePageTest`, `HomeCourseCardTest`, `DashboardLayoutTest`. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)