### PR TITLE
Clip long support emails and reroute README license links

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -13,8 +13,10 @@ use App\Notifications\PluginRejected;
 use App\Services\OgImageService;
 use App\Services\PluginSyncService;
 use App\Services\SatisService;
+use App\Support\PluginReadme;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -515,13 +517,39 @@ class Plugin extends Model
 
     public function getLicenseUrl(): ?string
     {
+        return $this->getRepositoryFileUrl('LICENSE');
+    }
+
+    /**
+     * Whether we host the license agreement for this plugin ourselves.
+     */
+    public function hasLicensePage(): bool
+    {
+        return $this->isPaid() && filled($this->license_html);
+    }
+
+    /**
+     * Build a URL to a file at the root of the plugin's repository.
+     */
+    public function getRepositoryFileUrl(string $path): ?string
+    {
         $repoInfo = $this->getRepositoryOwnerAndName();
 
         if (! $repoInfo) {
             return null;
         }
 
-        return "https://github.com/{$repoInfo['owner']}/{$repoInfo['repo']}/blob/main/LICENSE";
+        return "https://github.com/{$repoInfo['owner']}/{$repoInfo['repo']}/blob/main/".ltrim($path, '/');
+    }
+
+    /**
+     * The README, with links to the plugin's license file pointed at our license page.
+     */
+    protected function renderedReadmeHtml(): Attribute
+    {
+        return Attribute::make(get: fn () => $this->readme_html
+            ? PluginReadme::rewriteLicenseLinks($this->readme_html, $this)
+            : $this->readme_html);
     }
 
     public function generateWebhookSecret(): string

