### PR TITLE
Add cross-platform showcase filter with per-platform screenshots

### DIFF
--- a/app/Filament/Resources/ShowcaseResource.php
+++ b/app/Filament/Resources/ShowcaseResource.php
@@ -109,6 +109,28 @@ class ShowcaseResource extends Resource
                                     ->url()
                                     ->maxLength(255),
                             ]),
+
+                        Schemas\Components\Fieldset::make('Platform-specific Screenshots')
+                            ->visible(fn (Schemas\Components\Utilities\Get $get) => $get('has_mobile') && $get('has_desktop'))
+                            ->schema([
+                                Forms\Components\FileUpload::make('mobile_screenshots')
+                                    ->label('Mobile Screenshots (optional, up to 5)')
+                                    ->image()
+                                    ->multiple()
+                                    ->maxFiles(5)
+                                    ->disk('public')
+                                    ->directory('showcase-screenshots')
+                                    ->reorderable(),
+
+                                Forms\Components\FileUpload::make('desktop_screenshots')
+                                    ->label('Desktop Screenshots (optional, up to 5)')
+                                    ->image()
+                                    ->multiple()
+                                    ->maxFiles(5)
+                                    ->disk('public')
+                                    ->directory('showcase-screenshots')
+                                    ->reorderable(),
+                            ]),
                     ]),
 
                 Schemas\Components\Section::make('Certification')

--- a/app/Http/Controllers/ShowcaseController.php
+++ b/app/Http/Controllers/ShowcaseController.php
@@ -16,6 +16,8 @@ class ShowcaseController extends Controller
             $query->withMobile();
         } elseif ($platform === 'desktop') {
             $query->withDesktop();
+        } elseif ($platform === 'both') {
+            $query->withMobile()->withDesktop();
         }
 
         $showcases = $query->paginate(10);

--- a/app/Livewire/ShowcaseSubmissionForm.php
+++ b/app/Livewire/ShowcaseSubmissionForm.php
@@ -34,6 +34,16 @@ class ShowcaseSubmissionForm extends Component
 
     public array $existingScreenshots = [];
 
+    #[Validate('nullable|array|max:5')]
+    public array $mobileScreenshots = [];
+
+    public array $existingMobileScreenshots = [];
+
+    #[Validate('nullable|array|max:5')]
+    public array $desktopScreenshots = [];
+
+    public array $existingDesktopScreenshots = [];
+
     #[Validate('boolean')]
     public bool $hasMobile = false;
 
@@ -67,6 +77,8 @@ class ShowcaseSubmissionForm extends Component
             $this->description = $showcase->description;
             $this->existingImage = $showcase->image;
             $this->existingScreenshots = $showcase->screenshots ?? [];
+            $this->existingMobileScreenshots = $showcase->mobile_screenshots ?? [];
+            $this->existingDesktopScreenshots = $showcase->desktop_screenshots ?? [];
             $this->hasMobile = $showcase->has_mobile;
             $this->hasDesktop = $showcase->has_desktop;
             $this->playStoreUrl = $showcase->play_store_url ?? '';
@@ -85,6 +97,8 @@ class ShowcaseSubmissionForm extends Component
             'description' => 'required|string|max:2000',
             'image' => 'nullable|image|max:2048',
             'screenshots.*' => 'nullable|image|max:2048',
+            'mobileScreenshots.*' => 'nullable|image|max:2048',
+            'desktopScreenshots.*' => 'nullable|image|max:2048',
             'hasMobile' => 'boolean',
             'hasDesktop' => 'boolean',
             'playStoreUrl' => 'nullable|url|max:255',
@@ -115,9 +129,44 @@ class ShowcaseSubmissionForm extends Component
         }
     }
 
