### PR TITLE
Send /newsletter to the on-site signup modal

### DIFF
--- a/resources/views/components/newsletter-modal.blade.php
+++ b/resources/views/components/newsletter-modal.blade.php
@@ -1,15 +1,23 @@
 {{--
     Newsletter signup modal. Opened from anywhere on the site by dispatching an
     `open-newsletter-modal` window event, so triggers don't have to be nested
-    inside it. The form posts straight to Mailcoach, which then redirects to one
-    of our own `newsletter.*` pages depending on the outcome.
+    inside it. It also opens itself when the page is loaded with `?newsletter` in
+    the URL, which is where the `/newsletter` shortlink sends people. The form
+    posts straight to Mailcoach, which then redirects to one of our own
+    `newsletter.*` pages depending on the outcome.
 --}}
 <div
-    x-data="{ open: false }"
-    @open-newsletter-modal.window="
-        open = true
-        $nextTick(() => $refs.email?.focus())
-    "
+    x-data="{
+        open: false,
+        show() {
+            this.open = true
+            this.$nextTick(() => this.$refs.email?.focus())
+        },
+    }"
+    @if (request()->has('newsletter'))
+        x-init="show()"
+    @endif
+    @open-newsletter-modal.window="show()"
     @keydown.escape.window="open = false"
 >
     {{-- Backdrop --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,7 +62,8 @@ use Laravel\Pennant\Middleware\EnsureFeaturesAreActive;
 |
 */
 
-Route::redirect('newsletter', 'https://simonhamp.mailcoach.app/nativephp');
+// The shortlink lands on the homepage and pops the signup modal open.
+Route::redirect('newsletter', '/?newsletter=1');
 Route::redirect('phpverse-2025', 'https://lp.jetbrains.com/phpverse-2025');
 Route::redirect('docs/1/getting-started/sponsoring', '/sponsor');
 Route::redirect('docs/desktop/1/getting-started/sponsoring', '/sponsor');

--- a/tests/Feature/NewsletterSignupTest.php
+++ b/tests/Feature/NewsletterSignupTest.php
@@ -74,6 +74,29 @@ class NewsletterSignupTest extends TestCase
     }
 
     #[Test]
+    public function the_newsletter_shortlink_sends_people_to_the_homepage_with_the_modal_open()
+    {
+        $this->get('/newsletter')
+            ->assertRedirect('/?newsletter=1');
+    }
+
+    #[Test]
+    public function the_modal_opens_itself_when_the_url_asks_for_it()
+    {
+        $this->get('/?newsletter=1')
+            ->assertOk()
+            ->assertSee('x-init="show()"', escape: false);
+    }
+
+    #[Test]
+    public function the_modal_stays_closed_on_a_normal_page_load()
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertDontSee('x-init="show()"', escape: false);
+    }
+
+    #[Test]
     public function the_confirmation_page_tells_people_to_check_their_inbox()
     {
         $this->get(route('newsletter.confirm'))


### PR DESCRIPTION
## What

`/newsletter` used to redirect straight out to the Mailcoach hosted signup page. It now redirects to the homepage with `?newsletter=1`, and the newsletter modal opens itself when that query string is present.

## Why

The shortlink was the one newsletter entry point that still pushed people off the site onto Mailcoach's own page, bypassing the branded modal added in #490. Keeping people on nativephp.com means they get the same "Get 10% off" framing, and signups land on our own `newsletter.*` confirmation pages.

## How

- `routes/web.php` — `Route::redirect('newsletter', '/?newsletter=1')` (302, as before).
- `resources/views/components/newsletter-modal.blade.php` — the open logic moved into a `show()` method so the `open-newsletter-modal` window event and the URL trigger share one path. `x-init="show()"` is rendered only when the request carries `?newsletter`.

Because the modal lives in the layout, `?newsletter` opens it on any page, not just the homepage. `request()->has()` is forgiving, so `?newsletter`, `?newsletter=1` and anything else all work.

## Testing

Three tests added to `tests/Feature/NewsletterSignupTest.php` covering the redirect target, the modal opening with the query string, and it staying closed without one. All 12 tests in the file pass.

Verified against the live site over HTTP: `/newsletter` → `302 https://…/?newsletter=1`, and `x-init="show()"` renders only with the query string. The browser console shows no Alpine errors. I could not get a screenshot of the modal painted open — the preview screenshot tooling returned no image data in this session — so a quick visual check before merging is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)