--- a/app/Support/PluginReadme.php
+++ b/app/Support/PluginReadme.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Plugin;
+
+class PluginReadme
+{
+    /**
+     * File extensions a license file is commonly given.
+     */
+    protected const LICENSE_EXTENSIONS = 'md|markdown|mdown|txt|rst|html?';
+
+    /**
+     * Matches LICENSE, LICENCE, UNLICENSE, COPYING and suffixed variants such as LICENSE-MIT.
+     */
+    protected const LICENSE_NAME = '/^(?:(?:un)?licen[sc]e|copying)(?:[-_][a-z0-9.]+)?$/';
+
+    /**
+     * Point links to a plugin's license file at the license page we host for it.
+     */
+    public static function rewriteLicenseLinks(string $html, Plugin $plugin): string
+    {
+        if ($html === '') {
+            return $html;
+        }
+
+        $rewritten = preg_replace_callback(
+            '/(<a\b[^>]*?\bhref\s*=\s*)(["\'])(.*?)\2/i',
+            function (array $matches) use ($plugin): string {
+                $url = static::licenseUrlFor(htmlspecialchars_decode($matches[3], ENT_QUOTES), $plugin);
+
+                return $url === null
+                    ? $matches[0]
+                    : $matches[1].$matches[2].e($url).$matches[2];
+            },
+            $html
+        );
+
+        return $rewritten ?? $html;
+    }
+
+    /**
+     * Resolve the URL a license link should point at, or null if it isn't a license link.
+     */
+    protected static function licenseUrlFor(string $href, Plugin $plugin): ?string
+    {
+        $file = static::licenseFile($href, $plugin);
+
+        if ($file === null) {
+            return null;
+        }
+
+        if ($plugin->hasLicensePage()) {
+            return route('plugins.license', $plugin->routeParams());
+        }
+
+        return $plugin->getRepositoryFileUrl($file);
+    }
+
+    /**
+     * Extract the license file a link refers to, or null if it points elsewhere.
+     */
+    protected static function licenseFile(string $href, Plugin $plugin): ?string
+    {
+        $href = trim($href);
+
+        if ($href === '' || str_starts_with($href, '#')) {
+            return null;
+        }
+
+        $parts = parse_url($href);
+
+        if ($parts === false) {
+            return null;
+        }
+
+        $file = isset($parts['scheme']) || isset($parts['host'])
+            ? static::repositoryFile($parts, $plugin)
+            : static::rootRelativeFile($parts['path'] ?? '');
+
+        return $file !== null && static::looksLikeLicenseFile($file) ? $file : null;
+    }
+
+    /**
+     * Resolve a relative link that sits alongside the README at the repository root.
+     */
+    protected static function rootRelativeFile(string $path): ?string
+    {
+        $path = ltrim(preg_replace('#^(?:\./)+#', '', $path) ?? '', '/');
+
+        return $path === '' || str_contains($path, '/') ? null : $path;
+    }
+
+    /**
+     * Resolve an absolute GitHub link back to a file at the plugin's repository root.
+     *
+     * @param  array<string, mixed>  $parts
+     */
+    protected static function repositoryFile(array $parts, Plugin $plugin): ?string
+    {
+        if (! in_array(strtolower($parts['scheme'] ?? 'https'), ['http', 'https'], true)) {
+            return null;
+        }
+
+        $repo = $plugin->getRepositoryOwnerAndName();
+
+        if (! $repo) {
+            return null;
+        }
+
+        // github.com/{owner}/{repo}/blob/{ref}/{file} or raw.githubusercontent.com/{owner}/{repo}/{ref}/{file}
+        $fileIndex = match (strtolower((string) ($parts['host'] ?? ''))) {
+            'github.com', 'www.github.com' => 4,
+            'raw.githubusercontent.com' => 3,
+            default => null,
+        };
+
+        $segments = array_values(array_filter(explode('/', (string) ($parts['path'] ?? '')), 'strlen'));
+
+        if ($fileIndex === null || count($segments) !== $fileIndex + 1) {
+            return null;
+        }
+
+        if (strcasecmp($segments[0], $repo['owner']) !== 0 || strcasecmp($segments[1], $repo['repo']) !== 0) {
+            return null;
+        }
+
+        if ($fileIndex === 4 && ! in_array(strtolower($segments[2]), ['blob', 'raw'], true)) {
+            return null;
+        }
+
+        return $segments[$fileIndex];
+    }
+
+    protected static function looksLikeLicenseFile(string $file): bool
+    {
+        $name = mb_strtolower(rawurldecode($file));
+        $name = preg_replace('/\.(?:'.static::LICENSE_EXTENSIONS.')$/', '', $name) ?? $name;
+
+        return (bool) preg_match(static::LICENSE_NAME, $name);
+    }
+}

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -246,7 +246,7 @@
                         aria-labelledby="plugin-title"
                     >
                         @if ($plugin->readme_html)
-                            {!! $plugin->readme_html !!}
+                            {!! $plugin->rendered_readme_html !!}
                         @else
                             <div class="rounded-xl border border-gray-200 bg-gray-50 p-8 text-center dark:border-gray-700 dark:bg-slate-800/50">
                                 <p class="text-gray-500 dark:text-gray-400">
@@ -403,7 +403,7 @@
                             <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">License</dt>
                             <dd class="mt-1">
                                 @if ($plugin->getLicense())
-                                    @if ($plugin->isPaid() && $plugin->license_html)
+                                    @if ($plugin->hasLicensePage())
                                         <a
                                             href="{{ route('plugins.license', $plugin->routeParams()) }}"
                                             class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
@@ -473,13 +473,14 @@
                                     @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
                                         <a
                                             href="mailto:{{ $plugin->support_channel }}"
-                                            class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                            title="{{ $plugin->support_channel }}"
+                                            class="inline-flex max-w-full items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
                                         >
-                                            {{ $plugin->support_channel }}
-                                            <x-heroicon-o-envelope class="size-3" />
+                                            <span class="truncate">{{ $plugin->support_channel }}</span>
+                                            <x-heroicon-o-envelope class="size-3 shrink-0" />
                                         </a>
                                     @else
-                                        <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
+                                        <span class="block truncate text-sm font-medium text-gray-900 dark:text-white" title="{{ $plugin->support_channel }}">{{ $plugin->support_channel }}</span>
                                     @endif
                                 </dd>
                             </div>

