### PR TITLE
docs(mobile/4): skip Node setup for native starter kit

### DIFF
--- a/resources/views/docs/mobile/4/getting-started/quick-start.md
+++ b/resources/views/docs/mobile/4/getting-started/quick-start.md
@@ -16,7 +16,7 @@ Don't waste hours downloading, installing, and configuring Xcode and Android Stu
 If you are creating new Laravel app, you can build using our starter kit:
 
 ```bash
-laravel new my-app --using=nativephp/mobile-starter
+laravel new my-app --using=nativephp/mobile-starter --no-node
 
 cd my-app
 


### PR DESCRIPTION
## Summary

- add `--no-node` to the Mobile v4 starter-kit command

## Why

The NativePHP Mobile starter uses native PHP/EDGE UI and does not ship with a Node or Vite asset pipeline. Laravel's default Node setup can therefore trigger an unnecessary `npm run build` step, which fails because there is no Vite configuration or dependency to build.

Passing `--no-node` creates the starter in the form it is intended to run, giving new users a clean setup path without an irrelevant Node installation step.

## Validation

- `git diff --check`