### PR TITLE
Mobile v4 docs: drop the beta caveat from the SuperNative overview

### DIFF
--- a/resources/views/docs/mobile/4/architecture/about-the-new-architecture.md
+++ b/resources/views/docs/mobile/4/architecture/about-the-new-architecture.md
@@ -67,8 +67,7 @@ app faster. If your app is happy in the web view, it will keep working exactly a
 
 ## Should you use it today?
 
-SuperNative is **the default**. New apps render native screens from the very first route. It's in beta, so expect
-rapid iteration. If you'd rather wait,
-[opting out](../architecture/super-native#is-the-web-view-still-an-option) is one route and one component.
+SuperNative is **the default**. New apps render native screens from the very first route. If you'd rather keep the
+web view, [opting out](../architecture/super-native#is-the-web-view-still-an-option) is one route and one component.
 
 Ready to go deeper? Start with [The Renderer](renderer).


### PR DESCRIPTION
## Summary

Removes "It's in beta, so expect rapid iteration" from the "Should you use it today?" section of the v4 Architecture overview. v4 is a stable release.

This commit was pushed to #492 about a minute after that PR merged, so it never landed. Same change, new PR.

## Test plan

- [ ] Confirm `/docs/mobile/4/architecture/about-the-new-architecture` no longer mentions beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112bxu7tWLuSwy1NLdV3xwA
