### PR TITLE
Modal : Namespace fix for v4

### DIFF
--- a/resources/views/docs/mobile/4/edge-components/modal.md
+++ b/resources/views/docs/mobile/4/edge-components/modal.md
@@ -104,7 +104,7 @@ Programmatically setting `visible` to `false` from PHP does not fire the callbac
 ## Element
 
 ```php
-use Nativephp\NativeUi\Elements\Modal;
+use Native\Mobile\UI\Elements\Modal;
 
 Modal::make()
     ->visible($showDetails)


### PR DESCRIPTION
Modal was using an old namespace