### PR TITLE
Add status tabs and a column manager to the admin Plugins list

### DIFF
--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -363,11 +363,18 @@ class PluginResource extends Resource
             ])
             ->reorderableColumns()
             ->filters([
-                Tables\Filters\SelectFilter::make('status')
-                    ->options(PluginStatus::class)
-                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'])
-                        ? $query->where('status', $data['value'])
+                Tables\Filters\Filter::make('drafts')
+                    ->schema([
+                        Forms\Components\Checkbox::make('show_drafts')
+                            ->label('Show drafts'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => ($data['show_drafts'] ?? false)
+                        ? $query
                         : $query->where('status', '!=', PluginStatus::Draft)
+                    )
+                    ->indicateUsing(fn (array $data): array => ($data['show_drafts'] ?? false)
+                        ? ['show_drafts' => 'Showing drafts']
+                        : []
                     ),
                 Tables\Filters\SelectFilter::make('type')
                     ->options(PluginType::class),

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -22,6 +22,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\HtmlString;
@@ -259,17 +260,19 @@ class PluginResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\ImageColumn::make('logo_path')
-                    ->label('')
+                    ->label('Logo')
                     ->disk('public')
                     ->circular()
                     ->defaultImageUrl(fn () => 'https://ui-avatars.com/api/?name=P&color=7C3AED&background=EDE9FE')
-                    ->size(40),
+                    ->size(40)
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('name')
                     ->label('Package Name')
                     ->searchable()
                     ->sortable()
-                    ->fontFamily('mono'),
+                    ->fontFamily('mono')
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('type')
                     ->badge()
@@ -277,18 +280,21 @@ class PluginResource extends Resource
                         PluginType::Free => 'gray',
                         PluginType::Paid => 'success',
                     })
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('tier')
                     ->badge()
                     ->color(fn (?PluginTier $state): string => $state?->color() ?? 'gray')
                     ->sortable()
-                    ->placeholder('-'),
+                    ->placeholder('-')
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('user.email')
                     ->label('Submitted By')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
@@ -298,7 +304,8 @@ class PluginResource extends Resource
                         PluginStatus::Approved => 'success',
                         PluginStatus::Rejected => 'danger',
                     })
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('mobile_min_version')
                     ->label('Mobile SDK')
@@ -307,25 +314,30 @@ class PluginResource extends Resource
 
                 Tables\Columns\ToggleColumn::make('is_official')
                     ->label('Official')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\ToggleColumn::make('featured')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\ToggleColumn::make('is_active')
                     ->label('Active')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\ToggleColumn::make('works_in_jump')
                     ->label('Jump')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\IconColumn::make('reviewed_at')
                     ->label('Reviewed')
                     ->boolean()
                     ->getStateUsing(fn (Plugin $record): bool => $record->reviewed_at !== null)
                     ->tooltip(fn (Plugin $record): ?string => $record->reviewed_at?->diffForHumans())
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\IconColumn::make('satis_synced_at')
                     ->label('Satis')
@@ -333,19 +345,23 @@ class PluginResource extends Resource
                     ->getStateUsing(fn (Plugin $record): bool => $record->isSatisSynced())
                     ->tooltip(fn (Plugin $record): ?string => $record->satis_synced_at?->diffForHumans())
                     ->visible(fn (): bool => true)
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('created_at')
                     ->label('Submitted')
                     ->dateTime()
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('approved_at')
                     ->label('Approved')
                     ->dateTime()
                     ->placeholder('-')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(),
             ])
+            ->reorderableColumns()
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
                     ->options(PluginStatus::class)
@@ -507,7 +523,12 @@ class PluginResource extends Resource
             ->bulkActions([
 
             ])
-            ->defaultSort('created_at', 'desc');
+            ->defaultSort(
+                fn (HasTable $livewire): string => ($livewire instanceof Pages\ListPlugins && $livewire->getActiveTabStatus() === PluginStatus::Approved)
+                    ? 'approved_at'
+                    : 'created_at',
+                'desc',
+            );
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
+++ b/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
@@ -2,9 +2,12 @@
 
 namespace App\Filament\Resources\PluginResource\Pages;
 
+use App\Enums\PluginStatus;
 use App\Filament\Resources\PluginResource;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Schemas\Components\Tabs\Tab;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListPlugins extends ListRecords
 {
@@ -15,5 +18,29 @@ class ListPlugins extends ListRecords
         return [
             Actions\CreateAction::make(),
         ];
+    }
+
+    public function getTabs(): array
+    {
+        return [
+            PluginStatus::Pending->value => $this->makeStatusTab(PluginStatus::Pending, 'Pending'),
+            PluginStatus::Approved->value => $this->makeStatusTab(PluginStatus::Approved, 'Approved'),
+            PluginStatus::Rejected->value => $this->makeStatusTab(PluginStatus::Rejected, 'Rejected'),
+            'all' => Tab::make('All'),
+        ];
+    }
+
+    /**
+     * The status the active tab is scoped to, or null when the tab lists every status.
+     */
+    public function getActiveTabStatus(): ?PluginStatus
+    {
+        return PluginStatus::tryFrom($this->activeTab ?? '');
+    }
+
+    private function makeStatusTab(PluginStatus $status, string $label): Tab
+    {
+        return Tab::make($label)
+            ->modifyQueryUsing(fn (Builder $query) => $query->where('status', $status));
     }
 }