+    public function removeExistingMobileScreenshot(int $index): void
+    {
+        if (isset($this->existingMobileScreenshots[$index])) {
+            unset($this->existingMobileScreenshots[$index]);
+            $this->existingMobileScreenshots = array_values($this->existingMobileScreenshots);
+        }
+    }
+
+    public function removeExistingDesktopScreenshot(int $index): void
+    {
+        if (isset($this->existingDesktopScreenshots[$index])) {
+            unset($this->existingDesktopScreenshots[$index]);
+            $this->existingDesktopScreenshots = array_values($this->existingDesktopScreenshots);
+        }
+    }
+
     public function removeExistingImage(): void
     {
         $this->existingImage = null;
+    }
+
+    /**
+     * @param  array<int, string>  $existing
+     * @param  array<int, \Livewire\Features\SupportFileUploads\TemporaryUploadedFile>  $uploads
+     * @return array<int, string>
+     */
+    protected function storeScreenshots(array $existing, array $uploads): array
+    {
+        $paths = $existing;
+
+        foreach ($uploads as $upload) {
+            if (count($paths) >= 5) {
+                break;
+            }
+            $paths[] = $upload->store('showcase-screenshots', 'public');
+        }
+
+        return $paths;
     }
 
     public function submit(): mixed
@@ -135,19 +184,19 @@ class ShowcaseSubmissionForm extends Component
             $imagePath = $this->image->store('showcase-images', 'public');
         }
 
-        $screenshotPaths = $this->existingScreenshots;
-        foreach ($this->screenshots as $screenshot) {
-            if (count($screenshotPaths) >= 5) {
-                break;
-            }
-            $screenshotPaths[] = $screenshot->store('showcase-screenshots', 'public');
-        }
+        $bothPlatforms = $this->hasMobile && $this->hasDesktop;
+
+        $screenshotPaths = $this->storeScreenshots($this->existingScreenshots, $this->screenshots);
+        $mobileScreenshotPaths = $bothPlatforms ? $this->storeScreenshots($this->existingMobileScreenshots, $this->mobileScreenshots) : [];
+        $desktopScreenshotPaths = $bothPlatforms ? $this->storeScreenshots($this->existingDesktopScreenshots, $this->desktopScreenshots) : [];
 
         $data = [
             'title' => $this->title,
             'description' => $this->description,
             'image' => $imagePath,
             'screenshots' => $screenshotPaths ?: null,
+            'mobile_screenshots' => $mobileScreenshotPaths ?: null,
+            'desktop_screenshots' => $desktopScreenshotPaths ?: null,
             'has_mobile' => $this->hasMobile,
             'has_desktop' => $this->hasDesktop,
             'play_store_url' => $this->hasMobile ? ($this->playStoreUrl ?: null) : null,
@@ -199,8 +248,8 @@ class ShowcaseSubmissionForm extends Component
                 Storage::disk('public')->delete($this->showcase->image);
             }
 
-            if ($this->showcase->screenshots) {
-                foreach ($this->showcase->screenshots as $screenshot) {
+            foreach ([$this->showcase->screenshots, $this->showcase->mobile_screenshots, $this->showcase->desktop_screenshots] as $screenshots) {
+                foreach ($screenshots ?? [] as $screenshot) {
                     Storage::disk('public')->delete($screenshot);
                 }
             }

--- a/app/Models/Showcase.php
+++ b/app/Models/Showcase.php
@@ -18,6 +18,8 @@ class Showcase extends Model
         'description',
         'image',
         'screenshots',
+        'mobile_screenshots',
+        'desktop_screenshots',
         'has_mobile',
         'has_desktop',
         'play_store_url',
@@ -60,6 +62,20 @@ class Showcase extends Model
         return $this->approved_at !== null && $this->updated_at->isAfter($this->approved_at);
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public function screenshotsFor(?string $platform): array
+    {
+        $override = match ($platform) {
+            'mobile' => $this->mobile_screenshots,
+            'desktop' => $this->desktop_screenshots,
+            default => null,
+        };
+
+        return ! empty($override) ? $override : ($this->screenshots ?? []);
+    }
+
     #[Scope]
     protected function approved(Builder $query): Builder
     {
@@ -88,6 +104,8 @@ class Showcase extends Model
     {
         return [
             'screenshots' => 'array',
+            'mobile_screenshots' => 'array',
+            'desktop_screenshots' => 'array',
             'has_mobile' => 'boolean',
             'has_desktop' => 'boolean',
             'certified_nativephp' => 'boolean',

--- a/database/factories/ShowcaseFactory.php
+++ b/database/factories/ShowcaseFactory.php
@@ -33,6 +33,8 @@ class ShowcaseFactory extends Factory
             'description' => fake()->paragraph(3),
             'image' => null,
             'screenshots' => null,
+            'mobile_screenshots' => null,
+            'desktop_screenshots' => null,
             'has_mobile' => $hasMobile,
             'has_desktop' => $hasDesktop,
             'play_store_url' => $hasMobile ? fake()->optional(0.7)->url() : null,
@@ -130,6 +132,20 @@ class ShowcaseFactory extends Factory
     public function withWideScreenshots(int $count = 3): static
     {
         return $this->withScreenshots($count, tall: false);
+    }
+
+    public function withMobileScreenshots(int $count = 3): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'mobile_screenshots' => array_map(fn () => $this->generatePlaceholderScreenshot(tall: true), range(1, $count)),
+        ]);
+    }
+
+    public function withDesktopScreenshots(int $count = 3): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'desktop_screenshots' => array_map(fn () => $this->generatePlaceholderScreenshot(tall: false), range(1, $count)),
+        ]);
     }
 
     protected function generatePlaceholderScreenshot(bool $tall = false): string

