### PR TITLE
Message plugin developers without approving or rejecting

### DIFF
--- a/app/Enums/PluginActivityType.php
+++ b/app/Enums/PluginActivityType.php
@@ -2,6 +2,8 @@
 
 namespace App\Enums;
 
+use Illuminate\Support\Str;
+
 enum PluginActivityType: string
 {
     case Submitted = 'submitted';
@@ -11,6 +13,18 @@ enum PluginActivityType: string
     case DescriptionUpdated = 'description_updated';
     case Withdrawn = 'withdrawn';
     case ReturnedToDraft = 'returned_to_draft';
+    case MessageToDeveloper = 'message_to_developer';
+    case MessageFromDeveloper = 'message_from_developer';
+
+    /**
+     * Types that represent a message in the admin <-> developer conversation.
+     *
+     * @return array<int, self>
+     */
+    public static function messageTypes(): array
+    {
+        return [self::MessageToDeveloper, self::MessageFromDeveloper];
+    }
 
     public function label(): string
     {
@@ -22,6 +36,20 @@ enum PluginActivityType: string
             self::DescriptionUpdated => 'Description Updated',
             self::Withdrawn => 'Withdrawn',
             self::ReturnedToDraft => 'Returned to Draft',
+            self::MessageToDeveloper => 'Message Sent',
+            self::MessageFromDeveloper => 'Developer Reply',
+        };
+    }
+
+    /**
+     * The same history read from the developer's side of the conversation.
+     */
+    public function developerLabel(): string
+    {
+        return match ($this) {
+            self::MessageToDeveloper => 'Message from NativePHP',
+            self::MessageFromDeveloper => 'Your Reply',
+            default => $this->label(),
         };
     }
 
@@ -35,6 +63,23 @@ enum PluginActivityType: string
             self::DescriptionUpdated => 'gray',
             self::Withdrawn => 'warning',
             self::ReturnedToDraft => 'warning',
+            self::MessageToDeveloper => 'primary',
+            self::MessageFromDeveloper => 'info',
+        };
+    }
+
+    /**
+     * Flux badge colour, grouping the log into approvals, rejections, each side
+     * of the conversation, and muted everyday status changes.
+     */
+    public function badgeColor(): string
+    {
+        return match ($this) {
+            self::Approved => 'green',
+            self::Rejected => 'red',
+            self::MessageToDeveloper => 'purple',
+            self::MessageFromDeveloper => 'sky',
+            default => 'zinc',
         };
     }
 
@@ -48,6 +93,16 @@ enum PluginActivityType: string
             self::DescriptionUpdated => 'heroicon-o-pencil-square',
             self::Withdrawn => 'heroicon-o-arrow-uturn-left',
             self::ReturnedToDraft => 'heroicon-o-arrow-uturn-left',
+            self::MessageToDeveloper => 'heroicon-o-chat-bubble-left-right',
+            self::MessageFromDeveloper => 'heroicon-o-chat-bubble-left-ellipsis',
         };
+    }
+
+    /**
+     * The icon without its Blade component prefix, as Flux components expect it.
+     */
+    public function iconName(): string
+    {
+        return Str::after($this->icon(), 'heroicon-o-');
     }
 }

--- a/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
+++ b/app/Filament/Resources/PluginResource/Pages/EditPlugin.php
@@ -76,6 +76,40 @@ class EditPlugin extends EditRecord
                 ->modalHeading('Reject Plugin')
                 ->modalDescription(fn () => "Are you sure you want to reject '{$this->record->name}'?"),
 
+            Actions\Action::make('messageDeveloper')
+                ->label('Message Developer')
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('info')
+                ->form([
+                    Forms\Components\Textarea::make('message')
+                        ->label('Message')
+                        ->required()
+                        ->rows(5)
+                        ->maxLength(5000)
+                        ->helperText('The developer is emailed a notification without the message contents; they must sign in to read and reply.')
+                        ->placeholder('Ask a question or share feedback about this plugin...'),
+                ])
+                ->action(function (array $data): void {
+                    $this->record->messageDeveloper($data['message'], auth()->id());
+
+                    Notification::make()
+                        ->title('Message sent')
+                        ->body("{$this->record->user->email} has been notified that a message is waiting.")
+                        ->success()
+                        ->send();
+                })
+                ->modalHeading('Message Developer')
+                ->modalDescription(fn () => "Send a message to {$this->record->user->email} about '{$this->record->name}'. It will appear in the Activity History and they can reply from their dashboard.")
+                ->modalSubmitActionLabel('Send Message'),
+
+            Actions\Action::make('viewListing')
+                ->label('View Listing Page')
+                ->icon('heroicon-o-eye')
+                ->color('gray')
+                ->url(fn () => route('plugins.show', $this->record->routeParams()))
+                ->openUrlInNewTab()
+                ->visible(fn () => $this->record->isApproved() || $this->record->isPending()),
+
             Actions\ActionGroup::make([
                 Actions\Action::make('convertToPaid')
                     ->label('Convert to Paid')
@@ -262,14 +296,6 @@ class EditPlugin extends EditRecord
                             ->success()
                             ->send();
                     }),
-
-                Actions\Action::make('viewListing')
-                    ->label('View Listing Page')
-                    ->icon('heroicon-o-eye')
-                    ->color('gray')
-                    ->url(fn () => route('plugins.show', $this->record->routeParams()))
-                    ->openUrlInNewTab()
-                    ->visible(fn () => $this->record->isApproved() || $this->record->isPending()),
             ])
                 ->icon('heroicon-m-ellipsis-vertical'),
         ];

--- a/app/Filament/Resources/PluginResource/RelationManagers/ActivitiesRelationManager.php
+++ b/app/Filament/Resources/PluginResource/RelationManagers/ActivitiesRelationManager.php
@@ -35,8 +35,9 @@ class ActivitiesRelationManager extends RelationManager
                     ->color('gray'),
 
                 Tables\Columns\TextColumn::make('note')
-                    ->label('Note/Reason')
-                    ->limit(50)
+                    ->label('Note/Message')
+                    ->limit(120)
+                    ->wrap()
                     ->tooltip(fn ($record) => $record->note)
                     ->placeholder('-'),
 

--- a/app/Livewire/Customer/Plugins/Show.php
+++ b/app/Livewire/Customer/Plugins/Show.php
@@ -2,20 +2,25 @@
 
 namespace App\Livewire\Customer\Plugins;
 
+use App\Enums\PluginActivityType;
 use App\Enums\PluginTier;
 use App\Enums\PluginType;
 use App\Jobs\ReviewPluginRepository;
 use App\Models\Plugin;
+use App\Models\PluginActivity;
 use App\Notifications\PluginPendingReview;
 use App\Notifications\PluginSubmitted;
 use App\Services\GitHubUserService;
 use Flux\Flux;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
+use Livewire\Attributes\Url;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\WithFileUploads;
@@ -47,16 +52,49 @@ class Show extends Component
 
     public string $notes = '';
 
+    #[Url(as: 'tab')]
     public string $activeTab = 'details';
 
     public string $pluginType = 'free';
 
     public ?string $tier = null;
 