--- a/tests/Feature/Filament/GrantPluginToUserActionTest.php
+++ b/tests/Feature/Filament/GrantPluginToUserActionTest.php
@@ -31,6 +31,7 @@ class GrantPluginToUserActionTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
             ->assertTableActionHidden('grantToUser', $plugin);
     }
 
@@ -40,6 +41,7 @@ class GrantPluginToUserActionTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
             ->assertTableActionVisible('grantToUser', $plugin);
     }
 
@@ -68,6 +70,7 @@ class GrantPluginToUserActionTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
             ->callAction(
                 TestAction::make('grantToUser')->table($plugin),
                 data: ['user_id' => $recipient->id],

--- a/tests/Feature/Filament/PluginListDraftFilterTest.php
+++ b/tests/Feature/Filament/PluginListDraftFilterTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Filament;
 
-use App\Enums\PluginStatus;
 use App\Filament\Resources\PluginResource\Pages\ListPlugins;
 use App\Models\Plugin;
 use App\Models\User;
@@ -24,6 +23,18 @@ class PluginListDraftFilterTest extends TestCase
         config(['filament.users' => ['admin@test.com']]);
     }
 
+    public function test_show_drafts_checkbox_renders_and_no_status_filter_remains(): void
+    {
+        Plugin::factory()->pending()->create();
+
+        $component = Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertTableFilterExists('drafts')
+            ->assertSee('Show drafts');
+
+        $this->assertNull($component->instance()->getTable()->getFilter('status'));
+    }
+
     public function test_draft_plugins_are_hidden_by_default(): void
     {
         $draft = Plugin::factory()->draft()->create();
@@ -36,7 +47,7 @@ class PluginListDraftFilterTest extends TestCase
             ->assertCanSeeTableRecords([$approved]);
     }
 
-    public function test_draft_plugins_are_visible_when_filtering_by_draft_status(): void
+    public function test_draft_plugins_are_visible_when_show_drafts_is_checked(): void
     {
         $draft = Plugin::factory()->draft()->create();
         $approved = Plugin::factory()->approved()->create();
@@ -44,8 +55,34 @@ class PluginListDraftFilterTest extends TestCase
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
             ->set('activeTab', 'all')
-            ->filterTable('status', PluginStatus::Draft->value)
+            ->filterTable('drafts', ['show_drafts' => true])
+            ->assertCanSeeTableRecords([$draft, $approved]);
+    }
+
+    public function test_drafts_are_hidden_again_when_show_drafts_is_unchecked(): void
+    {
+        $draft = Plugin::factory()->draft()->create();
+        $approved = Plugin::factory()->approved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'all')
+            ->filterTable('drafts', ['show_drafts' => true])
             ->assertCanSeeTableRecords([$draft])
-            ->assertCanNotSeeTableRecords([$approved]);
+            ->filterTable('drafts', ['show_drafts' => false])
+            ->assertCanNotSeeTableRecords([$draft])
+            ->assertCanSeeTableRecords([$approved]);
+    }
+
+    public function test_show_drafts_does_not_leak_drafts_into_the_status_tabs(): void
+    {
+        $draft = Plugin::factory()->draft()->create();
+        $pending = Plugin::factory()->pending()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->filterTable('drafts', ['show_drafts' => true])
+            ->assertCanSeeTableRecords([$pending])
+            ->assertCanNotSeeTableRecords([$draft]);
     }
 }

--- a/tests/Feature/Filament/PluginListDraftFilterTest.php
+++ b/tests/Feature/Filament/PluginListDraftFilterTest.php
@@ -31,6 +31,7 @@ class PluginListDraftFilterTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'all')
             ->assertCanNotSeeTableRecords([$draft])
             ->assertCanSeeTableRecords([$approved]);
     }
@@ -42,6 +43,7 @@ class PluginListDraftFilterTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'all')
             ->filterTable('status', PluginStatus::Draft->value)
             ->assertCanSeeTableRecords([$draft])
             ->assertCanNotSeeTableRecords([$approved]);