--- a/database/migrations/2026_08_18_120000_add_platform_screenshots_to_showcases_table.php
+++ b/database/migrations/2026_08_18_120000_add_platform_screenshots_to_showcases_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('showcases', function (Blueprint $table) {
+            $table->json('mobile_screenshots')->nullable()->after('screenshots');
+            $table->json('desktop_screenshots')->nullable()->after('mobile_screenshots');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('showcases', function (Blueprint $table) {
+            $table->dropColumn(['mobile_screenshots', 'desktop_screenshots']);
+        });
+    }
+};

--- a/database/seeders/ShowcaseSeeder.php
+++ b/database/seeders/ShowcaseSeeder.php
@@ -18,6 +18,7 @@ class ShowcaseSeeder extends Seeder
         Showcase::factory(2)->approved()->desktop()->withWideScreenshots(3)->create();
         Showcase::factory(2)->approved()->desktop()->create();
         Showcase::factory(2)->approved()->both()->withTallScreenshots(2)->create();
+        Showcase::factory(1)->approved()->both()->withMobileScreenshots(2)->withDesktopScreenshots(2)->create();
 
         // Recently approved (will show as "new") with screenshots
         Showcase::factory(2)->recentlyApproved()->mobile()->withTallScreenshots(4)->create();

--- a/resources/views/components/showcase-card.blade.php
+++ b/resources/views/components/showcase-card.blade.php
@@ -1,12 +1,16 @@
-@props(['showcase'])
+@props(['showcase', 'platform' => null])
+
+@php
+    $displayScreenshots = $showcase->screenshotsFor($platform);
+@endphp
 
 <article
     x-data="{
         currentSlide: 0,
         lightboxSlide: 0,
         lightboxOpen: false,
-        screenshots: {{ json_encode($showcase->screenshots ?? []) }},
-        screenshotUrls: {{ json_encode(collect($showcase->screenshots ?? [])->map(fn($s) => Storage::disk('public')->url($s))->values()) }},
+        screenshots: {{ json_encode($displayScreenshots) }},
+        screenshotUrls: {{ json_encode(collect($displayScreenshots)->map(fn($s) => Storage::disk('public')->url($s))->values()) }},
         get hasScreenshots() {
             return this.screenshots && this.screenshots.length > 0
         },
@@ -60,9 +64,9 @@
 
     {{-- Screenshot Carousel --}}
     <div class="relative aspect-video bg-gray-100 dark:bg-gray-900 overflow-hidden">
-        @if($showcase->screenshots && count($showcase->screenshots) > 0)
+        @if(count($displayScreenshots) > 0)
             <div class="relative h-full">
-                @foreach($showcase->screenshots as $index => $screenshot)
+                @foreach($displayScreenshots as $index => $screenshot)
                     <button
                         type="button"
                         x-show="currentSlide === {{ $index }}"

--- a/resources/views/livewire/showcase-submission-form.blade.php
+++ b/resources/views/livewire/showcase-submission-form.blade.php
@@ -41,6 +41,9 @@
     {{-- Screenshots Field --}}
     <flux:field>
         <flux:label>Screenshots (up to 5)</flux:label>