+    public string $replyMessage = '';
+
     #[Computed]
     public function hasCompletedDeveloperOnboarding(): bool
     {
         return auth()->user()->developerAccount?->hasCompletedOnboarding() ?? false;
+    }
+
+    /**
+     * The full activity history, newest first.
+     *
+     * @return Collection<int, PluginActivity>
+     */
+    #[Computed]
+    public function activities(): Collection
+    {
+        return $this->plugin->activities()
+            ->with('causer')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    /**
+     * Developers join a conversation the admins started; they can't open one.
+     * Drafts haven't been submitted yet, so there's nothing to discuss.
+     */
+    #[Computed]
+    public function canMessageAdmins(): bool
+    {
+        if ($this->plugin->isDraft()) {
+            return false;
+        }
+
+        return $this->activities->contains(
+            fn (PluginActivity $activity): bool => $activity->type === PluginActivityType::MessageToDeveloper
+        );
     }
 
     public function mount(string $vendor, string $package): void
@@ -232,6 +270,38 @@ class Show extends Component
         $this->plugin->refresh();
 
         Flux::toast(variant: 'success', text: 'Your plugin has been withdrawn from review and returned to draft.');
+    }
+
+    public function sendMessage(): void
+    {
+        if (! $this->canMessageAdmins) {
+            Flux::toast(variant: 'danger', text: 'You can only reply once the Marketplace admins have messaged you about this plugin.');
+
+            return;
+        }
+
+        $key = 'plugin-message-reply:'.auth()->id();
+
+        if (RateLimiter::tooManyAttempts($key, 10)) {
+            $seconds = RateLimiter::availableIn($key);
+
+            $this->addError('replyMessage', "You're sending messages too quickly. Please wait {$seconds} seconds.");
+
+            return;
+        }
+
+        $this->validate([
+            'replyMessage' => ['required', 'string', 'max:5000'],
+        ]);
+
+        RateLimiter::hit($key, 60);
+
+        $this->plugin->messageAdmins($this->replyMessage, auth()->id());
+
+        $this->replyMessage = '';
+        unset($this->activities, $this->canMessageAdmins);
+
+        Flux::toast(variant: 'success', text: 'Your message has been sent to the Marketplace admins.');
     }
 
     public function returnToDraft(): void

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -9,6 +9,8 @@ use App\Enums\PluginType;
 use App\Enums\PriceTier;
 use App\Jobs\SendNewPluginNotifications;
 use App\Notifications\PluginApproved;
+use App\Notifications\PluginDeveloperReplied;
+use App\Notifications\PluginMessageReceived;
 use App\Notifications\PluginRejected;
 use App\Services\OgImageService;
 use App\Services\PluginSyncService;
@@ -22,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\Notification;
 
 class Plugin extends Model
 {
@@ -133,6 +136,18 @@ class Plugin extends Model
     public function activities(): HasMany
     {
         return $this->hasMany(PluginActivity::class)->latest();
+    }
+
+    /**
+     * The admin <-> developer conversation, oldest message first.
+     *
+     * @return HasMany<PluginActivity>
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(PluginActivity::class)
+            ->messages()
+            ->oldest();
     }
 
     /**
@@ -689,6 +704,46 @@ class Plugin extends Model
             null,
             $this->user_id
         );
+    }
+
+    /**
+     * Send an ad-hoc message from the Marketplace admins to the plugin's developer.
+     *
+     * The message body is only ever surfaced in-app; the developer is emailed a
+     * content-free nudge to log in and read it.
+     */
+    public function messageDeveloper(string $message, ?int $causerId = null): PluginActivity
+    {
+        $activity = $this->activities()->create([
+            'type' => PluginActivityType::MessageToDeveloper,
+            'from_status' => null,
+            'to_status' => $this->status->value,
+            'note' => $message,
+            'causer_id' => $causerId,
+        ]);
+
+        $this->user->notify(new PluginMessageReceived($this));
+
+        return $activity;
+    }
+
+    /**
+     * Record a developer's reply to the Marketplace admins and notify them by email.
+     */
+    public function messageAdmins(string $message, ?int $causerId = null): PluginActivity
+    {
+        $activity = $this->activities()->create([
+            'type' => PluginActivityType::MessageFromDeveloper,
+            'from_status' => null,
+            'to_status' => $this->status->value,
+            'note' => $message,
+            'causer_id' => $causerId ?? $this->user_id,
+        ]);
+
+        Notification::route('mail', 'support@nativephp.com')
+            ->notify(new PluginDeveloperReplied($this, $activity));
+
+        return $activity;
     }
 
     public function updateDescription(string $description, int $updatedById): void

--- a/app/Models/PluginActivity.php
+++ b/app/Models/PluginActivity.php
@@ -4,12 +4,37 @@ namespace App\Models;
 
 use App\Enums\PluginActivityType;
 use App\Enums\PluginStatus;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PluginActivity extends Model
 {
     protected $guarded = [];
+
+    /**
+     * @param  Builder<PluginActivity>  $query
+     * @return Builder<PluginActivity>
+     */
+    #[Scope]
+    protected function messages(Builder $query): Builder
+    {
+        return $query->whereIn('type', PluginActivityType::messageTypes());
+    }
+
+    /**
+     * How this entry's causer should be described when the plugin's owner
+     * (`$ownerId`) is the one reading the log.
+     */
+    public function causerNameFor(int $ownerId): string
+    {
+        return match (true) {
+            $this->causer_id === $ownerId => 'you',
+            $this->causer !== null => $this->causer->name,
+            default => 'NativePHP',
+        };
+    }
 
     /**
      * @return BelongsTo<Plugin, PluginActivity>

--- a/app/Notifications/PluginDeveloperReplied.php
+++ b/app/Notifications/PluginDeveloperReplied.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Filament\Resources\PluginResource;
+use App\Models\Plugin;
+use App\Models\PluginActivity;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+
+class PluginDeveloperReplied extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public Plugin $plugin,
+        public PluginActivity $activity
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $plugin = $this->plugin->loadMissing('user');
+
+        return (new MailMessage)
+            ->subject('New plugin reply: '.$plugin->name)
+            ->greeting('A developer has replied about their plugin!')
+            ->line("**Plugin:** {$plugin->name}")
+            ->line('**From:** '.($plugin->user?->name ?? 'Unknown'))
+            ->line('**Reply:**')
+            ->line(Str::limit((string) $this->activity->note, 500))
+            ->action('View Plugin', PluginResource::getUrl('edit', ['record' => $plugin]));
+    }
+}

--- a/app/Notifications/PluginMessageReceived.php
+++ b/app/Notifications/PluginMessageReceived.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Plugin;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Tells a developer that the review team has messaged them about a plugin.
+ *
+ * The message body is deliberately withheld — they must sign in to read it and reply.
+ */
+class PluginMessageReceived extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public Plugin $plugin
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New message about your plugin')
+            ->greeting('Hello,')
+            ->line("The NativePHP team has sent you a message about your plugin **{$this->plugin->name}**.")
+            ->line('Please sign in to read it and reply.')
+            ->action('View Message', $this->actionUrl())
+            ->line('*Please do not reply to this email — responses must be sent from your plugin\'s page.*');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'New message about your plugin',
+            'body' => "The NativePHP team has sent you a message about {$this->plugin->name}. Sign in to read it and reply.",
+            'plugin_id' => $this->plugin->id,
+            'plugin_name' => $this->plugin->name,
+            'action_url' => $this->actionUrl(),
+            'action_label' => 'View Message',
+        ];
+    }
+
+    protected function actionUrl(): string
+    {
+        return route('customer.plugins.show', [...$this->plugin->routeParams(), 'tab' => 'activity']);
+    }
+}

