### PR TITLE
Add opt-in email digest for newly approved plugins

### DIFF
--- a/app/Console/Commands/ResendNewPluginNotifications.php
+++ b/app/Console/Commands/ResendNewPluginNotifications.php
@@ -4,7 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\Plugin;
 use App\Models\User;
-use App\Notifications\NewPluginAvailable;
+use App\Notifications\NewPluginsAvailable;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Notification;
 
@@ -14,7 +14,7 @@ class ResendNewPluginNotifications extends Command
         {plugins* : Plugin names (vendor/package) to resend notifications for}
         {--dry-run : Preview what would happen without sending notifications}';
 
-    protected $description = 'Resend NewPluginAvailable notifications to opted-in users for specified plugins';
+    protected $description = 'Email opted-in users a single combined digest for the specified plugins';
 
     public function handle(): int
     {
@@ -57,13 +57,11 @@ class ResendNewPluginNotifications extends Command
             return Command::SUCCESS;
         }
 
-        foreach ($plugins as $plugin) {
-            $pluginRecipients = $recipients->where('id', '!=', $plugin->user_id);
+        Notification::send($recipients, new NewPluginsAvailable($plugins));
 
-            Notification::send($pluginRecipients, new NewPluginAvailable($plugin));
+        $plugins->each->update(['new_plugin_notified_at' => now()]);
 
-            $this->info("Sent NewPluginAvailable for {$plugin->name} to {$pluginRecipients->count()} users.");
-        }
+        $this->info("Sent a single digest covering {$plugins->count()} plugin(s) to {$recipients->count()} users.");
 
         $this->newLine();
         $this->info('Done. All notifications queued.');

--- a/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
+++ b/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Resources\PluginResource\Pages;
 
 use App\Filament\Resources\PluginResource;
+use App\Jobs\SendPendingPluginEmailDigest;
+use App\Models\Plugin;
 use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListPlugins extends ListRecords
@@ -13,6 +16,26 @@ class ListPlugins extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('sendPendingNewPluginNotifications')
+                ->label(fn () => 'Email Subscribers ('.Plugin::query()->pendingNewPluginNotification()->count().')')
+                ->icon('heroicon-o-envelope')
+                ->color('warning')
+                ->visible(fn () => Plugin::query()->pendingNewPluginNotification()->count() > 0)
+                ->requiresConfirmation()
+                ->modalHeading('Email Pending Plugin Notifications')
+                ->modalDescription(fn () => 'This will email every subscribed user a single digest covering the '
+                    .Plugin::query()->pendingNewPluginNotification()->count()
+                    .' plugin(s) approved since the last digest.')
+                ->action(function (): void {
+                    SendPendingPluginEmailDigest::dispatch();
+
+                    Notification::make()
+                        ->title('Digest queued')
+                        ->body('The digest email is being sent to subscribed users.')
+                        ->success()
+                        ->send();
+                }),
+
             Actions\CreateAction::make(),
         ];
     }

--- a/app/Jobs/SendPendingPluginEmailDigest.php
+++ b/app/Jobs/SendPendingPluginEmailDigest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginsAvailable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class SendPendingPluginEmailDigest implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        $plugins = Plugin::query()->pendingNewPluginNotification()->get();
+
+        if ($plugins->isEmpty()) {
+            return;
+        }
+
+        $recipients = User::query()
+            ->whereNotNull('email_verified_at')
+            ->where('receives_new_plugin_notifications', true)
+            ->get();
+
+        foreach ($recipients as $recipient) {
+            $notifiablePlugins = $plugins->reject(fn (Plugin $plugin) => $plugin->user_id === $recipient->id);
+
+            if ($notifiablePlugins->isEmpty()) {
+                continue;
+            }
+
+            $recipient->notify(new NewPluginsAvailable($notifiablePlugins));
+        }
+
+        Plugin::query()
+            ->whereIn('id', $plugins->pluck('id'))
+            ->update(['new_plugin_notified_at' => now()]);
+    }
+}

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -393,6 +393,19 @@ class Plugin extends Model
         return $query->where('featured', true);
     }
 