+        @if ($hasMobile && $hasDesktop)
+            <flux:description>Shown on every platform. Add Mobile or Desktop screenshots below to override these for a specific platform.</flux:description>
+        @endif
         @if (count($existingScreenshots) > 0)
             <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-5">
                 @foreach ($existingScreenshots as $index => $screenshot)
@@ -111,6 +114,53 @@
                         <flux:error name="linuxDownloadUrl" />
                     </flux:field>
                 </div>
+            @endif
+
+            {{-- Platform-specific Screenshots (shown when both platforms are selected) --}}
+            @if ($hasMobile && $hasDesktop)
+                <flux:field>
+                    <flux:label>Mobile Screenshots (optional, up to 5)</flux:label>
+                    @if (count($existingMobileScreenshots) > 0)
+                        <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-5">
+                            @foreach ($existingMobileScreenshots as $index => $screenshot)
+                                <div wire:key="mobile-screenshot-{{ $index }}" class="group relative">
+                                    <img src="{{ Storage::disk('public')->url($screenshot) }}" alt="Mobile screenshot {{ $index + 1 }}" class="h-32 w-full rounded-lg object-cover">
+                                    <button type="button" wire:click="removeExistingMobileScreenshot({{ $index }})" class="absolute right-1 top-1 rounded-full bg-red-600 p-1 text-white opacity-0 transition-opacity group-hover:opacity-100">
+                                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                    @if (count($existingMobileScreenshots) < 5)
+                        <flux:input type="file" wire:model="mobileScreenshots" accept="image/*" multiple />
+                    @endif
+                    @error('mobileScreenshots.*') <flux:text class="text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text> @enderror
+                </flux:field>
+
+                <flux:field>
+                    <flux:label>Desktop Screenshots (optional, up to 5)</flux:label>
+                    @if (count($existingDesktopScreenshots) > 0)
+                        <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-5">
+                            @foreach ($existingDesktopScreenshots as $index => $screenshot)
+                                <div wire:key="desktop-screenshot-{{ $index }}" class="group relative">
+                                    <img src="{{ Storage::disk('public')->url($screenshot) }}" alt="Desktop screenshot {{ $index + 1 }}" class="h-32 w-full rounded-lg object-cover">
+                                    <button type="button" wire:click="removeExistingDesktopScreenshot({{ $index }})" class="absolute right-1 top-1 rounded-full bg-red-600 p-1 text-white opacity-0 transition-opacity group-hover:opacity-100">
+                                        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                                        </svg>
+                                    </button>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                    @if (count($existingDesktopScreenshots) < 5)
+                        <flux:input type="file" wire:model="desktopScreenshots" accept="image/*" multiple />
+                    @endif
+                    @error('desktopScreenshots.*') <flux:text class="text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text> @enderror
+                </flux:field>
             @endif
         </div>
 

--- a/resources/views/showcase.blade.php
+++ b/resources/views/showcase.blade.php
@@ -1,4 +1,4 @@
-<x-layout title="{{ $platform ? ucfirst($platform) . ' ' : '' }}Showcase - Apps Built with NativePHP">
+<x-layout title="{{ $platform === 'both' ? 'Cross-Platform ' : ($platform ? ucfirst($platform) . ' ' : '') }}Showcase - Apps Built with NativePHP">
     {{-- Hero Section --}}
     <section
         class="mt-10 md:mt-14"
@@ -35,6 +35,8 @@
                             Mobile
                         @elseif($platform === 'desktop')
                             Desktop
+                        @elseif($platform === 'both')
+                            Cross-Platform
                         @else
                             App
                         @endif
@@ -71,7 +73,7 @@
                 "
                 class="mx-auto mt-5 max-w-2xl text-center text-base/relaxed text-gray-600 sm:text-lg/relaxed dark:text-gray-400"
             >
-                Discover amazing {{ $platform ?? '' }} apps built by the NativePHP community. From productivity tools to creative applications, see what's possible with NativePHP.
+                Discover amazing {{ $platform === 'both' ? 'cross-platform' : ($platform ?? '') }} apps built by the NativePHP community. From productivity tools to creative applications, see what's possible with NativePHP.
             </p>
 
             {{-- Platform Filter --}}
