### PR TITLE
docs(mobile/4): accordion, @selectionChange, per-platform icons, native:font overhaul

### DIFF
--- a/resources/views/docs/mobile/4/edge-components/accordion.md
+++ b/resources/views/docs/mobile/4/edge-components/accordion.md
@@ -1,0 +1,147 @@
+---
+title: Accordion
+order: 90
+---
+
+## Overview
+
+An expandable disclosure section — a tappable header row that opens and closes a collapsible content area.
+Renders as a SwiftUI `DisclosureGroup` on iOS and a Compose column with an `AnimatedVisibility` content area
+on Android.
+
+An accordion wraps two child tags: a [`<native:accordion-header>`](#props) holding the always-visible row, and a
+[`<native:accordion-content>`](#props) holding the collapsible body. Both accept any child elements.
+
+@verbatim
+```blade
+@php $showSpecs = false; @endphp
+
+<native:accordion :expanded="$showSpecs" @change="toggleSpecs">
+    <native:accordion-header>
+        <native:text class="text-base font-semibold">Specifications</native:text>
+    </native:accordion-header>
+    <native:accordion-content>
+        <native:text class="text-sm text-theme-on-surface-variant">Weight — 1.24 kg</native:text>
+        <native:text class="text-sm text-theme-on-surface-variant">Battery — up to 18 hours</native:text>
+    </native:accordion-content>
+</native:accordion>
+```
+@endverbatim
+
+`showSpecs` is a public bool property on your component — the `@php` line stands in for
+`public bool $showSpecs = false;` — and `toggleSpecs()` is called with the new state whenever the user
+taps the header.
+
+Both platforms draw their own trailing chevron — the `DisclosureGroup` indicator on iOS, a rotating Material
+arrow on Android — so don't add one to your header content. Tapping anywhere on the header row toggles the
+section on both platforms.
+
+## Props
+
+- `expanded` - Whether the content area is open (optional, boolean, default: `false`). This is a live binding,
+  not just a mount-time hint — assigning the bound property from PHP animates the group open or closed at any
+  point, so patterns like "expand all" work
+- `a11y-label` - Accessibility label (optional)
+- `a11y-hint` - Accessibility hint (optional)
+
+`<native:accordion-header>` and `<native:accordion-content>` take no props of their own beyond the same
+`a11y-label` / `a11y-hint` pair — they exist to mark which children belong to which slot.
+
+## Events
+
+- `@change` - Component method called when the user expands or collapses the section. Receives the new
+  expanded state as a boolean parameter
+
+<aside>
+
+The direct children of `<native:accordion>` must be one `<native:accordion-header>` and one
+`<native:accordion-content>`. The renderers pick each slot by child type — any other direct child is
+silently ignored.
+
+</aside>
+
+## Two-way Binding
+
+The accordion's state prop is `expanded`, not `value` — and the `native:model` directive expands to a
+`:value` binding, which the accordion doesn't read. So unlike [`<native:toggle>`](toggle), `native:model`
+alone won't drive an accordion. Write the pair explicitly: bind `:expanded` and point `@change` at
+`__syncProperty`, the same sync handler `native:model` generates.
+
+@verbatim
+```blade
+@php $showDetails = false; @endphp
+
+<native:accordion :expanded="$showDetails" @change="__syncProperty('showDetails')">
+    <native:accordion-header>
+        <native:text class="text-base font-semibold">Order details</native:text>
+    </native:accordion-header>
+    <native:accordion-content>
+        <native:text class="text-sm text-theme-on-surface-variant">3 items · Arrives Thursday</native:text>
+    </native:accordion-content>
+</native:accordion>
+
+<native:text class="text-sm text-theme-on-surface-variant">{{ $showDetails ? 'Expanded' : 'Collapsed' }}</native:text>
+```
+@endverbatim
+
+Tapping the header syncs `showDetails` back automatically — the echo below updates on every toggle. The sync
+runs both ways: set `$showDetails` from any component method and the group animates to match. Both renderers
+echo-prevent, so adopting a programmatic value never fires `@change` back at your component.
+
+`sync-mode` and `debounce-ms` are not accepted — a header tap is a single discrete event, so there is nothing
+to defer or debounce.
+
+## Examples
+
+### FAQ list
+
+@verbatim
+```blade
+@php $faqs = [
+    ['q' => 'How do I reset my password?', 'a' => 'Use the link on the sign-in screen.'],
+    ['q' => 'Can I change my plan later?', 'a' => 'Yes — upgrades apply immediately, downgrades at renewal.'],
+]; @endphp
+
+<native:column class="w-full gap-0 px-4">
+    @foreach ($faqs as $faq)
+        <native:accordion>
+            <native:accordion-header>
+                <native:text class="text-base font-medium">{{ $faq['q'] }}</native:text>
+            </native:accordion-header>
+            <native:accordion-content>
+                <native:text class="text-sm text-theme-on-surface-variant pb-3">{{ $faq['a'] }}</native:text>
+            </native:accordion-content>
+        </native:accordion>
+        <native:divider />
+    @endforeach
+</native:column>
+```
+@endverbatim
+
+Accordions without `:expanded` start collapsed, and without `@change` they still toggle natively — wire the
+event only when your component needs to know.
+
+## Element
+
+```php
+use Native\Mobile\UI\Elements\Accordion;
+use Native\Mobile\UI\Elements\AccordionContent;
+use Native\Mobile\UI\Elements\AccordionHeader;
+use Native\Mobile\UI\Elements\Text;
+
+Accordion::make(
+    AccordionHeader::make(Text::make('Specifications')),
+    AccordionContent::make(Text::make('Weight — 1.24 kg')),
+)
+    ->expanded(true)
+    ->onChange('toggleSpecs');
+```
+
+- `make(Element ...$children)` - Create an accordion from its header and content children
+- `expanded(bool $expanded)` - Open or close the content area
+- `onChange(string $method)` - Component method invoked when the user toggles the section
+- `a11yLabel(string $value)` - Accessibility label
+- `a11yHint(string $value)` - Accessibility hint
+
+`AccordionHeader::make(...)` and `AccordionContent::make(...)` take their child elements the same way and
+expose only the two a11y setters.

--- a/resources/views/docs/mobile/4/edge-components/button.md
+++ b/resources/views/docs/mobile/4/edge-components/button.md
@@ -31,7 +31,13 @@ Slot content is treated as plain text — nested tags are stripped and whitespac
   in `config/native-ui.php`) — see [Theming](../digging-deeper/theming)
 - `size` - `sm`, `md` (default), `lg`
 - `icon` - A leading [icon](icon#icon-name-reference) name (optional)
+- `ios-icon` / `android-icon` - Per-platform overrides for the leading icon: an [SF Symbol](icon#ios-sf-symbols)
+  name on iOS, a [Material Icon](icon#android-material-icons) name on Android. `icon` is the fallback on whichever
+  platform has no override — or skip it and declare only per-platform icons. `iosIcon` / `androidIcon` and the
+  `<native:icon>`-style `ios` / `android` are accepted as aliases
 - `icon-trailing` - A trailing [icon](icon#icon-name-reference) name (optional)
+- `ios-icon-trailing` / `android-icon-trailing` - Per-platform overrides for the trailing icon, mirroring
+  `ios-icon` / `android-icon` (camelCase aliases accepted; no `ios` / `android` shorthand for this slot)
 - `font` - Custom font for the label: a `resources/fonts/` file token or a config alias like `accent` (optional, string) — see [Text › Custom fonts](text#custom-fonts)
 - `line-height` - Label line height as a multiplier of the font size (optional, float)
 - `line-height-px` - Label line height as an absolute value in pixels (optional, float)
@@ -95,6 +101,30 @@ attributes are intentionally dropped before reaching the renderer.
 />
 ```
 @endverbatim
+
+### Platform icons
+
+When one shared name doesn't map well on both platforms, give each platform its own symbol — an
+[SF Symbol](icon#ios-sf-symbols) name on iOS, a [Material Icon](icon#android-material-icons) name on Android:
+
+@verbatim
+```blade
+<native:button
+    label="Tap to Pay"
+    ios-icon="wave.3.right"
+    android-icon="nfc"
+    @press="startPayment"
+/>
+```
+@endverbatim
+
+Resolution happens per platform: each side uses its override, falling back to `icon` where none is given. Bound
+`:ios-icon` / `:android-icon` also accept `App\Icons` enum cases, exactly like
+[`<native:icon>`'s `:ios` / `:android`](icon#typed-icon-enums). The trailing slot works the same way via
+`ios-icon-trailing` / `android-icon-trailing`.
+
+On iOS the icon's layout height is pinned to the size-driven icon size, so button height depends only on `size` —
+not on which SF Symbol the button carries. Tall glyphs like `wave.3.right` no longer stretch the button.
 
 ### Loading state
 

--- a/resources/views/docs/mobile/4/edge-components/chip.md
+++ b/resources/views/docs/mobile/4/edge-components/chip.md
@@ -27,6 +27,10 @@ fully rounded and can be adjusted with `rounded-*` classes.
 - `label` - Chip text (optional, string). Can also be passed as the first argument to `make()`
 - `selected` / `value` - Whether the chip is active (optional, boolean, default: `false`)
 - `icon` - Leading [icon](icon#icon-name-reference) name (optional, string)
+- `ios-icon` / `android-icon` - Per-platform overrides for the leading icon: an [SF Symbol](icon#ios-sf-symbols)
+  name on iOS, a [Material Icon](icon#android-material-icons) name on Android. `icon` is the fallback on whichever
+  platform has no override. Bound `:ios-icon` / `:android-icon` also accept
+  [enum cases](icon#typed-icon-enums); `iosIcon` / `androidIcon` and `ios` / `android` are accepted as aliases
 - `disabled` - Disable the chip (optional, boolean, default: `false`)
 - `a11y-label` - Accessibility label (optional)
 - `a11y-hint` - Accessibility hint (optional)
@@ -80,6 +84,16 @@ driving `selected` from one property keeps the row single-select.
 @php $onlyVerified = false; @endphp
 
 <native:chip label="Verified" icon="check" native:model="onlyVerified" />
+```
+@endverbatim
+
+When the platforms need different symbols, override per platform — an SF Symbol on iOS, a Material name on Android:
+
+@verbatim
+```blade
+@php $tapToPay = false; @endphp
+
+<native:chip label="Tap to Pay" ios-icon="wave.3.right" android-icon="nfc" native:model="tapToPay" />
 ```
 @endverbatim
 

--- a/resources/views/docs/mobile/4/edge-components/tab-row.md
+++ b/resources/views/docs/mobile/4/edge-components/tab-row.md
@@ -68,6 +68,10 @@ Here `currentTab` stands in for `public int $currentTab = 0;` on your component.
 
 - `label` - Tab label (required, string). Can also be passed as the first argument to `make()`
 - `icon` - Optional [icon](icon#icon-name-reference) name rendered above the label
+- `ios-icon` / `android-icon` - Per-platform overrides for the tab icon: an [SF Symbol](icon#ios-sf-symbols) name
+  on iOS, a [Material Icon](icon#android-material-icons) name on Android. `icon` is the fallback on whichever
+  platform has no override. Bound `:ios-icon` / `:android-icon` also accept
+  [enum cases](icon#typed-icon-enums); `iosIcon` / `androidIcon` and `ios` / `android` are accepted as aliases
 - `a11y-label` - Accessibility label override (optional)
 
 ## Examples
@@ -116,6 +120,15 @@ typically add `fill` to the outer column and the content panes so they occupy th
     <native:tab label="Starred"  icon="star" />
     <native:tab label="Archived" icon="archive-box" />
 </native:tab-row>
+```
+@endverbatim
+
+When a shared name doesn't map well on both platforms, give a tab per-platform icons — an SF Symbol on iOS, a
+Material name on Android:
+
+@verbatim
+```blade
+<native:tab label="Tap to Pay" ios-icon="wave.3.right" android-icon="nfc" />
 ```
 @endverbatim
 

--- a/resources/views/docs/mobile/4/edge-components/text-input.md
+++ b/resources/views/docs/mobile/4/edge-components/text-input.md
@@ -70,6 +70,9 @@ All three variants accept the same shared prop set. The bare variant adds a `col
 - `sync-mode` - How change events dispatch back to your component: `live` (default), `blur`, or `debounce`. Usually
   set via the `native:model` modifiers below, but accepted directly too
 - `debounce-ms` - Milliseconds of inactivity before a `debounce` sync fires (optional, int, default: `300`)
+- `selection-debounce-ms` - Coalescing window for `@selectionChange` events (optional, int, default: `150`). `0` or
+  less means the default; positive values are floored at one frame (16ms). See
+  [Caret and selection reporting](#caret-and-selection-reporting)
 
 ### Decorations
 
@@ -77,6 +80,9 @@ All three variants accept the same shared prop set. The bare variant adds a `col
 - `suffix` - Text rendered after the input (optional, string)
 - `leading-icon` - Icon name rendered at the start (optional, string)
 - `trailing-icon` - Icon name rendered at the end (optional, string)
+- `ios-leading-icon` / `android-leading-icon` - Per-platform overrides for `leading-icon` (optional). See
+  [Per-platform icons](#per-platform-icons)
+- `ios-trailing-icon` / `android-trailing-icon` - Per-platform overrides for `trailing-icon` (optional)
 
 ### Typography
 
@@ -94,6 +100,9 @@ All three variants accept the same shared prop set. The bare variant adds a `col
 
 - `@change` - Component method called when the text changes. Receives the new value
 - `@submit` - Component method called when the user submits (e.g. presses return). Receives the current value
+- `@selectionChange` - Component method called when the caret moves or the selection changes. Receives the full
+  current text plus the selection start and end offsets — see
+  [Caret and selection reporting](#caret-and-selection-reporting)
 
 <aside>
 
@@ -134,6 +143,122 @@ automatically, so the `@{{ $name }}` echo updates as you type.
 - `live` (default) — every keystroke fires `@change`
 - `blur` — only fires on focus loss / submit
 - `debounce` — fires after `debounce-ms` of inactivity (300ms when unset), or immediately on blur / submit
+
+## Caret and selection reporting
+
+`@selectionChange` reports caret position and text selection back to your component — for the cases where `@change`
+alone can't tell you *where* the user is typing. The handler receives the full current text plus the selection range:
+
+```php
+public function onCaretMove(string $text, int $selectionStart, int $selectionEnd)
+{
+    // $selectionStart === $selectionEnd when the caret is a plain cursor;
+    // they differ when a range of text is selected.
+}
+```
+
+Offsets are Unicode code points into the text — not UTF-16 units or bytes — so emoji count as one character and the
+values are safe to feed straight into `mb_substr()`.
+
+Events are coalesced on the native side: at most one every 150ms while the caret moves, and the trailing position
+always fires. Tune the window per input with `selection-debounce-ms` (fluent: `->selectionDebounceMs()`) — `0` or
+less means the default, positive values are floored at one frame (16ms).
+
+The classic use is a mention / typeahead trigger:
+
+@verbatim
+```blade
+@php $message = ''; @endphp
+
+<native:outlined-text-input
+    label="Message"
+    native:model="message"
+    @selectionChange="onCaretMove"
+/>
+```
+@endverbatim
+
+```php
+public array $suggestions = [];
+
+public function onCaretMove(string $text, int $start, int $end): void
+{
+    // Look backwards from the caret for an "@mention" trigger.
+    $before = mb_substr($text, 0, $start, 'UTF-8');
+
+    if (preg_match('/@(\w*)$/u', $before, $m)) {
+        $this->suggestions = $this->matchingHandles($m[1]);
+    } else {
+        $this->suggestions = [];
+    }
+}
+```
+
+The handler slices the text at the caret, so typing `@ja` in the middle of a sentence surfaces suggestions for the
+fragment under the cursor — something `@change` can't do, since it only carries the value.
+
+<aside>
+
+Every `@selectionChange` event carries the full current text and costs a full component re-render. That is
+independent of the `native:model` sync mode — pairing it with `native:model.blur` or `.debounce` still ships the
+field contents to PHP on the selection cadence, not the model cadence. If you only need the text, stick with
+`@change`; reach for `@selectionChange` only when the caret position matters.
+
+</aside>
+
+A few contract details:
+
+- `@selectionChange` is never emitted for `secure` inputs. The callback isn't even serialized when `secure` is set,
+  and both renderers additionally refuse to emit — so caret telemetry can't leak password-field context.
+- When PHP pushes a new `value` onto the input, the field is replaced wholesale and the caret drops at the end.
+  Both platforms report that immediately as a single `(text, length, length)` event, bypassing the debounce — a
+  handler that rewrites the bound model will see one follow-up event.
+- Discontiguous selections (multi-range, iOS) are reported as a single span from the lowest start to the highest
+  end, so the range can cover text the user did not select.
+- `read-only` inputs don't report on iOS, where read-only implies disabled and the field never focuses; they do on
+  Android, which keeps them focusable for copy.
+
+<aside>
+
+Caret and selection reporting requires `nativephp/mobile` 4.0+, which ships the `text_selection` callback kind.
+
+</aside>
+
+## Per-platform icons
+
+The shared `leading-icon` / `trailing-icon` names render the same icon on both platforms. When each platform should
+show its own symbol, prefix the attribute with the platform — the same convention as
+[`<native:button>`](button)'s `ios-icon`:
+
+@verbatim
+```blade
+<native:outlined-text-input
+    label="Email"
+    leading-icon="email"
+    ios-leading-icon="envelope.badge"
+/>
+```
+@endverbatim
+
+iOS renders the `envelope.badge` SF Symbol; Android falls back to the shared `email` name. The shared attribute is
+the fallback for whichever platform has no override — set only a platform-prefixed attribute and the other platform
+renders no icon at all.
+
+Bound with `:`, the icon attributes also accept the typed icon enums (`App\Icons\Ios`, `App\Icons\Android`,
+`App\Icons\AndroidOutlined`) instead of strings — see [Icon › Typed icon enums](icon#typed-icon-enums):
+
+@verbatim
+```blade
+@use('App\Icons\Ios')
+@use('App\Icons\AndroidOutlined')
+
+<native:outlined-text-input
+    label="Search"
+    :ios-leading-icon="Ios::Magnifyingglass"
+    :android-leading-icon="AndroidOutlined::Search"
+/>
+```
+@endverbatim
 
 ## Bare variant
 
@@ -306,7 +431,9 @@ All three elements share the same fluent API (defined on `BaseTextInput`):
 - `font(string $name)` - Custom font (file token or config alias)
 - `a11yLabel(string $value)`, `a11yHint(string $value)`
 - `syncMode(string $mode)`, `debounceMs(int $ms)`
-- `onChange(string $method)`, `onSubmit(string $method)`
+- `selectionDebounceMs(int $ms)` - Coalescing window for `@selectionChange` events (150ms when unset; `0` or less
+  means the default, positive values floored at 16ms)
+- `onChange(string $method)`, `onSubmit(string $method)`, `onSelectionChange(string $method)`
 
 `BareTextInput` adds one method on top of the shared API:
 

--- a/resources/views/docs/mobile/4/edge-components/text.md
+++ b/resources/views/docs/mobile/4/edge-components/text.md
@@ -74,18 +74,47 @@ and is available fluently as `->font('Inter-Bold')`.
 
 ### Downloading from Google Fonts
 
-The `native:font` command downloads any [Google Fonts](https://fonts.google.com)
-family straight into `resources/fonts/` — no API key needed:
+The `native:font` command downloads a [Google Fonts](https://fonts.google.com)
+family into `resources/fonts/` and registers it in your config — no API key
+needed:
 
 ```bash
-php artisan native:font Lobster
-php artisan native:font "Rock Salt" Inter
-php artisan native:font Inter --weights=400,700 --italic
+php artisan native:font
+php artisan native:font "Rock Salt"
+php artisan native:font Inter --default
 ```
 
-Files are named `<Family>-<Style>.ttf` (`Inter-Bold`, `Inter-BoldItalic`, …) —
-ready to use as `font` tokens. Google Fonts are libre-licensed (OFL / Apache),
-so bundling them in your app is permitted.
+Run bare, the command opens a searchable list of the whole catalog; pass a
+family name (quoted when it contains spaces, matched case-insensitively) to
+skip the search. Either way you then pick which styles to download from a
+multiselect — Regular (400) is preselected — and the command handles one
+family per run.
+
+Files are named `<Family>-<Style>.ttf` (`Inter-Bold.ttf`, `Inter-BoldItalic.ttf`, …),
+so the basename is ready to use as a `font` token. Every downloaded style is
+also written to the `fonts` array in `config/native-ui.php` as an
+[alias](#font-aliases--the-app-wide-default) — the command suggests a key per
+style (`inter`, `inter-bold`, …) that you can rename at the prompt, and asks
+whether one style should become the app-wide `default`. Google Fonts are
+libre-licensed (OFL / Apache), so bundling them in your app is permitted.
+
+- `--default` — make the downloaded font the app-wide `default` alias without asking
+- `--force` — overwrite files that already exist in `resources/fonts/` (and skip the `--reset` confirmation)
+- `--reset` — delete every font file in `resources/fonts/` and reset the config to `'default' => 'System'` (asks first)
+- `--clear-cache` — clear the cached catalog (the family list is cached for 24 hours)
+
+Non-interactive runs (`--no-interaction`, CI) require the family argument,
+download only Regular (400) — or the first listed style for families without
+one — write the suggested alias keys as-is, and skip existing files unless
+`--force` is passed.
+
+<aside>
+
+**Upgrading**: the old `--weights=…` / `--italic` flags and multi-family
+arguments are gone. Run the command once per family and pick weights and
+italics in the style multiselect instead.
+
+</aside>
 
 ### Font aliases & the app-wide default
 
@@ -111,9 +140,11 @@ explicit `font-serif` / `font-mono` classes still win over it. Swapping a font
 app-wide becomes a one-line config change; blades keep their semantic names.
 Each alias must point directly at a file token (no alias-to-alias chaining).
 
-Prefer aliases over the older `font-family` theme token (which `fonts.default`
-supersedes when both are set). The `native:font --default` command still writes
-`font-family` and works either way.
+`native:font` maintains this array for you — every downloaded style gets an
+entry, and the `--default` flag (or the prompt) sets `default`. Prefer aliases
+over the older `font-family` theme token (which `fonts.default` supersedes when
+both are set); `native:font --default` only falls back to writing `font-family`
+when the config has no `fonts` block.
 
 <aside>
 


### PR DESCRIPTION
Documents the four nativephp/mobile-ui features merged today (2026-08-03):

## New page
- **`edge-components/accordion.md`** (order 90) — `<native:accordion>` with header/content children, `expanded` as a live two-way binding, `@change` contract, FAQ example, programmatic API. Includes an explicit note that `native:model` alone won't drive an accordion (the precompiler binds `:value`, which Accordion doesn't read) with the working `:expanded` + `@change="__syncProperty(...)"` form.

## Updated pages
- **`text-input.md`** — new *Caret and selection reporting* section for `@selectionChange`: handler signature, Unicode code-point offsets, 150ms native coalescing (`selection-debounce-ms`, 16ms floor), cost aside, and the contract bullets (secure inputs never emit, programmatic pushes emit one end-caret event, discontiguous iOS selections collapse to one span, read-only reports Android-only). Plus *Per-platform icons* (`ios-leading-icon` / `android-trailing-icon` etc.).
- **`button.md` / `chip.md` / `tab-row.md`** — `ios-icon` / `android-icon` overrides (with `ios`/`android` shorthand where it exists, trailing-slot forms on button), fallback semantics, and the iOS button height fix (glyph no longer drives button height).
- **`text.md`** — `native:font` rewritten for the new interactive single-family flow: catalog search, style multiselect, config `fonts` aliases written on download, `--default` / `--reset` / `--clear-cache` / `--force`, non-interactive/CI behavior, and an upgrading aside for the removed `--weights` / `--italic` flags.

Every documented behavior was verified against the package source (`applyAttributes()`, renderers, `FontCommand`/`GoogleFonts`) rather than the PR descriptions — a few subtleties (exact-name CLI matching, Regular-with-fallback in non-interactive runs, no short aliases on trailing slots) are stated as the code actually behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)