### PR TITLE
Add Docs MCP Server page, fix get_page path resolution

### DIFF
--- a/app/Http/Controllers/McpController.php
+++ b/app/Http/Controllers/McpController.php
@@ -6,61 +6,12 @@ use App\Http\Requests\McpSearchRequest;
 use App\Services\DocsSearchService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Sleep;
-use Illuminate\Support\Str;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class McpController extends Controller
 {
     public function __construct(
         protected DocsSearchService $docsSearch
     ) {}
-
-    /**
-     * SSE endpoint for MCP clients
-     */
-    public function sse(Request $request): StreamedResponse
-    {
-        $sessionId = Str::uuid()->toString();
-
-        return response()->stream(function () use ($sessionId): void {
-            // Send session info
-            $this->sendSseEvent([
-                'type' => 'session',
-                'sessionId' => $sessionId,
-            ]);
-
-            // Send server info
-            $this->sendSseEvent([
-                'type' => 'serverInfo',
-                'name' => 'nativephp-docs',
-                'version' => '1.0.0',
-                'capabilities' => ['tools' => new \stdClass],
-            ]);
-
-            // Send available tools
-            $this->sendSseEvent([
-                'type' => 'tools',
-                'tools' => $this->getToolDefinitions(),
-            ]);
-
-            // Keep connection alive
-            while (true) {
-                if (connection_aborted()) {
-                    break;
-                }
-                echo ": keepalive\n\n";
-                ob_flush();
-                flush();
-                Sleep::sleep(30);
-            }
-        }, 200, [
-            'Content-Type' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
-            'Connection' => 'keep-alive',
-            'X-Accel-Buffering' => 'no',
-        ]);
-    }
 
     /**
      * JSON-RPC message endpoint for tool calls
@@ -129,9 +80,9 @@ class McpController extends Controller
         return response()->json(['results' => $results]);
     }
 
-    public function pageApi(string $platform, string $version, string $section, string $slug): JsonResponse
+    public function pageApi(string $platform, string $version, string $path): JsonResponse
     {
-        $page = $this->docsSearch->getPage($platform, $version, $section, $slug);
+        $page = $this->docsSearch->getPageByPath("{$platform}/{$version}/{$path}");
 
         if (! $page) {
             return response()->json(['error' => 'Page not found'], 404);
@@ -188,7 +139,7 @@ class McpController extends Controller
             ],
             [
                 'name' => 'get_page',
-                'description' => 'Get full content of a documentation page by path (e.g., "mobile/3/apis/camera")',
+                'description' => 'Get full content of a documentation page by path (e.g., "mobile/4/plugins/core/camera")',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -369,12 +320,5 @@ class McpController extends Controller
         return [
             'content' => [['type' => 'text', 'text' => "# {$platform} v{$version} Navigation\n\n{$formatted}"]],
         ];
-    }
-
-    protected function sendSseEvent(array $data): void
-    {
-        echo 'data: '.json_encode($data)."\n\n";
-        ob_flush();
-        flush();
     }
 }

--- a/app/Services/DocsSearchService.php
+++ b/app/Services/DocsSearchService.php
@@ -49,7 +49,7 @@ class DocsSearchService
     {
         $platform = $this->sanitizePlatform($platform);
         $version = $this->sanitizeVersion($version);
-        $section = $this->sanitizePathSegment($section);
+        $section = $this->sanitizeSectionPath($section);
         $slug = $this->sanitizePathSegment($slug);
 
         if (! $platform || ! $version || ! $section || ! $slug) {
@@ -65,6 +65,11 @@ class DocsSearchService
         return $this->parsePage($filePath, $platform, $version, $section);
     }
 
+    /**
+     * Resolve a page from a `platform/version/section/slug` path. The section
+     * may itself be nested (e.g. `mobile/4/plugins/core/camera`), so anything
+     * between the version and the slug is treated as the section path.
+     */
     public function getPageByPath(string $path): ?array
     {
         $parts = explode('/', $path);
@@ -73,7 +78,11 @@ class DocsSearchService
             return null;
         }
 
-        return $this->getPage($parts[0], $parts[1], $parts[2], $parts[3]);
+        $platform = array_shift($parts);
+        $version = array_shift($parts);
+        $slug = array_pop($parts);
+
+        return $this->getPage($platform, $version, implode('/', $parts), $slug);
     }
 
     public function listApis(string $platform, string $version): array