@@ -106,6 +108,16 @@
                 >
                     Desktop
                 </a>
+                <a
+                    href="{{ route('showcase', 'both') }}"
+                    @class([
+                        'px-4 py-2 rounded-full text-sm font-medium transition-all',
+                        'bg-gray-900 text-white dark:bg-white dark:text-gray-900' => $platform === 'both',
+                        'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700' => $platform !== 'both',
+                    ])
+                >
+                    Cross-Platform
+                </a>
             </div>
         </header>
     </section>
@@ -115,7 +127,7 @@
         @if ($showcases->count() > 0)
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 @foreach ($showcases as $showcase)
-                    <x-showcase-card :showcase="$showcase" />
+                    <x-showcase-card :showcase="$showcase" :platform="$platform" />
                 @endforeach
             </div>
 
@@ -138,7 +150,7 @@
                     </h3>
                     <p class="text-gray-600 dark:text-gray-400">
                         @if($platform)
-                            No {{ $platform }} apps have been showcased yet. Be the first to submit yours!
+                            No {{ $platform === 'both' ? 'cross-platform' : $platform }} apps have been showcased yet. Be the first to submit yours!
                         @else
                             The showcase is empty. Be the first to submit your NativePHP app!
                         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -216,7 +216,7 @@ Route::post('course/checkout', function (Request $request) {
 Route::view('wall-of-love', 'wall-of-love')->name('wall-of-love');
 Route::view('brand', 'brand')->name('brand');
 Route::get('showcase/{platform?}', [ShowcaseController::class, 'index'])
-    ->where('platform', 'mobile|desktop')
+    ->where('platform', 'mobile|desktop|both')
     ->name('showcase');
 Route::view('laracon-us-2025-giveaway', 'laracon-us-2025-giveaway')->name('laracon-us-2025-giveaway');
 Route::view('privacy-policy', 'privacy-policy')->name('privacy-policy');

--- a/tests/Feature/ShowcasePageTest.php
+++ b/tests/Feature/ShowcasePageTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Showcase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ShowcasePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_showcase_page_lists_all_approved_apps(): void
+    {
+        Showcase::factory()->approved()->mobile()->create(['title' => 'Mobile App']);
+        Showcase::factory()->approved()->desktop()->create(['title' => 'Desktop App']);
+        Showcase::factory()->pending()->create(['title' => 'Pending App']);
+
+        $response = $this->get('/showcase');
+
+        $response->assertStatus(200);
+        $response->assertSee('Mobile App');
+        $response->assertSee('Desktop App');
+        $response->assertDontSee('Pending App');
+    }
+
+    public function test_mobile_filter_only_shows_apps_with_mobile_support(): void
+    {
+        Showcase::factory()->approved()->mobile()->create(['title' => 'Mobile Only App']);
+        Showcase::factory()->approved()->desktop()->create(['title' => 'Desktop Only App']);
+        Showcase::factory()->approved()->both()->create(['title' => 'Cross-Platform App']);
+
+        $response = $this->get('/showcase/mobile');
+
+        $response->assertStatus(200);
+        $response->assertSee('Mobile Only App');
+        $response->assertSee('Cross-Platform App');
+        $response->assertDontSee('Desktop Only App');
+    }
+
+    public function test_desktop_filter_only_shows_apps_with_desktop_support(): void
+    {
+        Showcase::factory()->approved()->mobile()->create(['title' => 'Mobile Only App']);
+        Showcase::factory()->approved()->desktop()->create(['title' => 'Desktop Only App']);
+        Showcase::factory()->approved()->both()->create(['title' => 'Cross-Platform App']);
+
+        $response = $this->get('/showcase/desktop');
+
+        $response->assertStatus(200);
+        $response->assertSee('Desktop Only App');
+        $response->assertSee('Cross-Platform App');
+        $response->assertDontSee('Mobile Only App');
+    }
+
+    public function test_both_filter_only_shows_apps_supporting_both_platforms(): void
+    {
+        Showcase::factory()->approved()->mobile()->create(['title' => 'Mobile Only App']);
+        Showcase::factory()->approved()->desktop()->create(['title' => 'Desktop Only App']);
+        Showcase::factory()->approved()->both()->create(['title' => 'Cross-Platform App']);
+
+        $response = $this->get('/showcase/both');
+
+        $response->assertStatus(200);
+        $response->assertSee('Cross-Platform App');
+        $response->assertDontSee('Mobile Only App');
+        $response->assertDontSee('Desktop Only App');
+    }
+
+    public function test_invalid_platform_returns_404(): void
+    {
+        $response = $this->get('/showcase/tablet');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_mobile_and_desktop_filters_show_platform_specific_screenshots(): void
+    {
+        Storage::fake('public');
+
+        $showcase = Showcase::factory()->approved()->both()
+            ->withMobileScreenshots(1)
+            ->withDesktopScreenshots(1)
+            ->create(['title' => 'Split Screenshots App']);
+
+        $mobileScreenshot = $showcase->mobile_screenshots[0];
+        $desktopScreenshot = $showcase->desktop_screenshots[0];
+
+        $mobileResponse = $this->get('/showcase/mobile');
+        $mobileResponse->assertSee($mobileScreenshot, false);
+        $mobileResponse->assertDontSee($desktopScreenshot, false);
+
+        $desktopResponse = $this->get('/showcase/desktop');
+        $desktopResponse->assertSee($desktopScreenshot, false);
+        $desktopResponse->assertDontSee($mobileScreenshot, false);
+    }
+
+    public function test_falls_back_to_shared_screenshots_without_platform_override(): void
+    {
+        Storage::fake('public');
+
+        $showcase = Showcase::factory()->approved()->both()->withScreenshots(1)->create([
+            'title' => 'Shared Screenshots App',
+        ]);
+
+        $sharedScreenshot = $showcase->screenshots[0];
+
+        $this->get('/showcase/mobile')->assertSee($sharedScreenshot, false);
+        $this->get('/showcase/desktop')->assertSee($sharedScreenshot, false);
+    }
+}

--- a/tests/Feature/ShowcaseSubmissionTest.php
+++ b/tests/Feature/ShowcaseSubmissionTest.php
@@ -7,8 +7,10 @@ use App\Models\Showcase;
 use App\Models\User;
 use App\Notifications\ShowcaseSubmitted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -122,5 +124,70 @@ class ShowcaseSubmissionTest extends TestCase
             ->toHtml();
 
         $this->assertStringContainsString('sent back for review', $resubmitted);
+    }
+
+    public function test_submitting_both_platforms_stores_platform_specific_screenshots(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ShowcaseSubmissionForm::class)
+            ->set('title', 'Cross-Platform App')
+            ->set('description', 'Works everywhere.')
+            ->set('hasMobile', true)
+            ->set('hasDesktop', true)
+            ->set('mobileScreenshots', [UploadedFile::fake()->image('mobile.png')])
+            ->set('desktopScreenshots', [UploadedFile::fake()->image('desktop.png')])
+            ->set('certifiedNativephp', true)
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $showcase = Showcase::where('title', 'Cross-Platform App')->firstOrFail();
+        $this->assertCount(1, $showcase->mobile_screenshots);
+        $this->assertCount(1, $showcase->desktop_screenshots);
+        Storage::disk('public')->assertExists($showcase->mobile_screenshots[0]);
+        Storage::disk('public')->assertExists($showcase->desktop_screenshots[0]);
+    }
+
+    public function test_submitting_a_single_platform_never_stores_platform_specific_screenshots(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ShowcaseSubmissionForm::class)
+            ->set('title', 'Mobile Only App')
+            ->set('description', 'Just mobile.')
+            ->set('hasMobile', true)
+            ->set('certifiedNativephp', true)
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $showcase = Showcase::where('title', 'Mobile Only App')->firstOrFail();
+        $this->assertNull($showcase->mobile_screenshots);
+        $this->assertNull($showcase->desktop_screenshots);
+    }
+
+    public function test_unchecking_a_platform_clears_its_platform_specific_screenshots(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create();
+        $showcase = Showcase::factory()->both()->withMobileScreenshots(2)->withDesktopScreenshots(2)->create([
+            'user_id' => $user->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ShowcaseSubmissionForm::class, ['showcase' => $showcase])
+            ->set('hasDesktop', false)
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $showcase->refresh();
+        $this->assertNull($showcase->mobile_screenshots);
+        $this->assertNull($showcase->desktop_screenshots);
     }
 }