+    /**
+     * Approved plugins that have not yet been included in an emailed "new plugins" digest.
+     *
+     * @param  Builder<Plugin>  $query
+     * @return Builder<Plugin>
+     */
+    #[Scope]
+    protected function pendingNewPluginNotification(Builder $query): Builder
+    {
+        return $query->where('status', PluginStatus::Approved)
+            ->whereNull('new_plugin_notified_at');
+    }
+
     public function getPackagistUrl(): string
     {
         return "https://packagist.org/packages/{$this->name}";
@@ -814,6 +827,7 @@ class Plugin extends Model
             'type' => PluginType::class,
             'tier' => PluginTier::class,
             'approved_at' => 'datetime',
+            'new_plugin_notified_at' => 'datetime',
             'featured' => 'boolean',
             'is_active' => 'boolean',
             'is_official' => 'boolean',

--- a/app/Notifications/NewPluginsAvailable.php
+++ b/app/Notifications/NewPluginsAvailable.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Http\Controllers\NotificationUnsubscribeController;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class NewPluginsAvailable extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  Collection<int, Plugin>  $plugins
+     */
+    public function __construct(
+        public Collection $plugins
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        if (! $notifiable->receives_new_plugin_notifications) {
+            return [];
+        }
+
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        /** @var User $notifiable */
+        $unsubscribeUrl = NotificationUnsubscribeController::signedUnsubscribeUrl($notifiable);
+
+        $count = $this->plugins->count();
+
+        $mail = (new MailMessage)
+            ->subject($count === 1
+                ? "New Plugin: {$this->plugins->first()->name}"
+                : "{$count} New Plugins on the NativePHP Marketplace")
+            ->greeting($count === 1 ? 'A new plugin is available!' : 'New plugins are available!')
+            ->line($count === 1
+                ? 'The following plugin has just been added to the NativePHP Plugin Marketplace:'
+                : 'The following plugins have just been added to the NativePHP Plugin Marketplace:');
+
+        foreach ($this->plugins as $plugin) {
+            $mail->line('**['.$plugin->name.']('.route('plugins.show', $plugin->routeParams()).')**');
+        }
+
+        return $mail->line('[Unsubscribe from new plugin notifications]('.$unsubscribeUrl.').');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => $this->plugins->count() === 1
+                ? "New Plugin: {$this->plugins->first()->name}"
+                : "{$this->plugins->count()} New Plugins on the NativePHP Marketplace",
+            'plugin_ids' => $this->plugins->pluck('id')->all(),
+            'plugin_names' => $this->plugins->pluck('name')->all(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_21_120000_add_new_plugin_notified_at_to_plugins_table.php
+++ b/database/migrations/2026_08_21_120000_add_new_plugin_notified_at_to_plugins_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->timestamp('new_plugin_notified_at')->nullable()->after('approved_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn('new_plugin_notified_at');
+        });
+    }
+};

--- a/tests/Feature/Filament/SendPendingNewPluginNotificationsActionTest.php
+++ b/tests/Feature/Filament/SendPendingNewPluginNotificationsActionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\PluginResource\Pages\ListPlugins;
+use App\Jobs\SendPendingPluginEmailDigest;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SendPendingNewPluginNotificationsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_action_hidden_when_no_plugins_are_pending(): void
+    {
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertActionHidden('sendPendingNewPluginNotifications');
+    }
+
+    public function test_action_visible_when_plugins_are_pending(): void
+    {
+        Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertActionVisible('sendPendingNewPluginNotifications');
+    }
+
+    public function test_action_dispatches_the_digest_job(): void
+    {
+        Bus::fake([SendPendingPluginEmailDigest::class]);
+
+        Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->callAction('sendPendingNewPluginNotifications')
+            ->assertNotified();
+
+        Bus::assertDispatched(SendPendingPluginEmailDigest::class);
+    }
+}

