### PR TITLE
docs(mobile/4): iOS build requires Xcode 26 (iOS 26 SDK)

### DIFF
--- a/resources/views/docs/mobile/4/getting-started/environment-setup.md
+++ b/resources/views/docs/mobile/4/getting-started/environment-setup.md
@@ -22,8 +22,8 @@ You can only compile iOS apps on a Mac. This is a limitation imposed by Apple. B
 
 </aside>
 
-1. macOS (required - iOS development is only possible on an Apple silicon Mac, M1+)
-2. [Xcode 16.0 or later](https://apps.apple.com/app/xcode/id497799835)
+1. macOS 15.6 or later (required - iOS development is only possible on an Apple silicon Mac, M1+)
+2. [Xcode 26 or later](https://apps.apple.com/app/xcode/id497799835) — ships the iOS 26 SDK, which the native renderer requires
 3. Xcode Command Line Tools
 4. Homebrew & CocoaPods
 5. _Optional_ iOS device for testing
@@ -32,7 +32,8 @@ You can only compile iOS apps on a Mac. This is a limitation imposed by Apple. B
 
 1. **Install Xcode**
    - Download from the [Mac App Store](https://apps.apple.com/app/xcode/id497799835)
-   - Minimum version: Xcode 16.0
+   - Minimum version: Xcode 26 (requires macOS 15.6 or later)
+   - The native renderer builds against the iOS 26 SDK (e.g. `tabViewBottomAccessory`), so earlier Xcode/SDK versions fail to compile.
 
 2. **Install Xcode Command Line Tools**
    ```shell

--- a/resources/views/docs/mobile/4/getting-started/environment-setup.md
+++ b/resources/views/docs/mobile/4/getting-started/environment-setup.md
@@ -23,7 +23,7 @@ You can only compile iOS apps on a Mac. This is a limitation imposed by Apple. B
 </aside>
 
 1. macOS 15.6 or later (required - iOS development is only possible on an Apple silicon Mac, M1+)
-2. [Xcode 26 or later](https://apps.apple.com/app/xcode/id497799835) — ships the iOS 26 SDK, which the native renderer requires
+2. [Xcode 26 or later](https://apps.apple.com/app/xcode/id497799835)
 3. Xcode Command Line Tools
 4. Homebrew & CocoaPods
 5. _Optional_ iOS device for testing
@@ -33,7 +33,6 @@ You can only compile iOS apps on a Mac. This is a limitation imposed by Apple. B
 1. **Install Xcode**
    - Download from the [Mac App Store](https://apps.apple.com/app/xcode/id497799835)
    - Minimum version: Xcode 26 (requires macOS 15.6 or later)
-   - The native renderer builds against the iOS 26 SDK (e.g. `tabViewBottomAccessory`), so earlier Xcode/SDK versions fail to compile.
 
 2. **Install Xcode Command Line Tools**
    ```shell


### PR DESCRIPTION
## What

Updates the **Mobile v4 → Getting Started → Environment Setup** iOS requirements from *Xcode 16.0 or later* to **Xcode 26 or later** (and notes the implied **macOS 15.6+**).

## Why

Building a fresh v4 app on **Xcode 16.4** (iOS 18.5 SDK) fails to compile in NativePHP's own renderer:

```
nativephp/ios/NativePHP/NativeRender/NativeRootTabsRenderer.swift:909
error: value of type 'TabBarAccessoryModifier.Content' has no member 'tabViewBottomAccessory'
```

[`tabViewBottomAccessory`](https://developer.apple.com/documentation/swiftui/view/tabviewbottomaccessory(content:)) is an **iOS 26-only** SwiftUI API. Because the symbol must exist in the SDK at compile time, an `#available` guard can't rescue an older SDK — the **iOS 26 SDK (shipped with Xcode 26)** is required. Xcode 26 in turn requires **macOS 15.6+**.

Reproduced with `nativephp/mobile` 4.0.1 / `nativephp/mobile-ui` 0.3.0 via `php artisan native:run ios`.

## Note for maintainers

I documented this as the current requirement, but if the intent is to keep supporting Xcode 16, the alternative is to gate the iOS 26 API in the renderer (compile-time SDK check) rather than change the docs — happy to adjust this PR either way.

## Changes

- `resources/views/docs/mobile/4/getting-started/environment-setup.md`: iOS requirements → Xcode 26 / macOS 15.6+, with a one-line rationale.