--- a/tests/Unit/ShowcaseTest.php
+++ b/tests/Unit/ShowcaseTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Showcase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class ShowcaseTest extends TestCase
+{
+    #[Test]
+    public function screenshots_for_falls_back_to_shared_screenshots_without_a_platform(): void
+    {
+        $showcase = new Showcase(['screenshots' => ['shared-1.png', 'shared-2.png']]);
+
+        $this->assertSame(['shared-1.png', 'shared-2.png'], $showcase->screenshotsFor(null));
+    }
+
+    #[Test]
+    public function screenshots_for_falls_back_to_shared_screenshots_when_no_override_exists(): void
+    {
+        $showcase = new Showcase(['screenshots' => ['shared-1.png']]);
+
+        $this->assertSame(['shared-1.png'], $showcase->screenshotsFor('mobile'));
+        $this->assertSame(['shared-1.png'], $showcase->screenshotsFor('desktop'));
+    }
+
+    #[Test]
+    public function screenshots_for_falls_back_to_shared_screenshots_when_override_is_empty(): void
+    {
+        $showcase = new Showcase(['screenshots' => ['shared-1.png'], 'mobile_screenshots' => []]);
+
+        $this->assertSame(['shared-1.png'], $showcase->screenshotsFor('mobile'));
+    }
+
+    #[Test]
+    public function screenshots_for_returns_the_mobile_override_when_present(): void
+    {
+        $showcase = new Showcase([
+            'screenshots' => ['shared-1.png'],
+            'mobile_screenshots' => ['mobile-1.png'],
+            'desktop_screenshots' => ['desktop-1.png'],
+        ]);
+
+        $this->assertSame(['mobile-1.png'], $showcase->screenshotsFor('mobile'));
+    }
+
+    #[Test]
+    public function screenshots_for_returns_the_desktop_override_when_present(): void
+    {
+        $showcase = new Showcase([
+            'screenshots' => ['shared-1.png'],
+            'mobile_screenshots' => ['mobile-1.png'],
+            'desktop_screenshots' => ['desktop-1.png'],
+        ]);
+
+        $this->assertSame(['desktop-1.png'], $showcase->screenshotsFor('desktop'));
+    }
+
+    #[Test]
+    public function screenshots_for_returns_an_empty_array_when_nothing_is_set(): void
+    {
+        $showcase = new Showcase;
+
+        $this->assertSame([], $showcase->screenshotsFor(null));
+        $this->assertSame([], $showcase->screenshotsFor('mobile'));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a fourth "Cross-Platform" pill to the public `/showcase` page filter,
  alongside the existing All Apps / Mobile / Desktop, for apps where both
  `has_mobile` and `has_desktop` are true. The data already supported this
  (independent booleans, and the submission form already lets you check
  both) - only the public filtering UI was missing it.
- Lets submitters optionally upload separate Mobile and Desktop screenshot
  sets once both platforms are selected, via two new nullable
  `mobile_screenshots` / `desktop_screenshots` columns. The showcase card
  now shows whichever set matches the visitor's current filter, falling
  back to the original shared `screenshots` field when no override exists.
- Backwards compatible by construction: single-platform submissions never
  touch the new columns, and the existing `screenshots` field/behavior is
  completely unchanged. The Filament admin's existing screenshots field is
  also untouched - the new per-platform fields are separate, only shown
  when both platform toggles are on.

## Test plan
- [ ] `php artisan test tests/Feature/ShowcasePageTest.php` (new - filter
      correctness for mobile/desktop/both, incl. per-platform screenshots)
- [ ] `php artisan test tests/Feature/ShowcaseSubmissionTest.php` (extended
      - platform-specific screenshot storage, and cleanup when a platform
      is unchecked)
- [ ] `php artisan test tests/Unit/ShowcaseTest.php` (new - `screenshotsFor()`
      fallback/override logic)
- [ ] `vendor/bin/pint --dirty --format agent`

I wasn't able to run these myself in this environment - `composer install`
needs a licensed Flux UI Pro token I don't have access to here.