--- a/tests/Feature/Filament/PluginListTabsTest.php
+++ b/tests/Feature/Filament/PluginListTabsTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\PluginResource;
+use App\Filament\Resources\PluginResource\Pages\ListPlugins;
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginListTabsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_pending_is_the_default_tab(): void
+    {
+        $pending = Plugin::factory()->pending()->create();
+        $approved = Plugin::factory()->approved()->create();
+        $rejected = Plugin::factory()->rejected()->create();
+        $draft = Plugin::factory()->draft()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertSet('activeTab', 'pending')
+            ->assertCanSeeTableRecords([$pending])
+            ->assertCanNotSeeTableRecords([$approved, $rejected, $draft]);
+    }
+
+    public function test_tabs_are_ordered_pending_approved_rejected_then_all(): void
+    {
+        $tabs = Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->instance()
+            ->getTabs();
+
+        $this->assertSame(['pending', 'approved', 'rejected', 'all'], array_keys($tabs));
+    }
+
+    public function test_list_page_renders_the_status_tabs(): void
+    {
+        Plugin::factory()->pending()->create();
+
+        $response = $this->actingAs($this->admin)->get(PluginResource::getUrl('index'));
+
+        $response->assertOk();
+        $response->assertSeeInOrder(['Pending', 'Approved', 'Rejected', 'All']);
+    }
+
+    public function test_approved_tab_only_shows_approved_plugins(): void
+    {
+        $pending = Plugin::factory()->pending()->create();
+        $approved = Plugin::factory()->approved()->create();
+        $rejected = Plugin::factory()->rejected()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
+            ->assertCanSeeTableRecords([$approved])
+            ->assertCanNotSeeTableRecords([$pending, $rejected]);
+    }
+
+    public function test_approved_tab_sorts_by_approval_date_in_reverse_chronological_order(): void
+    {
+        $oldest = Plugin::factory()->approved()->create([
+            'created_at' => now()->subDays(30),
+            'approved_at' => now()->subDays(10),
+        ]);
+        $newest = Plugin::factory()->approved()->create([
+            'created_at' => now()->subDays(2),
+            'approved_at' => now()->subDay(),
+        ]);
+        $middle = Plugin::factory()->approved()->create([
+            'created_at' => now()->subDays(20),
+            'approved_at' => now()->subDays(5),
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
+            ->assertCanSeeTableRecords([$newest, $middle, $oldest], inOrder: true);
+    }
+
+    public function test_other_tabs_sort_by_submission_date_in_reverse_chronological_order(): void
+    {
+        $oldest = Plugin::factory()->pending()->create(['created_at' => now()->subDays(10)]);
+        $newest = Plugin::factory()->pending()->create(['created_at' => now()->subDay()]);
+        $middle = Plugin::factory()->pending()->create(['created_at' => now()->subDays(5)]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertCanSeeTableRecords([$newest, $middle, $oldest], inOrder: true);
+    }
+
+    public function test_approved_tab_still_honours_a_column_sort_chosen_by_the_admin(): void
+    {
+        $first = Plugin::factory()->approved()->create([
+            'name' => 'acme/aaa-plugin',
+            'approved_at' => now()->subDay(),
+        ]);
+        $last = Plugin::factory()->approved()->create([
+            'name' => 'acme/zzz-plugin',
+            'approved_at' => now()->subDays(10),
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'approved')
+            ->sortTable('name', 'asc')
+            ->assertCanSeeTableRecords([$first, $last], inOrder: true)
+            ->sortTable('name', 'desc')
+            ->assertCanSeeTableRecords([$last, $first], inOrder: true);
+    }
+
+    public function test_rejected_tab_only_shows_rejected_plugins(): void
+    {
+        $pending = Plugin::factory()->pending()->create();
+        $approved = Plugin::factory()->approved()->create();
+        $rejected = Plugin::factory()->rejected()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'rejected')
+            ->assertCanSeeTableRecords([$rejected])
+            ->assertCanNotSeeTableRecords([$pending, $approved]);
+    }
+
+    public function test_all_tab_shows_every_reviewable_status(): void
+    {
+        $pending = Plugin::factory()->pending()->create();
+        $approved = Plugin::factory()->approved()->create();
+        $rejected = Plugin::factory()->rejected()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->set('activeTab', 'all')
+            ->assertCanSeeTableRecords([$pending, $approved, $rejected]);
+    }
+
+    public function test_hidden_columns_stay_hidden_when_switching_tabs(): void
+    {
+        Plugin::factory()->pending()->create();
+        Plugin::factory()->approved()->create();
+
+        $component = Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertCanRenderTableColumn('featured');
+
+        $component
+            ->call('applyTableColumnManager', $this->hideColumn($component->get('tableColumns'), 'featured'))
+            ->assertCanNotRenderTableColumn('featured')
+            ->set('activeTab', 'approved')
+            ->assertCanNotRenderTableColumn('featured')
+            ->set('activeTab', 'all')
+            ->assertCanNotRenderTableColumn('featured');
+    }
+
+    public function test_hidden_columns_are_remembered_on_a_later_visit(): void
+    {
+        Plugin::factory()->pending()->create();
+
+        $component = Livewire::actingAs($this->admin)->test(ListPlugins::class);
+
+        $component->call('applyTableColumnManager', $this->hideColumn($component->get('tableColumns'), 'featured'));
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPlugins::class)
+            ->assertCanNotRenderTableColumn('featured')
+            ->assertCanRenderTableColumn('name');
+    }
+
+    public function test_column_customisations_can_be_reset(): void
+    {
+        Plugin::factory()->pending()->create();
+
+        $component = Livewire::actingAs($this->admin)->test(ListPlugins::class);
+
+        $component
+            ->call('applyTableColumnManager', $this->hideColumn($component->get('tableColumns'), 'featured'))
+            ->assertCanNotRenderTableColumn('featured')
+            ->call('resetTableColumnManager')
+            ->assertCanRenderTableColumn('featured');
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $columns
+     * @return array<int, array<string, mixed>>
+     */
+    private function hideColumn(array $columns, string $name): array
+    {
+        return array_map(
+            fn (array $column): array => $column['name'] === $name
+                ? [...$column, 'isToggled' => false]
+                : $column,
+            $columns,
+        );
+    }
+}

--- a/tests/Feature/Filament/PluginResourceTest.php
+++ b/tests/Feature/Filament/PluginResourceTest.php
@@ -138,6 +138,7 @@ class PluginResourceTest extends TestCase
 
         Livewire::actingAs($this->admin)
             ->test(ListPlugins::class)
+            ->set('activeTab', 'all')
             ->assertCanRenderTableColumn('approved_at')
             ->sortTable('approved_at', 'desc')
             ->assertCanSeeTableRecords([$newest, $middle, $oldest], inOrder: true)


### PR DESCRIPTION
## What

Brings the admin Plugins list in line with Support Tickets by adding status tabs, makes the table's columns customisable, and replaces the now-redundant status filter with a single "Show drafts" checkbox.

### Tabs

| Tab | Scope |
|---|---|
| **Pending** (default) | `status = pending` |
| **Approved** | `status = approved`, sorted by approval date, newest first |
| **Rejected** | `status = rejected` |
| **All** | unscoped |

Same `getTabs()` shape as `ListSupportTickets`.

The Approved tab's ordering is applied as a tab-aware `defaultSort()` on the resource table rather than an `orderBy()` inside the tab's query scope. Tab scopes are applied *before* sorting, so ordering there would have made `approved_at` the primary sort and silently broken column-header sorting on that tab. As a default sort it stays overridable — there's a test covering that.

### Column manager

Every column is now `toggleable()`, plus `reorderableColumns()` so columns can be dragged into the order you want. Default visibility is unchanged (Mobile SDK stays hidden by default).

Persistence comes free: Filament keys the saved column state on the Livewire component class, and all four tabs are the same component — so hiding or reordering on Pending carries straight over to Approved, Rejected and All, and survives a reload. The column manager's Reset restores defaults.

### "Show drafts" replaces the status filter

With the tabs covering pending/approved/rejected, the status select filter was redundant — and picking a status that contradicted the active tab just produced an empty table. The only thing it still did was gate access to drafts, so it's now a single "Show drafts" checkbox. Default behaviour is unchanged: drafts are hidden until you tick the box.

Implementation note: the checkbox is passed to the filter as a `schema()` rather than using Filament's built-in `isActive` checkbox. A plain `Filter` only applies its `query()` when checked, but we need the opposite — drafts are excluded *unless* the box is ticked. With a schema there's no `isActive` key, so the query callback always runs and reads the checkbox state itself.

## Notes

- The logo column needed a real label (`Logo`) because `reorderableColumns()` rejects blank labels, so that header is now visible where it was previously empty.
- You can no longer isolate drafts on their own — ticking "Show drafts" mixes them into the All tab alongside everything else. The status column is sortable if you want them grouped. Happy to make it a Drafts tab instead if isolating them turns out to matter.

## Tests

New `tests/Feature/Filament/PluginListTabsTest.php` (12 tests): tab order, default tab, per-tab scoping, both sort orders, admin sort still winning on the Approved tab, column state carrying across tabs, surviving a revisit, and resetting. One test does a real HTTP GET of the list page and asserts a 200 with the four tabs rendering in order.

`PluginListDraftFilterTest` reworked for the checkbox (5 tests): the checkbox renders and the status filter is gone, drafts hidden by default, shown when ticked, hidden again when unticked, and not leaking into the status tabs.

Three other existing tests assumed the list page opened unfiltered, so they now set `activeTab` explicitly. 131 Filament tests pass; 456 plugin-related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
