### PR TITLE
Add Discord Master role for Masterclass purchasers

### DIFF
--- a/app/Http/Controllers/DiscordIntegrationController.php
+++ b/app/Http/Controllers/DiscordIntegrationController.php
@@ -89,6 +89,13 @@ class DiscordIntegrationController extends Controller
                 }
             }
 
+            if ($user->hasPurchasedMasterclass()) {
+                if ($discord->assignMasterRole($discordUser['id'])) {
+                    $user->update(['discord_master_role_granted_at' => now()]);
+                    $rolesAssigned[] = 'Master';
+                }
+            }
+
             if (count($rolesAssigned) > 0) {
                 $roleNames = implode(' and ', $rolesAssigned);
 
@@ -123,6 +130,10 @@ class DiscordIntegrationController extends Controller
             if ($user->discord_early_adopter_role_granted_at) {
                 $discord->removeEarlyAdopterRole($user->discord_id);
             }
+
+            if ($user->discord_master_role_granted_at) {
+                $discord->removeMasterRole($user->discord_id);
+            }
         }
 
         $user->update([
@@ -130,6 +141,7 @@ class DiscordIntegrationController extends Controller
             'discord_username' => null,
             'discord_role_granted_at' => null,
             'discord_early_adopter_role_granted_at' => null,
+            'discord_master_role_granted_at' => null,
         ]);
 
         return back()->with('success', 'Discord account disconnected successfully.');

--- a/app/Livewire/DiscordAccessBanner.php
+++ b/app/Livewire/DiscordAccessBanner.php
@@ -14,6 +14,8 @@ class DiscordAccessBanner extends Component
 
     public bool $hasEarlyAdopterRole = false;
 
+    public bool $hasMasterRole = false;
+
     public bool $isGuildMember = false;
 
     public function mount(bool $inline = false): void
@@ -29,6 +31,7 @@ class DiscordAccessBanner extends Component
         if (! $user || ! $user->discord_id) {
             $this->hasUltraRole = false;
             $this->hasEarlyAdopterRole = false;
+            $this->hasMasterRole = false;
             $this->isGuildMember = false;
 
             return;
@@ -43,12 +46,14 @@ class DiscordAccessBanner extends Component
                 'isGuildMember' => $discord->isGuildMember($user->discord_id),
                 'hasUltraRole' => $discord->hasUltraRole($user->discord_id),
                 'hasEarlyAdopterRole' => $discord->hasEarlyAdopterRole($user->discord_id),
+                'hasMasterRole' => $discord->hasMasterRole($user->discord_id),
             ];
         });
 
         $this->isGuildMember = $status['isGuildMember'];
         $this->hasUltraRole = $status['hasUltraRole'];
         $this->hasEarlyAdopterRole = $status['hasEarlyAdopterRole'];
+        $this->hasMasterRole = $status['hasMasterRole'] ?? false;
 
         if ($this->hasUltraRole && ! $user->discord_role_granted_at) {
             $user->update(['discord_role_granted_at' => now()]);
@@ -56,6 +61,10 @@ class DiscordAccessBanner extends Component
 
         if ($this->hasEarlyAdopterRole && ! $user->discord_early_adopter_role_granted_at) {
             $user->update(['discord_early_adopter_role_granted_at' => now()]);
+        }
+
+        if ($this->hasMasterRole && ! $user->discord_master_role_granted_at) {
+            $user->update(['discord_master_role_granted_at' => now()]);
         }
     }
 
