### PR TITLE
Remove Consulting link from header navigation

### DIFF
--- a/resources/views/components/navbar/mobile-menu.blade.php
+++ b/resources/views/components/navbar/mobile-menu.blade.php
@@ -107,7 +107,6 @@
                     $isUltraActive = request()->routeIs('pricing');
                     $isBlogActive = request()->routeIs('blog*');
                     $isPartnersActive = request()->routeIs('partners*');
-                    $isServicesActive = request()->routeIs('consulting');
                     $isBuildActive = request()->routeIs('build-my-app');
                     $isCourseActive = request()->routeIs('course');
                     $isSupportActive = request()->routeIs('support.*');
@@ -239,31 +238,6 @@
                         @endif
 
                         <div>Sponsor</div>
-                    </a>
-                </div>
-
-                {{-- Consulting Link (mobile only, shown in navbar on desktop) --}}
-                <div class="lg:hidden">
-                    <a
-                        href="{{ route('consulting') }}"
-                        @class([
-                            'flex items-center gap-2 py-3 transition duration-200',
-                            'font-medium' => $isServicesActive,
-                            'opacity-70 hover:translate-x-1 hover:opacity-100 dark:opacity-50' => ! $isServicesActive,
-                        ])
-                        aria-current="{{ $isServicesActive ? 'page' : 'false' }}"
-                    >
-                        @if ($isServicesActive)
-                            <x-icons.right-arrow
-                                class="size-4 shrink-0"
-                                aria-hidden="true"
-                                focusable="false"
-                            />
-                        @endif
-
-                        <div class="inline-flex items-center gap-2">
-                            Consulting
-                        </div>
                     </a>
                 </div>
 

--- a/resources/views/components/navigation-bar.blade.php
+++ b/resources/views/components/navigation-bar.blade.php
@@ -94,14 +94,6 @@
                 Masterclass
             </a>
 
-            {{-- Consulting link (desktop only) --}}
-            <a
-                href="{{ route('consulting') }}"
-                class="hidden items-center gap-1.5 rounded-full bg-blue-500/10 px-3 py-1.5 text-sm font-medium text-blue-600 transition duration-200 hover:bg-blue-500/20 lg:inline-flex dark:text-blue-400 dark:hover:bg-blue-500/20"
-            >
-                Consulting
-            </a>
-
             {{-- Build link (desktop only) --}}
             <a
                 href="{{ route('build-my-app') }}"

--- a/tests/Feature/NavigationMobileMenuBreakpointTest.php
+++ b/tests/Feature/NavigationMobileMenuBreakpointTest.php
@@ -20,6 +20,18 @@ class NavigationMobileMenuBreakpointTest extends TestCase
         $response->assertSee('class="relative z-40"', false);
     }
 
+    public function test_navigation_bar_does_not_show_consulting_link(): void
+    {
+        $this->blade('<x-navigation-bar />')
+            ->assertDontSee('Consulting');
+    }
+
+    public function test_mobile_menu_does_not_show_consulting_link(): void
+    {
+        $this->blade('<x-navbar.mobile-menu />')
+            ->assertDontSee('Consulting');
+    }
+
     public function test_resize_handler_does_not_auto_close_mobile_menu(): void
     {
         $response = $this->get('/');


### PR DESCRIPTION
## Summary
- Removes the Consulting link from the desktop navbar (`navigation-bar.blade.php`)
- Removes the Consulting link from the mobile menu (`navbar/mobile-menu.blade.php`), along with the now-unused `$isServicesActive` flag
- Adds tests asserting neither nav component renders a Consulting link

The consulting page itself and the footer link to it are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)