@@ -150,7 +159,7 @@ class DocsSearchService
             foreach (glob("{$base}/{$slug}/*/_index.md") ?: [] as $nested) {
                 $nestedSlug = basename(dirname($nested));
                 $nestedOrder = YamlFrontMatter::parse(file_get_contents($nested))->matter('order') ?? 9999;
-                $rank[$nestedSlug] = $rank[$slug] + 1 + min($nestedOrder, 9998);
+                $rank["{$slug}/{$nestedSlug}"] = $rank[$slug] + 1 + min($nestedOrder, 9998);
             }
         }
 
@@ -202,7 +211,9 @@ class DocsSearchService
             return [];
         }
 
-        $cacheKey = 'mcp_docs_pages_'.($platform ?? 'all').'_'.($version ?? 'all');
+        // v2 keys: page ids now carry the full section path, so entries cached
+        // under the old shape must not be reused after a deploy.
+        $cacheKey = 'mcp_docs_pages_v2_'.($platform ?? 'all').'_'.($version ?? 'all');
 
         if (config('app.env') !== 'local') {
             $cached = Cache::get($cacheKey);
@@ -232,7 +243,10 @@ class DocsSearchService
                     ->in($versionPath);
 
                 foreach ($finder as $file) {
-                    $section = basename(dirname($file->getPathname()));
+                    // Relative to the version directory, so a page nested in a
+                    // subsection keeps its full section path (`plugins/core`)
+                    // and the ids we hand out stay resolvable by getPage().
+                    $section = $file->getRelativePath();
                     $page = $this->parsePage($file->getPathname(), $plat, $ver, $section);
                     if ($page) {
                         $pages[] = $page;
@@ -391,6 +405,27 @@ class DocsSearchService
         }
 
         return preg_match('/^[0-9]+$/', $version) ? $version : null;
+    }
+
+    /**
+     * Validate a section path, which may nest (e.g. `plugins/core`). Every
+     * segment is checked on its own so traversal can't hide behind a separator.
+     */
+    protected function sanitizeSectionPath(?string $section): ?string
+    {
+        if ($section === null || $section === '') {
+            return null;
+        }
+
+        $segments = explode('/', $section);
+
+        foreach ($segments as $segment) {
+            if (! $this->sanitizePathSegment($segment)) {
+                return null;
+            }
+        }
+
+        return implode('/', $segments);
     }
 
     protected function sanitizePathSegment(?string $segment): ?string

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -296,6 +296,14 @@
                             Wall of Love
                         </a>
                     </li>
+                    <li>
+                        <a
+                            href="{{ route('mcp') }}"
+                            class="inline-block px-px py-1.5 transition duration-300 will-change-transform hover:translate-x-1 hover:text-gray-700 dark:hover:text-gray-300"
+                        >
+                            MCP
+                        </a>
+                    </li>
                     @feature(App\Features\ShowAuthButtons::class)
                         <li>
                             <a

--- a/resources/views/mcp-content.md
+++ b/resources/views/mcp-content.md
@@ -1,0 +1,154 @@
+Everything published in the NativePHP documentation — for both
+[Mobile](/docs/mobile/getting-started/introduction) and
+[Desktop](/docs/desktop/getting-started/introduction) — is available over
+[MCP](https://modelcontextprotocol.io). Any agent that speaks the protocol —
+Claude Code, Cursor, Copilot, and friends — can search and read the docs while
+it works, instead of relying on whatever it happened to memorise during training.
+
+It's hosted by us. There's nothing to install and no API key to create; just
+point your agent at this URL:
+
+```
+https://nativephp.com/api/mcp/message
+```
+
+## Adding it to your agent
+
+### Claude Code
+
+Add it from the terminal:
+
+```shell
+claude mcp add --transport http nativephp-docs https://nativephp.com/api/mcp/message
+```
+
+Or commit the config to your repo as `.mcp.json` so everyone on the project
+picks it up automatically:
+
+```json
+{
+    "mcpServers": {
+        "nativephp-docs": {
+            "type": "http",
+            "url": "https://nativephp.com/api/mcp/message"
+        }
+    }
+}
+```
+
+### Cursor
+
+Create `.cursor/mcp.json` in your project, or `~/.cursor/mcp.json` to enable it
+everywhere:
+
+```json
+{
+    "mcpServers": {
+        "nativephp-docs": {
+            "type": "http",
+            "url": "https://nativephp.com/api/mcp/message"
+        }
+    }
+}
+```
+
+### VS Code and GitHub Copilot
+
+Create `.vscode/mcp.json`. Note that VS Code uses `servers` where the others
+use `mcpServers`:
+
+```json
+{
+    "servers": {
+        "nativephp-docs": {
+            "type": "http",
+            "url": "https://nativephp.com/api/mcp/message"
+        }
+    }
+}
+```
+
+### Agents that only speak stdio
+
+Some agents can't talk to a remote server directly. Bridge to it with
+`mcp-remote`:
+
+```json
+{
+    "mcpServers": {
+        "nativephp-docs": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "mcp-remote",
+                "https://nativephp.com/api/mcp/message"
+            ]
+        }
+    }
+}
+```
+
+The server speaks the Streamable HTTP transport over a single endpoint, so
+`/api/mcp/message` is the only URL your agent needs.
+
+## What your agent can do
+
+Once connected, your agent gets these tools.
+
+### `search_docs`
+
+Full-text search across every platform and version. Takes a `query`, plus an
+optional `platform` (`mobile` or `desktop`), `version`, and `limit` (10 by
+default). Every result comes back with its title, section, a matching snippet,
+and the path you'd hand to `get_page`.
+
+This is the one agents reach for most. _"How do I ask for camera permission?"_
+gets answered from the docs rather than from memory.
+
+### `get_page`
+
+Fetches a full page by its `path`, in `platform/version/section/slug` form — for
+example `mobile/4/the-basics/device`, or `mobile/4/plugins/core/camera` where the
+section is itself nested. Paths come straight out of `search_docs` results, so
+agents generally chain the two.
+
+### `get_navigation`
+
+Returns the whole sidebar for a `platform` and `version`, grouped by section and
+in the order you see it on the site. Useful when an agent wants to orient itself
+before searching, or to check whether a topic is documented at all.
+
+### `list_apis`
+
+Lists the pages in a version's `apis` section. That section only exists in the
+Mobile v1 and v2 docs — from v3 onwards the native APIs are documented under
+Plugins, and the Desktop docs have no `apis` section at all. For anything
+current, use `get_navigation` or `search_docs` instead.
+
+## Reading pages without MCP
+
+Every docs page is served as raw markdown by adding `.md` to its URL, which is
+often the quickest way to hand an agent one specific page:
+
+```shell
+curl https://nativephp.com/docs/mobile/4/plugins/core/camera.md
+```
+
+There's also a small REST API, if you'd rather script against it than wire up an
+MCP client:
+
+- `/api/mcp/search?q=camera&platform=mobile` — search results as JSON
+- `/api/mcp/page/{platform}/{version}/{section}/{slug}` — a single page
+- `/api/mcp/navigation/{platform}/{version}` — the docs navigation tree
+- `/api/mcp/apis/{platform}/{version}` — the `apis` section listing
+- `/api/mcp/health` — liveness check, and the versions currently published
+
+Both the MCP and REST endpoints are rate limited to 60 requests per minute per
+IP address.
+
+## Pair it with Laravel Boost
+
+This server tells your agent what NativePHP _can_ do.
+[Laravel Boost](https://laravel.com/ai/boost) tells it about _your_ application:
+your routes, models, config, and installed package versions. They complement
+each other, and running both gives noticeably better results than either alone.

--- a/resources/views/mcp.blade.php
+++ b/resources/views/mcp.blade.php
@@ -1,0 +1,74 @@
+<x-layout title="Docs MCP Server">
+    {{-- Hero --}}
+    <section
+        class="mx-auto mt-10 w-full max-w-3xl px-5 md:mt-14"
+        aria-labelledby="article-title"
+    >
+        <header class="relative grid place-items-center text-center">
+            {{-- Blurred circle - Decorative --}}
+            <div
+                class="absolute top-0 right-1/2 -z-30 h-60 w-60 translate-x-1/2 rounded-full blur-[150px] md:w-80 dark:bg-slate-500/50"
+                aria-hidden="true"
+            ></div>
+
+            {{-- Primary Heading --}}
+            <h1
+                id="article-title"
+                x-init="
+                    () => {
+                        motion.inView($el, (element) => {
+                            motion.animate(
+                                $el,
+                                {
+                                    opacity: [0, 1],
+                                    x: [-5, 0],
+                                },
+                                {
+                                    duration: 0.7,
+                                    ease: motion.easeOut,
+                                },
+                            )
+                        })
+                    }
+                "
+                class="mt-8 text-3xl font-extrabold will-change-transform sm:text-4xl"
+            >
+                Docs MCP Server
+            </h1>
+
+            {{-- Standfirst --}}
+            <p class="max-w-xl pt-4 opacity-70">
+                Give your AI coding agent the NativePHP documentation, so it
+                stops guessing at APIs.
+            </p>
+        </header>
+
+        {{-- Divider --}}
+        <x-divider />
+
+        {{-- Content --}}
+        <article
+            x-init="
+                () => {
+                    motion.inView($el, (element) => {
+                        motion.animate(
+                            $el,
+                            {
+                                opacity: [0, 1],
+                                y: [5, 0],
+                            },
+                            {
+                                duration: 0.7,
+                                ease: motion.easeOut,
+                            },
+                        )
+                    })
+                }
+            "
+            class="prose mt-2 max-w-none text-gray-600 will-change-transform dark:text-gray-400 dark:prose-headings:text-white"
+            aria-labelledby="article-title"
+        >
+            {!! App\Support\CommonMark\CommonMark::convertToHtml(file_get_contents(resource_path('views/mcp-content.md'))) !!}
+        </article>
+    </section>
+</x-layout>

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,13 +20,16 @@ use Illuminate\Support\Facades\Route;
 
 // MCP Server routes (no session/cookies - fixes CSRF 419 errors)
 Route::prefix('mcp')->group(function (): void {
-    Route::get('sse', [McpController::class, 'sse'])->name('mcp.sse');
     Route::post('message', [McpController::class, 'message'])->name('mcp.message');
     Route::get('health', [McpController::class, 'health'])->name('mcp.health');
 
     // REST API endpoints
     Route::get('search', [McpController::class, 'searchApi'])->name('mcp.api.search');
-    Route::get('page/{platform}/{version}/{section}/{slug}', [McpController::class, 'pageApi'])->name('mcp.api.page');
+    // The trailing path is a wildcard so pages nested in a subsection
+    // (e.g. mobile/4/plugins/core/camera) resolve as well as flat ones.
+    Route::get('page/{platform}/{version}/{path}', [McpController::class, 'pageApi'])
+        ->where('path', '.*')
+        ->name('mcp.api.page');
     Route::get('apis/{platform}/{version}', [McpController::class, 'apisApi'])->name('mcp.api.apis');
     Route::get('navigation/{platform}/{version}', [McpController::class, 'navigationApi'])->name('mcp.api.navigation');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -227,6 +227,7 @@ Route::view('build-my-app', 'build-my-app')->name('build-my-app');
 Route::view('consulting', 'consulting')->name('consulting');
 Route::view('the-vibes', 'the-vibes')->name('the-vibes');
 Route::view('the-vibes-prospectus', 'the-vibes-prospectus')->name('the-vibes-prospectus');
+Route::view('mcp', 'mcp')->name('mcp');
 
 // Public plugin directory routes
 Route::middleware(EnsureFeaturesAreActive::using(ShowPlugins::class))->group(function (): void {

--- a/tests/Feature/DocsMcpServerPageTest.php
+++ b/tests/Feature/DocsMcpServerPageTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\DocsSearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DocsMcpServerPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The page renders fenced code blocks. Torchlight throws outside
+        // production when no token is configured (as in CI), so give it a token
+        // and fake the API to force its offline fallback.
+        config(['torchlight.token' => 'test-token']);
+        Http::fake([
+            '*' => Http::response(['blocks' => []], 200),
+        ]);
+    }
+
+    #[Test]
+    public function it_documents_the_endpoint_clients_should_connect_to(): void
+    {
+        $this->withoutVite()
+            ->get(route('mcp'))
+            ->assertOk()
+            ->assertSee('Docs MCP Server')
+            ->assertSee('https://nativephp.com/api/mcp/message');
+    }
+
+    #[Test]
+    public function it_shows_the_config_snippets_without_evaluating_them_as_blade(): void
+    {
+        $this->withoutVite()
+            ->get(route('mcp'))
+            ->assertOk()
+            ->assertSee('mcpServers')
+            ->assertSee('"servers"')
+            ->assertSee('mcp-remote');
+    }
+
+    #[Test]
+    public function it_is_reachable_from_the_footer_on_every_page(): void
+    {
+        $content = $this->withoutVite()
+            ->get(route('welcome'))
+            ->assertOk()
+            ->getContent();
+
+        $this->assertMatchesRegularExpression(
+            '/<a\s+href="'.preg_quote(route('mcp'), '/').'"[^>]*>\s*MCP\s*<\/a>/',
+            $content,
+            'The footer should link to the MCP page, labelled "MCP".',
+        );
+    }
+
+    #[Test]
+    public function the_documented_message_endpoint_lists_the_documented_tools(): void
+    {
+        $response = $this->postJson('/api/mcp/message', [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/list',
+        ]);
+
+        $response->assertOk();
+
+        $tools = collect($response->json('result.tools'))->pluck('name')->all();
+
+        $this->assertEqualsCanonicalizing(
+            ['search_docs', 'get_page', 'list_apis', 'get_navigation'],
+            $tools,
+        );
+    }
+
+    /**
+     * The documented workflow is search, then fetch. A path that search hands
+     * back has to be one get_page can actually resolve, including for pages
+     * nested in a subsection.
+     */
+    #[Test]
+    public function every_search_result_path_can_be_fetched_by_get_page(): void
+    {
+        $paths = collect(app(DocsSearchService::class)->search('camera', 'mobile', '4', 10))
+            ->pluck('id');
+
+        $this->assertTrue($paths->contains('mobile/4/plugins/core/camera'));
+
+        foreach ($paths as $path) {
+            $response = $this->postJson('/api/mcp/message', [
+                'jsonrpc' => '2.0',
+                'id' => 1,
+                'method' => 'tools/call',
+                'params' => ['name' => 'get_page', 'arguments' => ['path' => $path]],
+            ]);
+
+            $this->assertStringNotContainsString(
+                'Page not found',
+                $response->json('result.content.0.text'),
+                "search_docs returned {$path}, which get_page could not resolve.",
+            );
+        }
+    }
+
+    #[Test]
+    public function the_sse_route_is_gone_so_clients_cannot_hang_on_it(): void
+    {
+        $this->getJson('/api/mcp/sse')->assertNotFound();
+
+        $this->assertNull(
+            app('router')->getRoutes()->getByName('mcp.sse'),
+            'The SSE route never sent the endpoint event its transport requires.',
+        );
+    }
+
+    #[Test]
+    public function the_documented_raw_markdown_url_serves_a_page(): void
+    {
+        $this->get('/docs/mobile/4/plugins/core/camera.md')
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/plain; charset=utf-8');
+    }
+
+    #[Test]
+    public function the_docs_no_longer_carry_a_duplicate_copy_of_this_page(): void
+    {
+        $this->assertSame(
+            [],
+            glob(resource_path('views/docs/*/*/**/mcp-server.md')) ?: [],
+            'The MCP server is documented once, at '.route('mcp').'.',
+        );
+    }
+}

--- a/tests/Feature/McpSecurityTest.php
+++ b/tests/Feature/McpSecurityTest.php
@@ -53,6 +53,20 @@ class McpSecurityTest extends TestCase
         $response->assertStatus(404);
     }
 
+    public function test_page_api_rejects_traversal_hidden_in_a_nested_section(): void
+    {
+        $response = $this->getJson('/api/mcp/page/mobile/4/plugins/../../../../../../etc/passwd');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_page_api_rejects_an_absolute_looking_section(): void
+    {
+        $response = $this->getJson('/api/mcp/page/mobile/4//etc/passwd');
+
+        $response->assertStatus(404);
+    }
+
     public function test_apis_endpoint_rejects_invalid_platform(): void
     {
         $response = $this->getJson('/api/mcp/apis/../1');


### PR DESCRIPTION
## What

The docs MCP server has been live and completely undocumented — grepping `resources/` for `mcp`/`MCP`/`Model Context Protocol` returned zero matches across both desktop and mobile docs. This adds a standalone page at `/mcp`, linked from the footer as "MCP".

The page covers per-agent setup (Claude Code CLI + `.mcp.json`, Cursor, VS Code's `servers` key, an `mcp-remote` bridge for stdio-only agents), what the four tools do, the raw-markdown URL trick, and the REST endpoints.

It's one standalone page rather than a page per docs version, so the content doesn't have to be duplicated and kept in sync across `mobile/4` and `desktop/2`.

## Two defects fixed along the way

Verifying every claim against the live endpoint (rather than describing intent) surfaced two real bugs that the page would otherwise have had to warn readers about.

**`search_docs` returned ids that `get_page` could not resolve.** The section was derived as `basename(dirname($file))`, so `plugins/core/camera.md` came back as `mobile/4/core/camera` — but `getPage()` rebuilt the path as `{platform}/{version}/core/camera.md`, which doesn't exist. Searching for "camera" and fetching the top hit returned `Page not found`. This hit every core plugin page in mobile v3 and v4, and broke exactly the search-then-fetch chain agents rely on.

Sections now carry their full path relative to the version directory, which also makes the ids match the public docs URLs. `getPageByPath` treats everything between the version and the slug as the section, so existing 4-part paths are unaffected. A new `sanitizeSectionPath` validates each segment separately so traversal can't hide behind a separator. The page-list cache key is bumped to `v2` — without that, entries cached under the old shape would keep serving unresolvable paths for up to 24h after deploy even with correct code.

**Removed `/api/mcp/sse`.** SSE *is* a legitimate MCP transport (the 2024-11-05 HTTP+SSE revision), but this route didn't implement it: a compliant client's first expectation is an `event: endpoint` frame carrying the POST-back URI, and the stream emitted only `data:` lines — no `event:` field anywhere in it. It also returned JSON-RPC responses in the POST body rather than over the stream, which is Streamable HTTP behaviour. So it was a hybrid implementing neither transport, and any conforming client would connect and hang. It additionally held a PHP-FPM worker per connection in a `while (true)` keepalive loop. Nothing referenced it — no tests, no `.mcp.json`, no docs. Clients use the Streamable HTTP endpoint at `/api/mcp/message`, which is what the NativePHP Claude Code plugin already ships.

The REST `page` route is now a wildcard so nested pages resolve there too; existing 4-segment URLs are unchanged.

## Verification

Checked against the running app: `search_docs` for camera in mobile v4 returns `mobile/4/plugins/core/camera` and `get_page` resolves it; flat paths, `list_apis` for mobile v2, and navigation section ordering (`plugins/core` still sorts directly after `plugins`) all still work; `/api/mcp/sse` returns 404.

## Tests

`tests/Feature/DocsMcpServerPageTest.php` (8 tests) plus two new traversal cases in `McpSecurityTest`.

The notable one is `every_search_result_path_can_be_fetched_by_get_page`, which walks real search results and asserts each one resolves — it fails on the actual regression rather than on a hardcoded path. Also covered: the page renders with the endpoint, config snippets survive un-evaluated through Blade, the footer anchor matches both href and label, `tools/list` returns exactly the four documented tools, the `mcp.sse` route is gone from the route table, and a guard that no duplicate `mcp-server.md` reappears under `resources/views/docs/`.

## Notes for review

- The page content lives in `resources/views/mcp-content.md` rather than inline in the Blade file. Prettier's Blade plugin splits inline elements onto their own lines, which renders `<code>query</code>,` as `query ,` — visible on `/privacy-policy` today. A markdown heredoc inside `@php` was worse: `prettier-plugin-blade` appends a stray `'';` after the heredoc terminator on every run. A separate `.md` avoids both and gets Torchlight highlighting via the app's existing `CommonMark` pipeline.
- Still outstanding, not touched here: `/api/mcp/health` always reports `"pages": 0`, because `search('')` tokenizes to nothing so every page scores 0 and is filtered out. The page documents health as a liveness check and doesn't mention the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)