--- a/resources/views/livewire/customer/plugins/show.blade.php
+++ b/resources/views/livewire/customer/plugins/show.blade.php
@@ -250,15 +250,18 @@
             </flux:card>
         @endif
 
-        {{-- Editable fields for Draft plugins (with tabs) --}}
-        @if ($plugin->isDraft())
-            <flux:tab.group>
-                <flux:tabs wire:model="activeTab">
-                    <flux:tab name="details">Details</flux:tab>
+        {{-- Plugin details, submission and activity --}}
+        <flux:tab.group>
+            <flux:tabs wire:model.live="activeTab">
+                <flux:tab name="details">Details</flux:tab>
+                @if ($plugin->isDraft())
                     <flux:tab name="submit">Submit for Review</flux:tab>
-                </flux:tabs>
+                @endif
+                <flux:tab name="activity">Activity</flux:tab>
+            </flux:tabs>
 
-                <flux:tab.panel name="details">
+            <flux:tab.panel name="details">
+                @if ($plugin->isDraft())
                     {{-- GitHub Repo --}}
                     <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
                         <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
@@ -483,8 +486,335 @@
                             <flux:button type="submit" variant="primary">Save Changes</flux:button>
                         </div>
                     </form>
-                </flux:tab.panel>
+                @elseif ($plugin->isApproved())
+                    {{-- Editable fields for Approved plugins (no tabs) --}}
 