--- a/tests/Feature/Jobs/SendPendingPluginEmailDigestTest.php
+++ b/tests/Feature/Jobs/SendPendingPluginEmailDigestTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\SendPendingPluginEmailDigest;
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginsAvailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SendPendingPluginEmailDigestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_sends_one_digest_covering_all_pending_plugins(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $optedIn = User::factory()->create(['receives_new_plugin_notifications' => true]);
+
+        $pluginOne = Plugin::factory()->approved()->for($author)->create();
+        $pluginTwo = Plugin::factory()->approved()->for($author)->create();
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertSentTo($optedIn, NewPluginsAvailable::class, function ($notification) use ($pluginOne, $pluginTwo) {
+            return $notification->plugins->pluck('id')->sort()->values()->all()
+                === collect([$pluginOne->id, $pluginTwo->id])->sort()->values()->all();
+        });
+    }
+
+    public function test_job_does_not_notify_opted_out_users(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $optedOut = User::factory()->create(['receives_new_plugin_notifications' => false]);
+        Plugin::factory()->approved()->for($author)->create();
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertNotSentTo($optedOut, NewPluginsAvailable::class);
+    }
+
+    public function test_job_does_not_notify_unverified_users(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $unverified = User::factory()->unverified()->create(['receives_new_plugin_notifications' => true]);
+        Plugin::factory()->approved()->for($author)->create();
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertNotSentTo($unverified, NewPluginsAvailable::class);
+    }
+
+    public function test_job_excludes_a_recipients_own_plugins_from_their_digest(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $otherAuthor = User::factory()->create();
+
+        $ownPlugin = Plugin::factory()->approved()->for($author)->create();
+        $otherPlugin = Plugin::factory()->approved()->for($otherAuthor)->create();
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertSentTo($author, NewPluginsAvailable::class, function ($notification) use ($ownPlugin, $otherPlugin) {
+            return ! $notification->plugins->contains('id', $ownPlugin->id)
+                && $notification->plugins->contains('id', $otherPlugin->id);
+        });
+    }
+
+    public function test_job_skips_a_recipient_entirely_when_all_pending_plugins_are_their_own(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        Plugin::factory()->approved()->for($author)->create();
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertNotSentTo($author, NewPluginsAvailable::class);
+    }
+
+    public function test_job_marks_pending_plugins_as_notified(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $plugin = Plugin::factory()->approved()->for($author)->create();
+
+        $this->assertNull($plugin->new_plugin_notified_at);
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        $this->assertNotNull($plugin->fresh()->new_plugin_notified_at);
+    }
+
+    public function test_job_ignores_plugins_already_notified(): void
+    {
+        Notification::fake();
+
+        $author = User::factory()->create();
+        $recipient = User::factory()->create(['receives_new_plugin_notifications' => true]);
+
+        Plugin::factory()->approved()->for($author)->create([
+            'new_plugin_notified_at' => now()->subDay(),
+        ]);
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertNotSentTo($recipient, NewPluginsAvailable::class);
+    }
+
+    public function test_job_does_nothing_when_no_plugins_are_pending(): void
+    {
+        Notification::fake();
+
+        User::factory()->create(['receives_new_plugin_notifications' => true]);
+
+        (new SendPendingPluginEmailDigest)->handle();
+
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Feature/Notifications/NewPluginsAvailableTest.php
+++ b/tests/Feature/Notifications/NewPluginsAvailableTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Plugin;
+use App\Models\User;
+use App\Notifications\NewPluginsAvailable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class NewPluginsAvailableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_via_returns_empty_array_when_user_opted_out(): void
+    {
+        $user = User::factory()->create(['receives_new_plugin_notifications' => false]);
+        $plugin = Plugin::factory()->create();
+
+        $notification = new NewPluginsAvailable(new Collection([$plugin]));
+
+        $this->assertEmpty($notification->via($user));
+    }
+
+    public function test_via_returns_mail_and_database_when_user_opted_in(): void
+    {
+        $user = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin = Plugin::factory()->create();
+
+        $notification = new NewPluginsAvailable(new Collection([$plugin]));
+
+        $this->assertEquals(['mail', 'database'], $notification->via($user));
+    }
+
+    public function test_mail_subject_names_the_single_plugin_when_only_one(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->create(['name' => 'acme/awesome-plugin']);
+
+        $notification = new NewPluginsAvailable(new Collection([$plugin]));
+        $mail = $notification->toMail($user);
+
+        $this->assertEquals('New Plugin: acme/awesome-plugin', $mail->subject);
+    }
+
+    public function test_mail_subject_uses_a_count_when_multiple_plugins(): void
+    {
+        $user = User::factory()->create();
+        $plugins = Plugin::factory()->count(3)->create();
+
+        $notification = new NewPluginsAvailable($plugins);
+        $mail = $notification->toMail($user);
+
+        $this->assertEquals('3 New Plugins on the NativePHP Marketplace', $mail->subject);
+    }
+
+    public function test_mail_lists_every_plugin(): void
+    {
+        $user = User::factory()->create();
+        $pluginOne = Plugin::factory()->create(['name' => 'acme/one']);
+        $pluginTwo = Plugin::factory()->create(['name' => 'acme/two']);
+
+        $notification = new NewPluginsAvailable(new Collection([$pluginOne, $pluginTwo]));
+        $html = $notification->toMail($user)->render()->toHtml();
+
+        $this->assertStringContainsString('acme/one', $html);
+        $this->assertStringContainsString('acme/two', $html);
+    }
+
+    public function test_mail_links_to_each_plugin_page(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->create(['name' => 'acme/awesome-plugin']);
+
+        $notification = new NewPluginsAvailable(new Collection([$plugin]));
+        $html = $notification->toMail($user)->render()->toHtml();
+
+        $this->assertStringContainsString(
+            route('plugins.show', ['vendor' => 'acme', 'package' => 'awesome-plugin']),
+            $html
+        );
+    }
+
+    public function test_database_notification_contains_all_plugin_ids(): void
+    {
+        $user = User::factory()->create();
+        $pluginOne = Plugin::factory()->create();
+        $pluginTwo = Plugin::factory()->create();
+
+        $notification = new NewPluginsAvailable(new Collection([$pluginOne, $pluginTwo]));
+        $data = $notification->toArray($user);
+
+        $this->assertEquals([$pluginOne->id, $pluginTwo->id], $data['plugin_ids']);
+    }
+
+    public function test_mail_contains_signed_unsubscribe_link(): void
+    {
+        $user = User::factory()->create();
+        $plugin = Plugin::factory()->create();
+
+        $notification = new NewPluginsAvailable(new Collection([$plugin]));
+        $mail = $notification->toMail($user);
+
+        $baseUrl = route('notifications.unsubscribe', ['user' => $user]);
+        $found = collect($mail->introLines)->concat($mail->outroLines)->contains(function ($line) use ($baseUrl) {
+            return str_contains($line, 'Unsubscribe from new plugin notifications')
+                && str_contains($line, $baseUrl);
+        });
+
+        $this->assertTrue($found, 'Mail should contain a signed unsubscribe link.');
+    }
+}