--- a/tests/Feature/PluginReadmeLicenseLinkTest.php
+++ b/tests/Feature/PluginReadmeLicenseLinkTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginPrice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class PluginReadmeLicenseLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    private function createPaidPlugin(string $readmeHtml): Plugin
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create([
+            'name' => 'acme/paid-plugin',
+            'repository_url' => 'https://github.com/acme/paid-plugin',
+            'readme_html' => $readmeHtml,
+            'license_html' => '<p>License agreement content</p>',
+        ]);
+
+        PluginPrice::factory()->regular()->create([
+            'plugin_id' => $plugin->id,
+            'amount' => 2999,
+        ]);
+
+        return $plugin;
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function licenseFileProvider(): array
+    {
+        return [
+            'bare name' => ['LICENSE'],
+            'markdown' => ['LICENSE.md'],
+            'text' => ['LICENSE.txt'],
+            'lowercase' => ['license.md'],
+            'british spelling' => ['LICENCE.md'],
+            'unlicense' => ['UNLICENSE'],
+            'copying' => ['COPYING'],
+            'suffixed' => ['LICENSE-MIT.md'],
+            'dot slash prefixed' => ['./LICENSE.md'],
+            'root prefixed' => ['/LICENSE.md'],
+            'github blob url' => ['https://github.com/acme/paid-plugin/blob/main/LICENSE.md'],
+            'github raw url' => ['https://raw.githubusercontent.com/acme/paid-plugin/main/LICENSE'],
+        ];
+    }
+
+    #[DataProvider('licenseFileProvider')]
+    public function test_license_links_are_rerouted_to_the_license_page(string $href): void
+    {
+        $plugin = $this->createPaidPlugin('<p>See the <a href="'.$href.'">license</a>.</p>');
+
+        $this->assertStringContainsString(
+            '<a href="'.route('plugins.license', $plugin->routeParams()).'">license</a>',
+            $plugin->rendered_readme_html
+        );
+    }
+
+    public function test_license_links_are_rerouted_when_the_readme_is_rendered(): void
+    {
+        $plugin = $this->createPaidPlugin('<p>See the <a href="LICENSE.md">license</a>.</p>');
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertStatus(200)
+            ->assertSee('<a href="'.route('plugins.license', $plugin->routeParams()).'">license</a>', false)
+            ->assertDontSee('<a href="LICENSE.md">', false);
+    }
+
+    public function test_multiple_license_links_are_all_rerouted(): void
+    {
+        $plugin = $this->createPaidPlugin(
+            '<p><a href="LICENSE">MIT</a> and <a class="x" href=\'./LICENCE.txt\'>terms</a></p>'
+        );
+
+        $licenseUrl = route('plugins.license', $plugin->routeParams());
+
+        $this->assertSame(
+            '<p><a href="'.$licenseUrl.'">MIT</a> and <a class="x" href=\''.$licenseUrl.'\'>terms</a></p>',
+            $plugin->rendered_readme_html
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function nonLicenseLinkProvider(): array
+    {
+        return [
+            'other document' => ['CONTRIBUTING.md'],
+            'nested file' => ['docs/LICENSE.md'],
+            'anchor' => ['#license'],
+            'unrelated script' => ['https://example.com/license-checker.js'],
+            'another repository' => ['https://github.com/other/repo/blob/main/LICENSE.md'],
+            'repository subdirectory' => ['https://github.com/acme/paid-plugin/blob/main/docs/LICENSE.md'],
+            'repository tree' => ['https://github.com/acme/paid-plugin/tree/main/LICENSE.md'],
+            'mail link' => ['mailto:license@example.com'],
+        ];
+    }
+
+    #[DataProvider('nonLicenseLinkProvider')]
+    public function test_other_links_are_left_alone(string $href): void
+    {
+        $plugin = $this->createPaidPlugin('<p><a href="'.$href.'">link</a></p>');
+
+        $this->assertSame(
+            '<p><a href="'.$href.'">link</a></p>',
+            $plugin->rendered_readme_html
+        );
+    }
+
+    public function test_license_links_point_at_the_repository_when_there_is_no_license_page(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create([
+            'name' => 'acme/free-plugin',
+            'repository_url' => 'https://github.com/acme/free-plugin',
+            'readme_html' => '<p><a href="LICENSE.md">license</a></p>',
+        ]);
+
+        $this->assertSame(
+            '<p><a href="https://github.com/acme/free-plugin/blob/main/LICENSE.md">license</a></p>',
+            $plugin->rendered_readme_html
+        );
+    }
+
+    public function test_license_links_are_untouched_without_a_repository_or_license_page(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create([
+            'repository_url' => null,
+            'readme_html' => '<p><a href="LICENSE.md">license</a></p>',
+        ]);
+
+        $this->assertSame('<p><a href="LICENSE.md">license</a></p>', $plugin->rendered_readme_html);
+    }
+
+    public function test_readme_without_content_is_left_as_is(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create(['readme_html' => null]);
+
+        $this->assertNull($plugin->rendered_readme_html);
+    }
+}

--- a/tests/Feature/PluginShowSupportChannelTest.php
+++ b/tests/Feature/PluginShowSupportChannelTest.php
@@ -54,4 +54,19 @@ class PluginShowSupportChannelTest extends TestCase
         $response->assertStatus(200);
         $response->assertSee('support@example.com', false);
     }