@@ -139,6 +148,42 @@ class DiscordAccessBanner extends Component
             session()->flash('success', 'Early Adopter role assigned successfully!');
         } else {
             session()->flash('error', 'Failed to assign Early Adopter role. Please try again later.');
+        }
+    }
+
+    public function requestMasterRole(): void
+    {
+        $user = auth()->user();
+
+        if (! $user || ! $user->discord_id) {
+            session()->flash('error', 'Please connect your Discord account first.');
+
+            return;
+        }
+
+        if (! $user->hasPurchasedMasterclass()) {
+            session()->flash('error', 'The Master role is for Masterclass students.');
+
+            return;
+        }
+
+        $discord = DiscordApi::make();
+
+        if (! $discord->isGuildMember($user->discord_id)) {
+            session()->flash('error', 'Please join the NativePHP Discord server first.');
+
+            return;
+        }
+
+        $success = $discord->assignMasterRole($user->discord_id);
+
+        if ($success) {
+            $user->update(['discord_master_role_granted_at' => now()]);
+            Cache::forget("discord_role_status_{$user->id}");
+            $this->checkRoleStatus();
+            session()->flash('success', 'Master role assigned successfully!');
+        } else {
+            session()->flash('error', 'Failed to assign Master role. Please try again later.');
         }
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -126,6 +127,19 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
         }
 
         return $this->hasProductAccessViaTeam($product);