--- a/tests/Feature/ResendNewPluginNotificationsTest.php
+++ b/tests/Feature/ResendNewPluginNotificationsTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Plugin;
 use App\Models\User;
-use App\Notifications\NewPluginAvailable;
+use App\Notifications\NewPluginsAvailable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -27,8 +27,8 @@ class ResendNewPluginNotificationsTest extends TestCase
             'plugins' => [$plugin->name],
         ])->assertSuccessful();
 
-        Notification::assertSentTo($optedIn, NewPluginAvailable::class);
-        Notification::assertNotSentTo($optedOut, NewPluginAvailable::class);
+        Notification::assertSentTo($optedIn, NewPluginsAvailable::class);
+        Notification::assertNotSentTo($optedOut, NewPluginsAvailable::class);
     }
 
     public function test_does_not_send_to_plugin_author(): void
@@ -42,7 +42,7 @@ class ResendNewPluginNotificationsTest extends TestCase
             'plugins' => [$plugin->name],
         ])->assertSuccessful();
 
-        Notification::assertNotSentTo($author, NewPluginAvailable::class);
+        Notification::assertNotSentTo($author, NewPluginsAvailable::class);
     }
 
     public function test_fails_when_plugin_not_found(): void
@@ -76,7 +76,7 @@ class ResendNewPluginNotificationsTest extends TestCase
         Notification::assertNothingSent();
     }
 
-    public function test_handles_multiple_plugins(): void
+    public function test_handles_multiple_plugins_as_a_single_combined_digest(): void
     {
         Notification::fake();
 
@@ -88,7 +88,42 @@ class ResendNewPluginNotificationsTest extends TestCase
             'plugins' => [$plugin1->name, $plugin2->name],
         ])->assertSuccessful();
 