+
+    public function test_long_support_email_is_clipped_to_its_container(): void
+    {
+        $email = 'nativecodeforge.contented345@passinbox.com';
+
+        $plugin = Plugin::factory()->approved()->create([
+            'support_channel' => $email,
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertSee('title="'.$email.'"', false);
+        $response->assertSee('<span class="truncate">'.$email.'</span>', false);
+    }
 }


### PR DESCRIPTION
## Support email overflows the plugin details card

A long support address (e.g. `nativecodeforge.contented345@passinbox.com`) ran past the edge of the Plugin Details sidebar, leaving the envelope icon floating outside the container.

The address now sits in a `truncate` span inside a `max-w-full` inline-flex anchor with a `shrink-0` icon, so it clips with an ellipsis and the icon stays inside the card. The full address moves to a `title` tooltip. The same clipping is applied to the plain-text support-channel branch.

## README links to license files 404

READMEs commonly link to their license file relatively — `LICENSE.md`, `./LICENSE`, `/LICENSE.txt`, `LICENSE-MIT.md` — or by absolute GitHub URL. On the plugin page those resolve against our domain and 404.

`Plugin::rendered_readme_html` (new `App\Support\PluginReadme`) rewrites those `href`s at render time, so already-synced plugins are fixed without a re-sync. It matches:

- relative license names and variants: `LICENSE`, `LICENCE`, `UNLICENSE`, `COPYING`, suffixed forms like `LICENSE-MIT`, with `./` or `/` prefixes and `.md` / `.markdown` / `.txt` / `.rst` / `.html` extensions
- absolute `github.com/{owner}/{repo}/blob|raw/{ref}/LICENSE…` and `raw.githubusercontent.com` URLs, but only when the owner/repo match the plugin's own repository

Links go to `plugins/{vendor}/{package}/license` when we host the license page. Note that route deliberately 404s for free plugins, so sending every plugin there would swap one broken link for another — plugins without a hosted license page get an absolute link to the file in their GitHub repo instead, and plugins with no repository URL are left untouched. Non-license links, nested paths (`docs/LICENSE.md`), anchors, `mailto:` and other repositories' URLs are left alone.

`Plugin::hasLicensePage()` and `getRepositoryFileUrl()` are extracted so the sidebar and the rewriter agree on when the license page exists.

## Tests

New `PluginReadmeLicenseLinkTest` covers the license-name variants, the GitHub URL forms, the links that must be left alone, the repository fallback and the rendered page. A clipping case is added to `PluginShowSupportChannelTest`. The related plugin suites (license preview, plugin show, directory, sync, Filament resource) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)