+                    {{-- GitHub Repo --}}
+                    <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
+                        <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                            <div class="flex items-center justify-between">
+                                <div class="flex items-center gap-3">
+                                    <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
+                                    <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
+                                </div>
+                                <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
+                            </div>
+                        </flux:card>
+                    </a>
+
+                    {{-- Read-only Type & Tier --}}
+                    <flux:card class="mb-6">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <flux:heading size="lg">Type</flux:heading>
+                                <flux:text class="mt-1">
+                                    @if ($plugin->isPaid() && $plugin->tier)
+                                        Paid &mdash; {{ $plugin->tier->label() }}
+                                    @elseif ($plugin->isPaid())
+                                        Paid
+                                    @else
+                                        Free
+                                    @endif
+                                </flux:text>
+                            </div>
+                        </div>
+                    </flux:card>
+
+                    <form wire:submit="save" class="space-y-6">
+                        {{-- Display Name --}}
+                        <flux:card>
+                            <flux:heading size="lg">Name <span class="text-sm font-normal text-gray-400 dark:text-gray-500">(optional)</span></flux:heading>
+                            <flux:text class="mt-1">A display name for your plugin. If not set, your Composer package name will be used.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:input
+                                    wire:model="displayName"
+                                    placeholder="{{ $plugin->name }}"
+                                    maxlength="250"
+                                />
+                                <flux:text class="mt-2 text-xs">Maximum 250 characters</flux:text>
+                            </div>
+                        </flux:card>
+
+                        {{-- Description --}}
+                        <flux:card>
+                            <flux:heading size="lg">Description</flux:heading>
+                            <flux:text class="mt-1">Describe what your plugin does. This will be displayed in the plugin directory.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:textarea
+                                    wire:model="description"
+                                    rows="5"
+                                    placeholder="Describe what your plugin does, its key features, and how developers can use it..."
+                                />
+                                @error('description')
+                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                @enderror
+                                <flux:text class="mt-2 text-xs">Maximum 1000 characters</flux:text>
+                            </div>
+                        </flux:card>
+
+                        {{-- Icon --}}
+                        <flux:card x-data="{ mode: @entangle('iconMode') }">
+                            <flux:heading size="lg">Icon</flux:heading>
+                            <flux:text class="mt-1">Choose a gradient and icon, or upload your own logo.</flux:text>
+
+                            <div class="mt-4">
+                                {{-- Current Icon Preview --}}
+                                @if ($plugin->hasCustomIcon())
+                                    <div class="mb-4 flex items-center gap-4">
+                                        @if ($plugin->hasLogo())
+                                            <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 rounded-lg object-cover shadow-sm" />
+                                        @elseif ($plugin->hasGradientIcon())
+                                            <div class="grid size-16 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                                <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                            </div>
+                                        @endif
+                                        <flux:button size="sm" variant="danger" icon="trash" wire:click="deleteIcon" type="button">Remove icon</flux:button>
+                                    </div>
+                                @endif
+
+                                {{-- Gradient Icon Picker --}}
+                                <div x-show="mode === 'gradient'" x-cloak>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Choose a gradient</label>
+                                            <div class="mt-2 grid grid-cols-4 gap-3 sm:grid-cols-8">
+                                                @foreach (\App\Models\Plugin::gradientPresets() as $key => $classes)
+                                                    <label class="relative cursor-pointer">
+                                                        <input
+                                                            type="radio"
+                                                            wire:model="iconGradient"
+                                                            value="{{ $key }}"
+                                                            class="peer sr-only"
+                                                        />
+                                                        <div class="size-12 rounded-lg bg-gradient-to-br {{ $classes }} ring-2 ring-transparent ring-offset-2 transition-all peer-checked:ring-indigo-500 peer-focus:ring-indigo-500 hover:scale-105 dark:ring-offset-gray-800"></div>
+                                                    </label>
+                                                @endforeach
+                                            </div>
+                                            @error('iconGradient')
+                                                <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                            @enderror
+                                        </div>
+
+                                        <flux:input
+                                            wire:model="iconName"
+                                            label="Heroicon name"
+                                            placeholder="cube"
+                                            description="Enter a Heroicon outline name, e.g., cube, sparkles, bolt."
+                                        />
+                                        @error('iconName')
+                                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                        @enderror
+
+                                        <flux:button wire:click="updateIcon" variant="filled" type="button">Save Icon</flux:button>
+                                    </div>
+
+                                    <flux:separator class="my-4" />
+                                    <button type="button" @click="mode = 'upload'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                        Or upload your own logo instead
+                                    </button>
+                                </div>
+
+                                {{-- Custom Logo Upload --}}
+                                <div x-show="mode === 'upload'" x-cloak>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload a logo</label>
+                                            <div class="mt-2 flex items-center gap-4">
+                                                <input
+                                                    type="file"
+                                                    wire:model="logo"
+                                                    accept="image/png,image/jpeg,image/jpg,image/svg+xml,image/webp"
+                                                    class="block text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900/50 dark:file:text-indigo-300 dark:hover:file:bg-indigo-900/70"
+                                                />
+                                                <flux:button wire:click="uploadLogo" variant="filled" type="button">Upload</flux:button>
+                                            </div>
+                                            @error('logo')
+                                                <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                            @enderror
+                                            <flux:text class="mt-2 text-xs">PNG, JPG, SVG, or WebP. Max 1MB. Recommended: 256x256 pixels, square.</flux:text>
+                                        </div>
+                                    </div>
+
+                                    <flux:separator class="my-4" />
+                                    <button type="button" @click="mode = 'gradient'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
+                                        Or choose a gradient icon instead
+                                    </button>
+                                </div>
+                            </div>
+                        </flux:card>
+
+                        {{-- Support Channel --}}
+                        <flux:card>
+                            <flux:heading size="lg">Support</flux:heading>
+                            <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
+
+                            <div class="mt-4">
+                                <flux:input
+                                    wire:model="supportChannel"
+                                    placeholder="support@example.com or https://..."
+                                />
+                                @error('supportChannel')
+                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                                @enderror
+                            </div>
+                        </flux:card>
+
+                        {{-- Save Button --}}
+                        <div class="flex items-center justify-end">
+                            <flux:button type="submit" variant="primary">Save Changes</flux:button>
+                        </div>
+                    </form>
+                @else
+                    {{-- Read-only display for Pending/Rejected --}}
+                    <flux:card class="mb-6">
+                        <div class="flex items-start justify-between">
+                            <div class="flex items-start gap-4">
+                                @if ($plugin->hasLogo())
+                                    <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 shrink-0 rounded-lg object-cover shadow-sm" />
+                                @elseif ($plugin->hasGradientIcon())
+                                    <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
+                                        <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
+                                    </div>
+                                @else
+                                    <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-sm">
+                                        <x-vaadin-plug class="size-8" />
+                                    </div>
+                                @endif
+                                <div>
+                                    <flux:heading size="lg">{{ $plugin->display_name ?? $plugin->name }}</flux:heading>
+                                    @if ($plugin->description)
+                                        <flux:text class="mt-2">{{ $plugin->description }}</flux:text>
+                                    @else
+                                        <flux:text class="mt-2 text-gray-400 dark:text-gray-500">No description provided</flux:text>
+                                    @endif
+                                </div>
+                            </div>
+                            @if ($plugin->isPaid() && $plugin->tier)
+                                <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                                    {{ $plugin->tier->label() }}
+                                </span>
+                            @elseif ($plugin->isPaid())
+                                <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
+                                    Paid
+                                </span>
+                            @else
+                                <span class="inline-flex shrink-0 items-center text-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                                    Free
+                                </span>
+                            @endif
+                        </div>
+
+                        <flux:separator class="my-4" />
+
+                        <dl class="grid grid-cols-2 gap-3">
+                            {{-- Author --}}
+                            <div class="col-span-2">
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Author</dt>
+                                <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                                    {{ $plugin->user->display_name }}
+                                </dd>
+                            </div>
+
+                            {{-- Version --}}
+                            <div>
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Version</dt>
+                                <dd class="mt-1">
+                                    @if ($plugin->latest_version)
+                                        <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                            {{ $plugin->latest_version }}
+                                            <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                        </a>
+                                    @elseif ($plugin->review_checks['release_version'] ?? null)
+                                        <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                            {{ $plugin->review_checks['release_version'] }}
+                                            <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                        </a>
+                                    @else
+                                        <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                                    @endif
+                                </dd>
+                            </div>
+
+                            {{-- License --}}
+                            <div>
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">License</dt>
+                                <dd class="mt-1">
+                                    @if ($plugin->getLicense())
+                                        <a href="{{ $plugin->getLicenseUrl() }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                            {{ $plugin->getLicense() }}
+                                            <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                        </a>
+                                    @else
+                                        <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+                                    @endif
+                                </dd>
+                            </div>
+
+                            {{-- iOS Version --}}
+                            <div>
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min iOS</dt>
+                                <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                                    {{ $plugin->ios_version ?? ($plugin->review_checks['ios_min_version'] ?? '—') }}
+                                </dd>
+                            </div>
+
+                            {{-- Android Version --}}
+                            <div>
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min Android</dt>
+                                <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+                                    {{ $plugin->android_version ?? ($plugin->review_checks['android_min_version'] ?? '—') }}
+                                </dd>
+                            </div>
+
+                            {{-- Support Channel --}}
+                            <div class="col-span-2">
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Support Channel</dt>
+                                <dd class="mt-1">
+                                    @if ($plugin->support_channel)
+                                        @if (filter_var($plugin->support_channel, FILTER_VALIDATE_URL))
+                                            <a href="{{ $plugin->support_channel }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                {{ $plugin->support_channel }}
+                                                <x-heroicon-o-arrow-top-right-on-square class="size-3" />
+                                            </a>
+                                        @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
+                                            <a href="mailto:{{ $plugin->support_channel }}" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                                {{ $plugin->support_channel }}
+                                                <x-heroicon-o-envelope class="size-3" />
+                                            </a>
+                                        @else
+                                            <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
+                                        @endif
+                                    @else
+                                        <span class="text-sm text-gray-400 dark:text-gray-500">Not set</span>
+                                    @endif
+                                </dd>
+                            </div>
+
+                            {{-- Repository --}}
+                            <div class="col-span-2">
+                                <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Repository</dt>
+                                <dd class="mt-1">
+                                    <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
+                                        {{ $plugin->repository_url }}
+                                        <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
+                                    </a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </flux:card>
+
+                    @if ($plugin->notes)
+                        <flux:card class="mb-6">
+                            <flux:heading size="lg">Submission Notes</flux:heading>
+                            <flux:text class="mt-2">{{ $plugin->notes }}</flux:text>
+                        </flux:card>
+                    @endif
+                @endif
+            </flux:tab.panel>
+
+            @if ($plugin->isDraft())
                 <flux:tab.panel name="submit">
                     <div class="space-y-6">
                         {{-- Plugin Summary --}}
@@ -654,333 +984,59 @@
                         </div>
                     </div>
                 </flux:tab.panel>