+    }
+
+    /**
+     * Check if user has purchased The NativePHP Masterclass.
+     *
+     * Mirrors the direct-ownership check used to gate the course itself, so the
+     * Discord Master role tracks course access rather than team membership.
+     */
+    public function hasPurchasedMasterclass(): bool
+    {
+        return $this->productLicenses()
+            ->whereHas('product', fn (Builder $query) => $query->where('slug', 'nativephp-masterclass'))
+            ->exists();
     }
 
     /**
@@ -579,6 +593,7 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
             'claude_plugins_repo_access_granted_at' => 'datetime',
             'discord_role_granted_at' => 'datetime',
             'discord_early_adopter_role_granted_at' => 'datetime',
+            'discord_master_role_granted_at' => 'datetime',
         ];
     }
 }

--- a/app/Support/DiscordApi.php
+++ b/app/Support/DiscordApi.php
@@ -13,7 +13,8 @@ class DiscordApi
         private ?string $botToken,
         private ?string $guildId,
         private ?string $ultraRoleId,
-        private ?string $earlyAdopterRoleId
+        private ?string $earlyAdopterRoleId,
+        private ?string $masterRoleId = null
     ) {}
 
     public static function make(): static
@@ -22,7 +23,8 @@ class DiscordApi
             config('services.discord.bot_token', ''),
             config('services.discord.guild_id', ''),
             config('services.discord.ultra_role_id', ''),
-            config('services.discord.early_adopter_role_id', '')
+            config('services.discord.early_adopter_role_id', ''),
+            config('services.discord.master_role_id', '')
         );
     }
 
@@ -99,6 +101,21 @@ class DiscordApi
     public function hasEarlyAdopterRole(string $discordUserId): bool
     {
         return $this->hasRole($discordUserId, $this->earlyAdopterRoleId);
+    }
+
+    public function assignMasterRole(string $discordUserId): bool
+    {
+        return $this->assignRole($discordUserId, $this->masterRoleId, 'Master');
+    }
+
+    public function removeMasterRole(string $discordUserId): bool
+    {
+        return $this->removeRole($discordUserId, $this->masterRoleId, 'Master');
+    }
+
+    public function hasMasterRole(string $discordUserId): bool
+    {
+        return $this->hasRole($discordUserId, $this->masterRoleId);
     }
 
     private function assignRole(string $discordUserId, ?string $roleId, string $roleName): bool

--- a/config/services.php
+++ b/config/services.php
@@ -58,6 +58,7 @@ return [
         'guild_id' => env('DISCORD_GUILD_ID'),
         'ultra_role_id' => env('DISCORD_ULTRA_ROLE_ID'),
         'early_adopter_role_id' => env('DISCORD_EARLY_ADOPTER_ROLE_ID'),
+        'master_role_id' => env('DISCORD_MASTER_ROLE_ID'),
     ],
 
     'turnstile' => [

--- a/database/migrations/2026_08_12_211754_add_discord_master_role_granted_at_to_users_table.php
+++ b/database/migrations/2026_08_12_211754_add_discord_master_role_granted_at_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('discord_master_role_granted_at')->nullable()->after('discord_early_adopter_role_granted_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('discord_master_role_granted_at');
+        });
+    }
+};

--- a/resources/views/livewire/customer/integrations.blade.php
+++ b/resources/views/livewire/customer/integrations.blade.php
@@ -29,7 +29,7 @@
         <div class="mt-4 prose dark:prose-invert prose-sm max-w-none">
             <ul class="list-disc list-inside space-y-2">
                 <li><strong>GitHub:</strong> Max license holders can access the private <code>nativephp/mobile</code> repository. Plugin Dev Kit license holders and Ultra subscribers can access <code>nativephp/claude-code</code>.</li>
-                <li><strong>Discord:</strong> Max license holders and Ultra subscribers receive a special "Ultra" role in the NativePHP Discord server. Early Access Program customers receive the "Early Adopter" role.</li>
+                <li><strong>Discord:</strong> Max license holders and Ultra subscribers receive a special "Ultra" role in the NativePHP Discord server. Early Access Program customers receive the "Early Adopter" role. Masterclass students receive the "Master" role, unlocking private channels.</li>
             </ul>
             <p class="mt-4">
                 Need help? Join our <a href="https://discord.gg/nativephp" target="_blank" class="text-blue-600 hover:underline dark:text-blue-400">Discord community</a>.
@@ -117,7 +117,7 @@
             <livewire:git-hub-access-banner :inline="true" />
         @endif
 
-        @if(auth()->user()->hasMaxAccess() || auth()->user()->hasUltraAccess() || auth()->user()->isEapCustomer())
+        @if(auth()->user()->hasMaxAccess() || auth()->user()->hasUltraAccess() || auth()->user()->isEapCustomer() || auth()->user()->hasPurchasedMasterclass())
             <livewire:discord-access-banner :inline="true" />
         @endif
     </div>

--- a/resources/views/livewire/discord-access-banner.blade.php
+++ b/resources/views/livewire/discord-access-banner.blade.php
@@ -43,6 +43,16 @@
                                                 Early Adopter Eligible
                                             </span>
                                         @endif
+
+                                        @if($hasMasterRole)
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                                Master Role Active
+                                            </span>
+                                        @elseif(auth()->user()->hasPurchasedMasterclass())
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                                Master Eligible
+                                            </span>
+                                        @endif
                                     </div>
                                 @endif
                             @else
@@ -74,7 +84,13 @@
                                     <span wire:loading wire:target="requestEarlyAdopterRole">Requesting...</span>
                                 </button>
                             @endif
-                            @if(($hasUltraRole || !(auth()->user()->hasMaxAccess() || auth()->user()->hasUltraAccess())) && ($hasEarlyAdopterRole || !auth()->user()->isEapCustomer()))
+                            @if(!$hasMasterRole && auth()->user()->hasPurchasedMasterclass())
+                                <button wire:click="requestMasterRole" type="button" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    <span wire:loading.remove wire:target="requestMasterRole">Request Master Role</span>
+                                    <span wire:loading wire:target="requestMasterRole">Requesting...</span>
+                                </button>
+                            @endif
+                            @if(($hasUltraRole || !(auth()->user()->hasMaxAccess() || auth()->user()->hasUltraAccess())) && ($hasEarlyAdopterRole || !auth()->user()->isEapCustomer()) && ($hasMasterRole || !auth()->user()->hasPurchasedMasterclass()))
                                 <a href="https://discord.gg/nativephp" target="_blank" rel="noopener noreferrer" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                     Open Discord
                                 </a>

--- a/tests/Feature/DiscordIntegrationTest.php
+++ b/tests/Feature/DiscordIntegrationTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\License;
+use App\Models\Product;
+use App\Models\ProductLicense;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -24,6 +26,7 @@ class DiscordIntegrationTest extends TestCase
             'services.discord.guild_id' => 'test-guild-id',
             'services.discord.ultra_role_id' => 'ultra-role-id',
             'services.discord.early_adopter_role_id' => 'early-adopter-role-id',
+            'services.discord.master_role_id' => 'master-role-id',
         ]);
     }
 
@@ -135,6 +138,119 @@ class DiscordIntegrationTest extends TestCase
 
         $user->refresh();
         $this->assertNull($user->discord_early_adopter_role_granted_at);
+    }
+
+    #[Test]
+    public function integrations_page_shows_discord_banner_for_masterclass_owner(): void
+    {
+        $user = User::factory()->create();
+
+        ProductLicense::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => Product::where('slug', 'nativephp-masterclass')->firstOrFail()->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('customer.integrations'))
+            ->assertOk()
+            ->assertSee('Connect your Discord account to receive your roles.');
+    }
+
+    #[Test]
+    public function integrations_page_hides_discord_banner_for_users_without_roles(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('customer.integrations'))
+            ->assertOk()
+            ->assertDontSee('Connect your Discord account to receive your roles.');
+    }
+
+    #[Test]
+    public function callback_assigns_master_role_for_masterclass_owner(): void
+    {
+        $user = User::factory()->create();
+
+        ProductLicense::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => Product::where('slug', 'nativephp-masterclass')->firstOrFail()->id,
+        ]);
+
+        Http::fake([
+            'discord.com/api/oauth2/token' => Http::response([
+                'access_token' => 'test-access-token',
+            ]),
+            'discord.com/api/v10/users/@me' => Http::response([
+                'id' => '999888777',
+                'username' => 'student',
+            ]),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777' => Http::response([
+                'roles' => [],
+            ], 200),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/master-role-id' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/auth/discord/callback?code=test-code');
+
+        $response->assertRedirect(route('customer.integrations'));
+        $response->assertSessionHas('success');
+
+        $user->refresh();
+        $this->assertEquals('999888777', $user->discord_id);
+        $this->assertNotNull($user->discord_master_role_granted_at);
+    }
+
+    #[Test]
+    public function callback_does_not_assign_master_role_without_the_masterclass(): void
+    {
+        $user = User::factory()->create();
+
+        Http::fake([
+            'discord.com/api/oauth2/token' => Http::response([
+                'access_token' => 'test-access-token',
+            ]),
+            'discord.com/api/v10/users/@me' => Http::response([
+                'id' => '999888777',
+                'username' => 'newuser',
+            ]),
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777' => Http::response([
+                'roles' => [],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get('/auth/discord/callback?code=test-code');
+
+        $response->assertRedirect(route('customer.integrations'));
+
+        $this->assertNull($user->fresh()->discord_master_role_granted_at);
+    }
+
+    #[Test]
+    public function disconnect_removes_master_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '999888777',
+            'discord_username' => 'testuser',
+            'discord_master_role_granted_at' => now(),
+        ]);
+
+        Http::fake([
+            'discord.com/api/v10/guilds/test-guild-id/members/999888777/roles/master-role-id' => Http::response([], 204),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->delete('/dashboard/discord/disconnect');
+
+        $response->assertSessionHas('success', 'Discord account disconnected successfully.');
+
+        $user->refresh();
+        $this->assertNull($user->discord_id);
+        $this->assertNull($user->discord_master_role_granted_at);
+
+        Http::assertSentCount(1);
     }
 
     #[Test]

--- a/tests/Feature/Livewire/DiscordAccessBannerTest.php
+++ b/tests/Feature/Livewire/DiscordAccessBannerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Livewire;
 
 use App\Livewire\DiscordAccessBanner;
 use App\Models\License;
+use App\Models\Product;
+use App\Models\ProductLicense;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -25,6 +27,7 @@ class DiscordAccessBannerTest extends TestCase
             'services.discord.guild_id' => 'test-guild-id',
             'services.discord.ultra_role_id' => 'ultra-role-id',
             'services.discord.early_adopter_role_id' => 'early-adopter-role-id',
+            'services.discord.master_role_id' => 'master-role-id',
         ]);
     }
 
@@ -230,6 +233,140 @@ class DiscordAccessBannerTest extends TestCase
             ->test(DiscordAccessBanner::class)
             ->assertSee('Ultra Role Active')
             ->assertSee('Early Adopter Active');
+    }
+
+    #[Test]
+    public function it_shows_master_role_active_when_user_has_master_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true, roles: ['master-role-id']);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Master Role Active');
+
+        $this->assertNotNull($user->fresh()->discord_master_role_granted_at);
+    }
+
+    #[Test]
+    public function it_shows_master_eligible_for_masterclass_owner_without_role(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->grantMasterclass($user);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Master Eligible');
+    }
+
+    #[Test]
+    public function it_shows_request_master_role_button_for_masterclass_owner(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->grantMasterclass($user);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertSee('Request Master Role');
+    }
+
+    #[Test]
+    public function it_does_not_show_request_master_role_button_without_the_masterclass(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->assertDontSee('Request Master Role')
+            ->assertDontSee('Master Eligible');
+    }
+
+    #[Test]
+    public function it_assigns_master_role_on_request(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->grantMasterclass($user);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestMasterRole')
+            ->assertHasNoErrors();
+
+        $this->assertNotNull($user->fresh()->discord_master_role_granted_at);
+
+        Http::assertSent(fn ($request) => $request->method() === 'PUT'
+            && str_contains($request->url(), '/members/123456789/roles/master-role-id'));
+    }
+
+    #[Test]
+    public function it_does_not_assign_master_role_without_the_masterclass(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->fakeDiscordApi(isGuildMember: true);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestMasterRole');
+
+        $this->assertNull($user->fresh()->discord_master_role_granted_at);
+    }
+
+    #[Test]
+    public function it_does_not_assign_master_role_when_not_guild_member(): void
+    {
+        $user = User::factory()->create([
+            'discord_id' => '123456789',
+            'discord_username' => 'testuser',
+        ]);
+
+        $this->grantMasterclass($user);
+
+        $this->fakeDiscordApi(isGuildMember: false);
+
+        Livewire::actingAs($user)
+            ->test(DiscordAccessBanner::class)
+            ->call('requestMasterRole');
+
+        $this->assertNull($user->fresh()->discord_master_role_granted_at);
+    }
+
+    private function grantMasterclass(User $user): void
+    {
+        ProductLicense::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => Product::where('slug', 'nativephp-masterclass')->firstOrFail()->id,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## What

Masterclass students can now claim a **Master** role in the NativePHP Discord server from the Integrations page, unlocking private channels. This follows the existing Ultra / Early Adopter role pattern end to end.

- `DiscordApi` gains `assignMasterRole()` / `removeMasterRole()` / `hasMasterRole()`.
- New `discord_master_role_granted_at` column on `users`, mirroring the other two role timestamps.
- `User::hasPurchasedMasterclass()` checks for a `ProductLicense` against the `nativephp-masterclass` product.
- `DiscordAccessBanner` folds `$hasMasterRole` into the existing 5-minute cached status call, adds a `requestMasterRole()` action, and backfills the granted-at timestamp when the role is detected on Discord's side.
- The banner renders **Master Eligible** / **Master Role Active** badges and a **Request Master Role** button.
- `DiscordIntegrationController` assigns Master automatically on Discord connect for existing owners, and revokes it on disconnect.

## Why the entitlement check is direct-ownership

`hasPurchasedMasterclass()` deliberately checks the user's own `productLicenses` rather than reusing `hasProductLicense()`, which also grants access via the team owner. The course itself is gated on direct ownership (`Product::isOwnedBy()`), so this keeps the Discord role tracking course access exactly — Ultra team members don't get the Master role, because they can't watch the course either.

## Drive-by fix

The Discord banner's visibility gate on the Integrations page previously only admitted Max / Ultra / EAP customers, so someone who had bought only the Masterclass saw no Discord section at all. Masterclass owners now pass the gate.

## Deployment note

Requires `DISCORD_MASTER_ROLE_ID` to be set in the environment. The `Master` role needs creating in Discord with the relevant private-channel permissions, and the bot's own role must sit **above** Master in the server's role hierarchy or the assign call will 403.

## Not included

Nothing grants the role at *purchase* time — a buyer who already has Discord connected has to visit Integrations and click the button. That matches how the existing roles behave. If we'd rather it be automatic, the hook point is `HandleInvoicePaidJob::createProductLicense()`, alongside the existing GitHub repo-access grant (plus `products:grant` and the Filament comp action).

## Testing

28 tests passing across `DiscordIntegrationTest` and `DiscordAccessBannerTest`, covering the happy path, non-owners, not-in-guild, disconnect revocation, and page-level gating in both directions. 118 related tests (course content, purchase history, teams, Ultra access) still pass. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)