### PR TITLE
Remove The Vibes ad from the docs and blog sidebars

### DIFF
--- a/resources/views/components/blog/ad-rotation.blade.php
+++ b/resources/views/components/blog/ad-rotation.blade.php
@@ -1,4 +1,4 @@
-@props(['ads' => ['mobile', 'desktop', 'bifrost', 'devkit', 'ultra', 'vibes', 'masterclass']])
+@props(['ads' => ['mobile', 'desktop', 'bifrost', 'devkit', 'ultra', 'masterclass']])
 
 @php
     $adsJson = json_encode($ads);
@@ -276,54 +276,6 @@
             />
             <x-icons.star
                 class="absolute bottom-12 right-6 z-10 w-2.5 text-amber-100 animate-pulse "
-            />
-        </a>
-    @endif
-
-    {{-- The Vibes Ad --}}
-    @if (in_array('vibes', $ads))
-        <a
-            x-show="ad === 'vibes'"
-            x-cloak
-            href="{{ route('the-vibes') }}"
-            class="group relative z-0 grid place-items-center overflow-hidden rounded-2xl px-4 py-8 text-center text-pretty transition duration-200 hover:ring-1 hover:ring-violet-400"
-        >
-            {{-- Background image --}}
-            <img
-                src="{{ Vite::asset('resources/images/the-vibes/what-is-vibes.webp') }}"
-                alt=""
-                aria-hidden="true"
-                class="absolute inset-0 -z-10 size-full object-cover blur-[1px] contrast-75 brightness-65"
-                loading="lazy"
-            />
-
-            {{-- Title --}}
-            <div class="z-10 text-lg font-bold text-white drop-shadow">
-                The Vibes
-            </div>
-
-            {{-- Tagline --}}
-            <div class="z-10 mt-2 text-sm text-violet-100 drop-shadow">
-                The unofficial Laracon US
-                <strong class="text-white">Day 3</strong>
-            </div>
-
-            {{-- CTA --}}
-            <div class="z-10 mt-4 rounded-lg bg-white/20 px-4 py-1.5 text-sm font-medium text-white backdrop-blur-sm transition group-hover:bg-white/30">
-                Grab Your Spot
-            </div>
-
-            {{-- Scarcity Label --}}
-            <div class="z-10 mt-2 text-xs text-violet-100 drop-shadow">
-                Only 100 tickets!
-            </div>
-
-            {{-- Decorative stars --}}
-            <x-icons.star
-                class="absolute top-4 right-3 z-10 w-3 -rotate-7 text-violet-300 animate-ping "
-            />
-            <x-icons.star
-                class="absolute top-8 left-4 z-10 w-2 rotate-12 text-indigo-300 animate-spin "
             />
         </a>
     @endif

--- a/resources/views/docs/index.blade.php
+++ b/resources/views/docs/index.blade.php
@@ -47,7 +47,7 @@
 
             {{-- Ad rotation --}}
             <x-blog.ad-rotation
-                :ads="$platform === 'desktop' ? ['mobile', 'bifrost', 'ultra', 'vibes', 'masterclass'] : ['desktop', 'bifrost', 'devkit', 'ultra', 'vibes', 'masterclass']"
+                :ads="$platform === 'desktop' ? ['mobile', 'bifrost', 'ultra', 'masterclass'] : ['desktop', 'bifrost', 'devkit', 'ultra', 'masterclass']"
             />
         </x-docs.toc-and-sponsors>
     </x-slot>
@@ -204,6 +204,6 @@
     {{-- Mobile ad rotation --}}
     <x-blog.ad-rotation
         class="mx-auto mt-5 max-w-52 xl:hidden"
-        :ads="$platform === 'desktop' ? ['mobile', 'bifrost', 'ultra', 'vibes', 'masterclass'] : ['desktop', 'bifrost', 'devkit', 'ultra', 'vibes', 'masterclass']"
+        :ads="$platform === 'desktop' ? ['mobile', 'bifrost', 'ultra', 'masterclass'] : ['desktop', 'bifrost', 'devkit', 'ultra', 'masterclass']"
     />
 </x-docs-layout>


### PR DESCRIPTION
The Vibes has been and gone, so its sidebar ad shouldn't keep rotating in.

## What changed

- `resources/views/components/blog/ad-rotation.blade.php` — dropped `'vibes'` from the default `$ads` prop and deleted the Vibes ad block outright, so it can't render even if something still passes `'vibes'` in.
- `resources/views/docs/index.blade.php` — removed `'vibes'` from both ad lists (the sticky sidebar rotation and the mobile one below the page), across the desktop and mobile platform variants.

The blog sidebar, `blog.blade.php`, and `article.blade.php` all use the default rotation, so the prop change covers them.

## Left alone

The `/the-vibes` page, its route, the partner prospectus, and the `the-vibes-banner` component are all untouched — this is just the sidebar ad. Happy to retire the rest in a follow-up if that's wanted.

`resources/images/the-vibes/what-is-vibes.webp` is no longer referenced by the ad but is still used by the event page, so it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)