-            </flux:tab.group>
-        @elseif ($plugin->isApproved())
-            {{-- Editable fields for Approved plugins (no tabs) --}}
-
-            {{-- GitHub Repo --}}
-            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="block">
-                <flux:card class="mb-6 transition hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3">
-                            <x-icons.github class="size-5 text-gray-400 dark:text-gray-500" />
-                            <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->name }}</span>
-                        </div>
-                        <x-heroicon-o-arrow-top-right-on-square class="size-4 text-gray-400 dark:text-gray-500" />
-                    </div>
-                </flux:card>
-            </a>
-
-            {{-- Read-only Type & Tier --}}
-            <flux:card class="mb-6">
-                <div class="flex items-center justify-between">
-                    <div>
-                        <flux:heading size="lg">Type</flux:heading>
-                        <flux:text class="mt-1">
-                            @if ($plugin->isPaid() && $plugin->tier)
-                                Paid &mdash; {{ $plugin->tier->label() }}
-                            @elseif ($plugin->isPaid())
-                                Paid
-                            @else
-                                Free
-                            @endif
-                        </flux:text>
-                    </div>
-                </div>
-            </flux:card>
-
-            <form wire:submit="save" class="space-y-6">
-                {{-- Display Name --}}
-                <flux:card>
-                    <flux:heading size="lg">Name <span class="text-sm font-normal text-gray-400 dark:text-gray-500">(optional)</span></flux:heading>
-                    <flux:text class="mt-1">A display name for your plugin. If not set, your Composer package name will be used.</flux:text>
-
-                    <div class="mt-4">
-                        <flux:input
-                            wire:model="displayName"
-                            placeholder="{{ $plugin->name }}"
-                            maxlength="250"
-                        />
-                        <flux:text class="mt-2 text-xs">Maximum 250 characters</flux:text>
-                    </div>
-                </flux:card>
-
-                {{-- Description --}}
-                <flux:card>
-                    <flux:heading size="lg">Description</flux:heading>
-                    <flux:text class="mt-1">Describe what your plugin does. This will be displayed in the plugin directory.</flux:text>
-
-                    <div class="mt-4">
-                        <flux:textarea
-                            wire:model="description"
-                            rows="5"
-                            placeholder="Describe what your plugin does, its key features, and how developers can use it..."
-                        />
-                        @error('description')
-                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                        @enderror
-                        <flux:text class="mt-2 text-xs">Maximum 1000 characters</flux:text>
-                    </div>
-                </flux:card>
-
-                {{-- Icon --}}
-                <flux:card x-data="{ mode: @entangle('iconMode') }">
-                    <flux:heading size="lg">Icon</flux:heading>
-                    <flux:text class="mt-1">Choose a gradient and icon, or upload your own logo.</flux:text>
-
-                    <div class="mt-4">
-                        {{-- Current Icon Preview --}}
-                        @if ($plugin->hasCustomIcon())
-                            <div class="mb-4 flex items-center gap-4">
-                                @if ($plugin->hasLogo())
-                                    <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 rounded-lg object-cover shadow-sm" />
-                                @elseif ($plugin->hasGradientIcon())
-                                    <div class="grid size-16 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
-                                        <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
-                                    </div>
-                                @endif
-                                <flux:button size="sm" variant="danger" icon="trash" wire:click="deleteIcon" type="button">Remove icon</flux:button>
-                            </div>
-                        @endif
-
-                        {{-- Gradient Icon Picker --}}
-                        <div x-show="mode === 'gradient'" x-cloak>
-                            <div class="space-y-4">
-                                <div>
-                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Choose a gradient</label>
-                                    <div class="mt-2 grid grid-cols-4 gap-3 sm:grid-cols-8">
-                                        @foreach (\App\Models\Plugin::gradientPresets() as $key => $classes)
-                                            <label class="relative cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    wire:model="iconGradient"
-                                                    value="{{ $key }}"
-                                                    class="peer sr-only"
-                                                />
-                                                <div class="size-12 rounded-lg bg-gradient-to-br {{ $classes }} ring-2 ring-transparent ring-offset-2 transition-all peer-checked:ring-indigo-500 peer-focus:ring-indigo-500 hover:scale-105 dark:ring-offset-gray-800"></div>
-                                            </label>
-                                        @endforeach
-                                    </div>
-                                    @error('iconGradient')
-                                        <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                                    @enderror
-                                </div>
-
-                                <flux:input
-                                    wire:model="iconName"
-                                    label="Heroicon name"
-                                    placeholder="cube"
-                                    description="Enter a Heroicon outline name, e.g., cube, sparkles, bolt."
-                                />
-                                @error('iconName')
-                                    <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                                @enderror
-
-                                <flux:button wire:click="updateIcon" variant="filled" type="button">Save Icon</flux:button>
-                            </div>
-
-                            <flux:separator class="my-4" />
-                            <button type="button" @click="mode = 'upload'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
-                                Or upload your own logo instead
-                            </button>
-                        </div>
-
-                        {{-- Custom Logo Upload --}}
-                        <div x-show="mode === 'upload'" x-cloak>
-                            <div class="space-y-4">
-                                <div>
-                                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload a logo</label>
-                                    <div class="mt-2 flex items-center gap-4">
-                                        <input
-                                            type="file"
-                                            wire:model="logo"
-                                            accept="image/png,image/jpeg,image/jpg,image/svg+xml,image/webp"
-                                            class="block text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-indigo-700 hover:file:bg-indigo-100 dark:text-gray-400 dark:file:bg-indigo-900/50 dark:file:text-indigo-300 dark:hover:file:bg-indigo-900/70"
-                                        />
-                                        <flux:button wire:click="uploadLogo" variant="filled" type="button">Upload</flux:button>
-                                    </div>
-                                    @error('logo')
-                                        <flux:text class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                                    @enderror
-                                    <flux:text class="mt-2 text-xs">PNG, JPG, SVG, or WebP. Max 1MB. Recommended: 256x256 pixels, square.</flux:text>
-                                </div>
-                            </div>
-
-                            <flux:separator class="my-4" />
-                            <button type="button" @click="mode = 'gradient'" class="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400">
-                                Or choose a gradient icon instead
-                            </button>
-                        </div>
-                    </div>
-                </flux:card>
-
-                {{-- Support Channel --}}
-                <flux:card>
-                    <flux:heading size="lg">Support</flux:heading>
-                    <flux:text class="mt-1">How can users get support for your plugin? Provide an email address or a URL.</flux:text>
-
-                    <div class="mt-4">
-                        <flux:input
-                            wire:model="supportChannel"
-                            placeholder="support@example.com or https://..."
-                        />
-                        @error('supportChannel')
-                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
-                        @enderror
-                    </div>
-                </flux:card>
-
-                {{-- Save Button --}}
-                <div class="flex items-center justify-end">
-                    <flux:button type="submit" variant="primary">Save Changes</flux:button>
-                </div>
-            </form>
-        @else
-            {{-- Read-only display for Pending/Rejected --}}
-            <flux:card class="mb-6">
-                <div class="flex items-start justify-between">
-                    <div class="flex items-start gap-4">
-                        @if ($plugin->hasLogo())
-                            <img src="{{ $plugin->getLogoUrl() }}" alt="{{ $plugin->name }} logo" class="size-16 shrink-0 rounded-lg object-cover shadow-sm" />
-                        @elseif ($plugin->hasGradientIcon())
-                            <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br {{ $plugin->getGradientClasses() }} text-white shadow-sm">
-                                <x-dynamic-component :component="'heroicon-o-' . $plugin->icon_name" class="size-8" />
-                            </div>
-                        @else
-                            <div class="grid size-16 shrink-0 place-items-center rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-sm">
-                                <x-vaadin-plug class="size-8" />
-                            </div>
-                        @endif
-                        <div>
-                            <flux:heading size="lg">{{ $plugin->display_name ?? $plugin->name }}</flux:heading>
-                            @if ($plugin->description)
-                                <flux:text class="mt-2">{{ $plugin->description }}</flux:text>
-                            @else
-                                <flux:text class="mt-2 text-gray-400 dark:text-gray-500">No description provided</flux:text>
-                            @endif
-                        </div>
-                    </div>
-                    @if ($plugin->isPaid() && $plugin->tier)
-                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
-                            {{ $plugin->tier->label() }}
-                        </span>
-                    @elseif ($plugin->isPaid())
-                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400">
-                            Paid
-                        </span>
-                    @else
-                        <span class="inline-flex shrink-0 items-center text-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-                            Free
-                        </span>
-                    @endif
-                </div>
-
-                <flux:separator class="my-4" />
-
-                <dl class="grid grid-cols-2 gap-3">
-                    {{-- Author --}}
-                    <div class="col-span-2">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Author</dt>
-                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                            {{ $plugin->user->display_name }}
-                        </dd>
-                    </div>
-
-                    {{-- Version --}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Version</dt>
-                        <dd class="mt-1">
-                            @if ($plugin->latest_version)
-                                <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                    {{ $plugin->latest_version }}
-                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
-                                </a>
-                            @elseif ($plugin->review_checks['release_version'] ?? null)
-                                <a href="{{ $plugin->repository_url }}/releases" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                    {{ $plugin->review_checks['release_version'] }}
-                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
-                                </a>
-                            @else
-                                <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
-                            @endif
-                        </dd>
-                    </div>
-
-                    {{-- License --}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">License</dt>
-                        <dd class="mt-1">
-                            @if ($plugin->getLicense())
-                                <a href="{{ $plugin->getLicenseUrl() }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                    {{ $plugin->getLicense() }}
-                                    <x-heroicon-o-arrow-top-right-on-square class="size-3" />
-                                </a>
-                            @else
-                                <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
-                            @endif
-                        </dd>
-                    </div>
-
-                    {{-- iOS Version --}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min iOS</dt>
-                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                            {{ $plugin->ios_version ?? ($plugin->review_checks['ios_min_version'] ?? '—') }}
-                        </dd>
-                    </div>
-
-                    {{-- Android Version --}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Min Android</dt>
-                        <dd class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
-                            {{ $plugin->android_version ?? ($plugin->review_checks['android_min_version'] ?? '—') }}
-                        </dd>
-                    </div>
-
-                    {{-- Support Channel --}}
-                    <div class="col-span-2">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Support Channel</dt>
-                        <dd class="mt-1">
-                            @if ($plugin->support_channel)
-                                @if (filter_var($plugin->support_channel, FILTER_VALIDATE_URL))
-                                    <a href="{{ $plugin->support_channel }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                        {{ $plugin->support_channel }}
-                                        <x-heroicon-o-arrow-top-right-on-square class="size-3" />
-                                    </a>
-                                @elseif (filter_var($plugin->support_channel, FILTER_VALIDATE_EMAIL))
-                                    <a href="mailto:{{ $plugin->support_channel }}" class="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                        {{ $plugin->support_channel }}
-                                        <x-heroicon-o-envelope class="size-3" />
-                                    </a>
-                                @else
-                                    <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $plugin->support_channel }}</span>
-                                @endif
-                            @else
-                                <span class="text-sm text-gray-400 dark:text-gray-500">Not set</span>
-                            @endif
-                        </dd>
-                    </div>
-
-                    {{-- Repository --}}
-                    <div class="col-span-2">
-                        <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">Repository</dt>
-                        <dd class="mt-1">
-                            <a href="{{ $plugin->repository_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300">
-                                {{ $plugin->repository_url }}
-                                <x-heroicon-o-arrow-top-right-on-square class="size-3.5" />
-                            </a>
-                        </dd>
-                    </div>
-                </dl>
-            </flux:card>
-
-            @if ($plugin->notes)
-                <flux:card class="mb-6">
-                    <flux:heading size="lg">Submission Notes</flux:heading>
-                    <flux:text class="mt-2">{{ $plugin->notes }}</flux:text>
-                </flux:card>
             @endif
-        @endif
+
+            <flux:tab.panel name="activity">
+                @if ($this->canMessageAdmins)
+                    <form wire:submit="sendMessage" class="mb-8">
+                        <flux:textarea
+                            wire:model="replyMessage"
+                            label="Send a message to Marketplace admins"
+                            rows="3"
+                            placeholder="Type your message here..."
+                            @keydown.meta.enter="$wire.sendMessage()"
+                            @keydown.ctrl.enter="$wire.sendMessage()"
+                        />
+                        @error('replyMessage')
+                            <flux:text class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</flux:text>
+                        @enderror
+
+                        <div class="mt-3 flex items-center justify-end gap-3">
+                            <flux:text class="text-xs">&#8984;/Ctrl + Enter to send</flux:text>
+                            <flux:button type="submit" variant="primary" icon="paper-airplane">Send Message</flux:button>
+                        </div>
+                    </form>
+                @endif
+
+                <ul class="space-y-5">
+                    @foreach ($this->activities as $activity)
+                        <li class="flex flex-col gap-1.5 sm:flex-row sm:gap-3" wire:key="activity-{{ $activity->id }}">
+                            <div class="shrink-0 sm:w-52 sm:pt-px">
+                                <flux:badge :color="$activity->type->badgeColor()" :icon="$activity->type->iconName()" size="sm">
+                                    {{ $activity->type->developerLabel() }}
+                                </flux:badge>
+                            </div>
+
+                            <div class="min-w-0 flex-1">
+                                @if ($activity->from_status && $activity->from_status !== $activity->to_status)
+                                    <p class="text-sm text-zinc-800 dark:text-zinc-200">
+                                        {{ $activity->from_status->label() }} &rarr; {{ $activity->to_status->label() }}
+                                    </p>
+                                @endif
+
+                                @if ($activity->note)
+                                    <p class="whitespace-pre-line text-sm text-zinc-800 dark:text-zinc-200">{{ $activity->note }}</p>
+                                @endif
+
+                                <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                                    {{ $activity->created_at->format('d M Y, H:i') }} &middot; by {{ $activity->causerNameFor($plugin->user_id) }}
+                                </p>
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            </flux:tab.panel>
+        </flux:tab.group>
 
     </div>
 

--- a/tests/Feature/Filament/PluginMessageDeveloperTest.php
+++ b/tests/Feature/Filament/PluginMessageDeveloperTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\PluginActivityType;
+use App\Filament\Resources\PluginResource\Pages\EditPlugin;
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\PluginMessageReceived;
+use Filament\Actions\Action;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginMessageDeveloperTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_message_developer_action_logs_activity_and_notifies_developer(): void
+    {
+        Notification::fake();
+
+        $developer = User::factory()->create();
+        $plugin = Plugin::factory()->pending()->for($developer)->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->callAction('messageDeveloper', ['message' => 'Could you add a README example?'])
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        $activity = $plugin->activities()->first();
+
+        $this->assertSame(PluginActivityType::MessageToDeveloper, $activity->type);
+        $this->assertSame('Could you add a README example?', $activity->note);
+        $this->assertSame($this->admin->id, $activity->causer_id);
+        $this->assertNull($activity->from_status);
+        $this->assertSame($plugin->status, $activity->to_status);
+
+        Notification::assertSentTo(
+            $developer,
+            PluginMessageReceived::class,
+            fn (PluginMessageReceived $notification) => $notification->plugin->is($plugin)
+        );
+    }
+
+    public function test_message_developer_action_does_not_change_plugin_status(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->pending()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->callAction('messageDeveloper', ['message' => 'Just checking in.']);
+
+        $this->assertTrue($plugin->fresh()->isPending());
+        $this->assertNull($plugin->fresh()->rejection_reason);
+        $this->assertNull($plugin->fresh()->approved_at);
+    }
+
+    public function test_message_developer_action_requires_a_message(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->pending()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->callAction('messageDeveloper', ['message' => ''])
+            ->assertHasActionErrors(['message' => 'required']);
+
+        $this->assertSame(0, $plugin->activities()->count());
+        Notification::assertNothingSent();
+    }
+
+    public function test_message_developer_action_is_available_for_every_status(): void
+    {
+        foreach (['draft', 'pending', 'approved', 'rejected'] as $state) {
+            $plugin = Plugin::factory()->{$state}()->create();
+
+            Livewire::actingAs($this->admin)
+                ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+                ->assertActionVisible('messageDeveloper');
+        }
+    }
+
+    public function test_developer_email_does_not_reveal_the_message_contents(): void
+    {
+        $developer = User::factory()->create();
+        $plugin = Plugin::factory()->pending()->for($developer)->create();
+
+        $plugin->messageDeveloper('Top secret reviewer feedback', $this->admin->id);
+
+        $mail = (new PluginMessageReceived($plugin))->toMail($developer);
+        $rendered = (string) $mail->render();
+
+        $this->assertStringNotContainsString('Top secret reviewer feedback', $rendered);
+        $this->assertStringContainsString('Please sign in to read it and reply.', $rendered);
+        $this->assertStringContainsString(
+            route('customer.plugins.show', $plugin->routeParams()),
+            $rendered
+        );
+    }
+
+    public function test_view_listing_action_is_a_top_level_header_action(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertActionVisible('viewListing');
+
+        $actions = Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->instance()
+            ->getCachedHeaderActions();
+
+        $topLevelNames = collect($actions)
+            ->filter(fn ($action) => $action instanceof Action)
+            ->map(fn (Action $action) => $action->getName())
+            ->all();
+
+        $this->assertContains('viewListing', $topLevelNames);
+        $this->assertContains('messageDeveloper', $topLevelNames);
+    }
+
+    public function test_view_listing_action_is_hidden_for_draft_plugins(): void
+    {
+        $plugin = Plugin::factory()->draft()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(EditPlugin::class, ['record' => $plugin->getRouteKey()])
+            ->assertActionHidden('viewListing');
+    }
+}

--- a/tests/Feature/Livewire/Customer/PluginMessagesTest.php
+++ b/tests/Feature/Livewire/Customer/PluginMessagesTest.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace Tests\Feature\Livewire\Customer;
+
+use App\Enums\PluginActivityType;
+use App\Enums\PluginStatus;
+use App\Livewire\Customer\Plugins\Show;
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\PluginDeveloperReplied;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class PluginMessagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $developer;
+
+    private User $reviewer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->developer = User::factory()->create();
+        $this->reviewer = User::factory()->create(['name' => 'Reviewer Rita']);
+
+        RateLimiter::clear('plugin-message-reply:'.$this->developer->id);
+    }
+
+    private function pluginWithMessage(string $message = 'Please add iOS support notes.'): Plugin
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->pending()->for($this->developer)->create();
+        $plugin->messageDeveloper($message, $this->reviewer->id);
+
+        return $plugin->fresh();
+    }
+
+    private function testable(Plugin $plugin): Testable
+    {
+        return Livewire::actingAs($this->developer)->test(Show::class, [
+            'vendor' => $plugin->routeParams()['vendor'],
+            'package' => $plugin->routeParams()['package'],
+        ]);
+    }
+
+    public function test_activity_tab_shows_reviewer_message_and_its_author(): void
+    {
+        $plugin = $this->pluginWithMessage('Please add iOS support notes.');
+
+        $this->testable($plugin)
+            ->assertSee('Activity')
+            ->assertSee('Please add iOS support notes.')
+            ->assertSee('Message from NativePHP')
+            ->assertSee('Reviewer Rita');
+    }
+
+    public function test_activity_tab_lists_the_full_history_newest_first(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->draft()->for($this->developer)->create();
+        $plugin->submit();
+        $plugin->messageDeveloper('One tweak needed before approval.', $this->reviewer->id);
+        $plugin->refresh();
+        $plugin->messageAdmins('Tweaked and pushed.', $this->developer->id);
+
+        $this->testable($plugin)
+            ->assertSeeInOrder([
+                'Tweaked and pushed.',
+                'One tweak needed before approval.',
+            ])
+            ->assertSee('Your Reply')
+            ->assertSee('Message from NativePHP')
+            ->assertSee('Submitted')
+            ->assertSee('Pending Review');
+    }
+
+    public function test_status_changes_appear_in_the_activity_tab_without_any_messages(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->draft()->for($this->developer)->create();
+        $plugin->submit();
+        $plugin->refresh();
+        $plugin->withdraw();
+
+        $this->testable($plugin)
+            ->assertSee('Withdrawn')
+            ->assertSee('Submitted')
+            ->assertSee('by you');
+    }
+
+    public function test_message_form_is_hidden_until_the_admins_send_a_message(): void
+    {
+        $plugin = Plugin::factory()->pending()->for($this->developer)->create();
+
+        $this->testable($plugin)
+            ->assertSee('Activity')
+            ->assertDontSee('Send a message to Marketplace admins');
+    }
+
+    public function test_message_form_is_hidden_on_drafts_even_after_an_admin_message(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->draft()->for($this->developer)->create();
+        $plugin->messageDeveloper('Heads up before you submit.', $this->reviewer->id);
+        $plugin->refresh();
+
+        $this->testable($plugin)
+            ->assertSee('Heads up before you submit.')
+            ->assertDontSee('Send a message to Marketplace admins');
+    }
+
+    public function test_draft_plugins_reject_developer_messages(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->draft()->for($this->developer)->create();
+        $plugin->messageDeveloper('Heads up before you submit.', $this->reviewer->id);
+        $plugin->refresh();
+
+        $this->testable($plugin)
+            ->set('replyMessage', 'Can I ask something first?')
+            ->call('sendMessage');
+
+        $this->assertSame(0, $plugin->activities()
+            ->where('type', PluginActivityType::MessageFromDeveloper)
+            ->count());
+
+        Notification::assertSentOnDemandTimes(PluginDeveloperReplied::class, 0);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function messageableStatuses(): array
+    {
+        return [
+            'pending' => ['pending'],
+            'approved' => ['approved'],
+            'rejected' => ['rejected'],
+        ];
+    }
+
+    #[DataProvider('messageableStatuses')]
+    public function test_developer_can_message_admins_on_submitted_plugins(string $state): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->{$state}()->for($this->developer)->create();
+        $plugin->messageDeveloper('A question about your plugin.', $this->reviewer->id);
+        $plugin->refresh();
+
+        $this->testable($plugin)
+            ->assertSee('Send a message to Marketplace admins')
+            ->set('replyMessage', 'Here is my answer.')
+            ->call('sendMessage')
+            ->assertHasNoErrors();
+
+        $this->assertSame(2, $plugin->messages()->count());
+    }
+
+    public function test_tab_query_parameter_opens_the_activity_tab(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        Livewire::actingAs($this->developer)
+            ->withQueryParams(['tab' => 'activity'])
+            ->test(Show::class, [
+                'vendor' => $plugin->routeParams()['vendor'],
+                'package' => $plugin->routeParams()['package'],
+            ])
+            ->assertSet('activeTab', 'activity');
+    }
+
+    public function test_every_activity_type_renders_with_a_badge_and_icon(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->pending()->for($this->developer)->create();
+
+        foreach (PluginActivityType::cases() as $type) {
+            $plugin->activities()->create([
+                'type' => $type,
+                'from_status' => PluginStatus::Draft,
+                'to_status' => PluginStatus::Pending,
+                'note' => "Note for {$type->value}",
+                'causer_id' => $this->reviewer->id,
+            ]);
+        }
+
+        $component = $this->testable($plugin);
+
+        foreach (PluginActivityType::cases() as $type) {
+            $component
+                ->assertSee($type->developerLabel())
+                ->assertSee("Note for {$type->value}");
+        }
+    }
+
+    public function test_details_is_the_default_tab(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        $this->testable($plugin)->assertSet('activeTab', 'details');
+    }
+
+    public function test_developer_can_reply_and_the_team_is_notified(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        Notification::fake();
+
+        $this->testable($plugin)
+            ->set('replyMessage', 'Sure — added in v1.2.0.')
+            ->call('sendMessage')
+            ->assertHasNoErrors()
+            ->assertSet('replyMessage', '');
+
+        $reply = $plugin->messages()->latest('id')->first();
+
+        $this->assertSame(PluginActivityType::MessageFromDeveloper, $reply->type);
+        $this->assertSame('Sure — added in v1.2.0.', $reply->note);
+        $this->assertSame($this->developer->id, $reply->causer_id);
+        $this->assertSame($plugin->status, $reply->to_status);
+
+        Notification::assertSentOnDemand(
+            PluginDeveloperReplied::class,
+            fn (PluginDeveloperReplied $notification, array $channels, object $notifiable) => $notifiable->routes['mail'] === 'support@nativephp.com'
+                && $notification->plugin->is($plugin)
+                && $notification->activity->is($reply)
+        );
+    }
+
+    public function test_reply_appears_in_the_thread_after_sending(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        Notification::fake();
+
+        $this->testable($plugin)
+            ->set('replyMessage', 'Thanks for the review!')
+            ->call('sendMessage')
+            ->assertSee('Thanks for the review!');
+    }
+
+    public function test_reply_is_required(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        Notification::fake();
+
+        $this->testable($plugin)
+            ->set('replyMessage', '')
+            ->call('sendMessage')
+            ->assertHasErrors(['replyMessage' => 'required']);
+
+        $this->assertSame(1, $plugin->messages()->count());
+        Notification::assertNothingSent();
+    }
+
+    public function test_reply_is_rejected_when_there_is_no_conversation(): void
+    {
+        $plugin = Plugin::factory()->pending()->for($this->developer)->create();
+
+        Notification::fake();
+
+        $this->testable($plugin)
+            ->set('replyMessage', 'Hello?')
+            ->call('sendMessage');
+
+        $this->assertSame(0, $plugin->messages()->count());
+        Notification::assertNothingSent();
+    }
+
+    public function test_messages_are_only_visible_to_the_plugin_owner(): void
+    {
+        $plugin = $this->pluginWithMessage('Confidential review note.');
+
+        $intruder = User::factory()->create();
+
+        Livewire::actingAs($intruder)
+            ->test(Show::class, [
+                'vendor' => $plugin->routeParams()['vendor'],
+                'package' => $plugin->routeParams()['package'],
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_replies_are_rate_limited(): void
+    {
+        $plugin = $this->pluginWithMessage();
+
+        Notification::fake();
+
+        $component = $this->testable($plugin);
+
+        for ($i = 0; $i < 10; $i++) {
+            $component->set('replyMessage', "Reply {$i}")->call('sendMessage');
+        }
+
+        $component->set('replyMessage', 'One too many')->call('sendMessage')
+            ->assertHasErrors('replyMessage');
+
+        $this->assertSame(11, $plugin->messages()->count());
+    }
+}


### PR DESCRIPTION
Adds a way for Marketplace admins to have a conversation with a plugin's developer about a specific plugin, independently of approving or rejecting it.

## Admin

- New **Message Developer** button on the plugin edit page, alongside Approve and Reject. Available for every status.
- **View Listing Page** promoted out of the ⋮ submenu to sit next to the other header buttons.
- Messages are recorded as plugin activities, so they appear in the existing Activity History relation manager. The note column is wider and wraps so conversations are readable.

## Developer

- New **Activity** tab on the plugin page showing the full history, newest first, with colour coding: green for approvals, red for rejections, purple for messages from NativePHP, sky for the developer's own replies, and muted zinc for everyday status changes.
- The active tab is tracked in the query string (`?tab=activity`), so refreshing keeps your place.
- A reply box appears above the log — but only for submitted plugins (pending, approved or rejected) **and** only once an admin has messaged first. Developers can't open arbitrary threads about drafts. This is enforced server-side, not just by hiding the form. Replies are rate limited to 10/min.

## Email

- `PluginMessageReceived` (mail + database) tells the developer a message is waiting and deep-links to the Activity tab. **The message body is never included** — they have to sign in to read it. A test asserts the rendered email doesn't contain the message text.
- `PluginDeveloperReplied` notifies `support@nativephp.com` when a developer replies.

## Notes

- No migration — this reuses the existing `plugin_activities` table with two new `PluginActivityType` cases, so messages land in the log for free.
- The blade diff looks large but is mostly mechanical: the plugin page's tab group used to be draft-only and is now universal, so the approved and pending/rejected branches moved one level deeper and were reindented. `git diff -w` shows the substantive change.
- Message bodies render as escaped plain text rather than going through the `CommonMark` helper the support-ticket thread uses, since that's configured with `html_input => 'allow'` plus a Blade preprocessor.

## Testing

415 plugin-related tests pass, including 32 new ones across `PluginMessageDeveloperTest` and `PluginMessagesTest`. Notably `test_every_activity_type_renders_with_a_badge_and_icon` loops every enum case, which is what proves all the badge colours and Flux icon names resolve.

Not visually verified — the preview webview was erroring throughout, so the timeline layout has only been checked at the render-assertion level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)