-        Notification::assertSentTo($user, NewPluginAvailable::class, 2);
+        Notification::assertSentTo($user, NewPluginsAvailable::class, 1);
+        Notification::assertSentTo($user, NewPluginsAvailable::class, function ($notification) use ($plugin1, $plugin2) {
+            return $notification->plugins->pluck('id')->sort()->values()->all()
+                === collect([$plugin1->id, $plugin2->id])->sort()->values()->all();
+        });
+    }
+
+    public function test_excludes_all_specified_plugin_authors_from_the_combined_digest(): void
+    {
+        Notification::fake();
+
+        $authorOne = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $authorTwo = User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin1 = Plugin::factory()->approved()->for($authorOne)->create();
+        $plugin2 = Plugin::factory()->approved()->for($authorTwo)->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin1->name, $plugin2->name],
+        ])->assertSuccessful();
+
+        Notification::assertNotSentTo($authorOne, NewPluginsAvailable::class);
+        Notification::assertNotSentTo($authorTwo, NewPluginsAvailable::class);
+    }
+
+    public function test_marks_sent_plugins_as_notified(): void
+    {
+        Notification::fake();
+
+        User::factory()->create(['receives_new_plugin_notifications' => true]);
+        $plugin = Plugin::factory()->approved()->create();
+
+        $this->artisan('plugins:resend-new-plugin-notifications', [
+            'plugins' => [$plugin->name],
+        ])->assertSuccessful();
+
+        $this->assertNotNull($plugin->fresh()->new_plugin_notified_at);
     }
 
     public function test_succeeds_with_no_opted_in_users(): void


### PR DESCRIPTION
## What

Adds an admin-triggered way to email subscribers about newly approved plugins as a single combined digest, instead of one email per plugin.

- New `new_plugin_notified_at` column on `plugins` tracks which approved plugins haven't been included in an email digest yet (`Plugin::pendingNewPluginNotification()` scope).
- New `NewPluginsAvailable` notification (mail + database) that covers one or many plugins in a single message.
- New `SendPendingPluginEmailDigest` job: batches everything pending into one email per subscriber, excluding each recipient's own plugins from their own digest.
- New "Email Subscribers (N)" header action on the admin Plugins list, visible only when there's something pending, that dispatches the job.
- `plugins:resend-new-plugin-notifications` now sends the same batched notification, so resending for named plugins is one combined email instead of one per plugin — signature, validation, and `--dry-run` behaviour are unchanged.

## Why

#476 moved automatic new-plugin announcements to in-app only, so nobody gets emailed on every single approval anymore — which fixed the spam problem, but also removed any way to email people about new plugins at all. That PR's own description flagged this as a follow-up:

> If we want to keep a manual "email people about a batch of new plugins" escape hatch, it needs its own notification class; it can't share this one any more.

This PR is that escape hatch: an admin can review what's piled up (the action label shows the count) and send one email covering everything at once, rather than either spamming per-approval or having no email option at all.

## What this does *not* change

- `Plugin::approve()` — untouched. It still dispatches `SendNewPluginNotifications` for the automatic in-app notification, same as after #476.
- `NewPluginAvailable` / `SendNewPluginNotifications` — untouched. They remain the automatic, in-app-only, per-approval path.
- `PluginApproved` (the author's own "your plugin was approved" email) — untouched.

## Tests

- `tests/Feature/Jobs/SendPendingPluginEmailDigestTest.php` — digest content, opt-out/unverified exclusion, own-plugin exclusion per recipient, marks plugins notified, idempotent on already-notified plugins, no-op when nothing pending.
- `tests/Feature/Notifications/NewPluginsAvailableTest.php` — via(), mail subject/content for one vs many plugins, database payload, unsubscribe link.
- `tests/Feature/Filament/SendPendingNewPluginNotificationsActionTest.php` — action visibility and job dispatch.
- `tests/Feature/ResendNewPluginNotificationsTest.php` — updated for the new notification class; added coverage for the combined-digest behaviour and for marking plugins as notified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)