### PR TITLE
Add plugin ratings and admin-only reporting

### DIFF
--- a/app/Enums/PluginReportCategory.php
+++ b/app/Enums/PluginReportCategory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PluginReportCategory: string
+{
+    case MaliciousCode = 'malicious_code';
+    case UnresponsiveAuthor = 'unresponsive_author';
+    case Other = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::MaliciousCode => 'Malicious or Unsafe Code',
+            self::UnresponsiveAuthor => 'Unresponsive Author',
+            self::Other => 'Other',
+        };
+    }
+}

--- a/app/Enums/PluginReportStatus.php
+++ b/app/Enums/PluginReportStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PluginReportStatus: string
+{
+    case Open = 'open';
+    case Resolved = 'resolved';
+    case Dismissed = 'dismissed';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Open => 'Open',
+            self::Resolved => 'Resolved',
+            self::Dismissed => 'Dismissed',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Open => 'danger',
+            self::Resolved => 'success',
+            self::Dismissed => 'gray',
+        };
+    }
+}

--- a/app/Filament/Resources/PluginReportResource.php
+++ b/app/Filament/Resources/PluginReportResource.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\PluginReportCategory;
+use App\Enums\PluginReportStatus;
+use App\Filament\Resources\PluginReportResource\Pages;
+use App\Models\PluginReport;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Infolists;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Schemas;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+
+final class PluginReportResource extends Resource
+{
+    protected static ?string $model = PluginReport::class;
+
+    protected static \BackedEnum|string|null $navigationIcon = 'heroicon-o-flag';
+
+    protected static ?string $navigationLabel = 'Plugin Reports';
+
+    protected static \UnitEnum|string|null $navigationGroup = 'Products';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static ?string $modelLabel = 'Plugin Report';
+
+    protected static ?string $pluralModelLabel = 'Plugin Reports';
+
+    protected static ?string $slug = 'plugin-reports';
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = PluginReport::query()->open()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'danger';
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->schema([]);
+    }
+
+    private static function resolutionActions(): array
+    {
+        return [
+            Actions\Action::make('resolve')
+                ->label('Mark Resolved')
+                ->icon('heroicon-o-check-circle')
+                ->color('success')
+                ->visible(fn (PluginReport $record): bool => $record->isOpen())
+                ->form([
+                    Forms\Components\Textarea::make('resolution_note')
+                        ->label('Resolution Note')
+                        ->helperText('Optional internal note — not visible to the reporter or the plugin author.')
+                        ->rows(3),
+                ])
+                ->action(function (PluginReport $record, array $data): void {
+                    $record->resolve(Auth::user(), $data['resolution_note'] ?: null);
+
+                    Notification::make()
+                        ->title('Report marked resolved')
+                        ->success()
+                        ->send();
+                }),
+
+            Actions\Action::make('dismiss')
+                ->label('Dismiss')
+                ->icon('heroicon-o-x-circle')
+                ->color('gray')
+                ->visible(fn (PluginReport $record): bool => $record->isOpen())
+                ->requiresConfirmation()
+                ->modalDescription('Dismiss this report as not actionable? It will be removed from the open reports count.')
+                ->form([
+                    Forms\Components\Textarea::make('resolution_note')
+                        ->label('Resolution Note')
+                        ->helperText('Optional internal note — not visible to the reporter or the plugin author.')
+                        ->rows(3),
+                ])
+                ->action(function (PluginReport $record, array $data): void {
+                    $record->dismiss(Auth::user(), $data['resolution_note'] ?: null);
+
+                    Notification::make()
+                        ->title('Report dismissed')
+                        ->success()
+                        ->send();
+                }),
+        ];
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->inlineLabel()
+            ->columns(1)
+            ->schema([
+                Schemas\Components\Section::make('Report Details')
+                    ->inlineLabel()
+                    ->columns(1)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('plugin.name')
+                            ->label('Plugin'),
+                        Infolists\Components\TextEntry::make('user.email')
+                            ->label('Reported By')
+                            ->copyable(),
+                        Infolists\Components\TextEntry::make('category')
+                            ->badge()
+                            ->formatStateUsing(fn (PluginReportCategory $state): string => $state->label()),
+                        Infolists\Components\TextEntry::make('status')
+                            ->badge()
+                            ->color(fn (PluginReportStatus $state): string => $state->color())
+                            ->formatStateUsing(fn (PluginReportStatus $state): string => $state->label()),
+                        Infolists\Components\TextEntry::make('message')
+                            ->label('Report Message')
+                            ->columnSpanFull(),
+                        Infolists\Components\TextEntry::make('created_at')
+                            ->label('Filed At')
+                            ->dateTime(),
+                    ]),
+
+                Schemas\Components\Section::make('Resolution')
+                    ->inlineLabel()
+                    ->columns(1)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('resolvedBy.email')
+                            ->label('Resolved By')
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('resolved_at')
+                            ->label('Resolved At')
+                            ->dateTime()
+                            ->placeholder('—'),
+                        Infolists\Components\TextEntry::make('resolution_note')
+                            ->label('Note')
+                            ->placeholder('—')
+                            ->columnSpanFull(),
+                    ])
+                    ->visible(fn (PluginReport $record): bool => ! $record->isOpen()),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('plugin.name')
+                    ->label('Plugin')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('user.email')
+                    ->label('Reported By')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('category')
+                    ->badge()
+                    ->formatStateUsing(fn (PluginReportCategory $state): string => $state->label())
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (PluginReportStatus $state): string => $state->color())
+                    ->formatStateUsing(fn (PluginReportStatus $state): string => $state->label())
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('message')
+                    ->limit(80)
+                    ->wrap()
+                    ->tooltip(fn (PluginReport $record): string => $record->message),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Filed')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(PluginReportStatus::class),
+                Tables\Filters\SelectFilter::make('category')
+                    ->options(PluginReportCategory::class),
+            ])
+            ->actions([
+                Actions\ViewAction::make(),
+                ...self::resolutionActions(),
+            ])
+            ->bulkActions([])
+            ->defaultSort('created_at', 'desc')
+            ->recordUrl(
+                fn ($record) => self::getUrl('view', ['record' => $record])
+            );
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPluginReports::route('/'),
+            'view' => Pages\ViewPluginReport::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PluginReportResource/Pages/ListPluginReports.php
+++ b/app/Filament/Resources/PluginReportResource/Pages/ListPluginReports.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PluginReportResource\Pages;
+
+use App\Filament\Resources\PluginReportResource;
+use Filament\Resources\Pages\ListRecords;
+
+final class ListPluginReports extends ListRecords
+{
+    protected static string $resource = PluginReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/PluginReportResource/Pages/ViewPluginReport.php
+++ b/app/Filament/Resources/PluginReportResource/Pages/ViewPluginReport.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PluginReportResource\Pages;
+
+use App\Filament\Resources\PluginReportResource;
+use App\Models\PluginReport;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Auth;
+
+final class ViewPluginReport extends ViewRecord
+{
+    protected static string $resource = PluginReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('resolve')
+                ->label('Mark Resolved')
+                ->icon('heroicon-o-check-circle')
+                ->color('success')
+                ->visible(fn (): bool => $this->record instanceof PluginReport && $this->record->isOpen())
+                ->form([
+                    Forms\Components\Textarea::make('resolution_note')
+                        ->label('Resolution Note')
+                        ->helperText('Optional internal note — not visible to the reporter or the plugin author.')
+                        ->rows(3),
+                ])
+                ->action(function (array $data): void {
+                    /** @var PluginReport $report */
+                    $report = $this->record;
+                    $report->resolve(Auth::user(), $data['resolution_note'] ?: null);
+
+                    Notification::make()
+                        ->title('Report marked resolved')
+                        ->success()
+                        ->send();
+
+                    $this->refreshFormData(['status']);
+                }),
+
+            Actions\Action::make('dismiss')
+                ->label('Dismiss')
+                ->icon('heroicon-o-x-circle')
+                ->color('gray')
+                ->visible(fn (): bool => $this->record instanceof PluginReport && $this->record->isOpen())
+                ->requiresConfirmation()
+                ->modalDescription('Dismiss this report as not actionable? It will be removed from the open reports count.')
+                ->form([
+                    Forms\Components\Textarea::make('resolution_note')
+                        ->label('Resolution Note')
+                        ->helperText('Optional internal note — not visible to the reporter or the plugin author.')
+                        ->rows(3),
+                ])
+                ->action(function (array $data): void {
+                    /** @var PluginReport $report */
+                    $report = $this->record;
+                    $report->dismiss(Auth::user(), $data['resolution_note'] ?: null);
+
+                    Notification::make()
+                        ->title('Report dismissed')
+                        ->success()
+                        ->send();
+
+                    $this->refreshFormData(['status']);
+                }),
+        ];
+    }
+}

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -258,6 +258,9 @@ class PluginResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->withCount([
+                'reports as open_reports_count' => fn (Builder $query): Builder => $query->open(),
+            ]))
             ->columns([
                 Tables\Columns\ImageColumn::make('logo_path')
                     ->label('Logo')
@@ -306,6 +309,12 @@ class PluginResource extends Resource
                     })
                     ->sortable()
                     ->toggleable(),
+
+                Tables\Columns\TextColumn::make('open_reports_count')
+                    ->label('Reports')
+                    ->badge()
+                    ->color(fn (int $state): string => $state > 0 ? 'danger' : 'gray')
+                    ->sortable(),
 
                 Tables\Columns\TextColumn::make('mobile_min_version')
                     ->label('Mobile SDK')
@@ -544,6 +553,7 @@ class PluginResource extends Resource
             RelationManagers\PricesRelationManager::class,
             RelationManagers\LicensesRelationManager::class,
             RelationManagers\ActivitiesRelationManager::class,
+            RelationManagers\RatingsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/PluginResource/RelationManagers/RatingsRelationManager.php
+++ b/app/Filament/Resources/PluginResource/RelationManagers/RatingsRelationManager.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PluginResource\RelationManagers;
+
+use Filament\Actions;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+final class RatingsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'ratings';
+
+    protected static ?string $title = 'Ratings';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('rating')
+                    ->label('Stars')
+                    ->formatStateUsing(fn (int $state): string => str_repeat('★', $state).str_repeat('☆', 5 - $state))
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('user.email')
+                    ->label('User')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Rated')
+                    ->dateTime()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Last Changed')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->headerActions([])
+            ->actions([
+                Actions\DeleteAction::make()
+                    ->label('Remove')
+                    ->modalHeading('Remove Rating')
+                    ->modalDescription('This will delete the rating and recalculate the plugin\'s average. Use this to moderate abusive or fake ratings.'),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->paginated([10, 25, 50]);
+    }
+}

--- a/app/Http/Controllers/Auth/CustomerAuthController.php
+++ b/app/Http/Controllers/Auth/CustomerAuthController.php
@@ -23,8 +23,10 @@ class CustomerAuthController extends Controller
 {
     public function __construct(protected CartService $cartService) {}
 
-    public function showLogin(): View
+    public function showLogin(Request $request): View
     {
+        $this->rememberIntendedUrl($request);
+
         return view('auth.login');
     }
 
@@ -170,6 +172,27 @@ class CustomerAuthController extends Controller
         return $status === PasswordBroker::PASSWORD_RESET
             ? to_route('customer.login')->with('status', __($status))
             : back()->withErrors(['email' => [__($status)]]);
+    }
+
+    /**
+     * Remember where the user was headed, so login sends them back there.
+     *
+     * Only same-site paths are accepted; anything else is ignored so the
+     * `redirect` parameter can't be used as an open redirect.
+     */
+    private function rememberIntendedUrl(Request $request): void
+    {
+        $redirect = $request->query('redirect');
+
+        if (! is_string($redirect) || ! str_starts_with($redirect, '/')) {
+            return;
+        }
+
+        if (str_starts_with($redirect, '//') || str_starts_with($redirect, '/\\')) {
+            return;
+        }
+
+        session(['url.intended' => url($redirect)]);
     }
 
     private function acceptPendingTeamInvitation(User $user): void

--- a/app/Http/Controllers/PluginRatingController.php
+++ b/app/Http/Controllers/PluginRatingController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StorePluginRatingRequest;
+use App\Models\Plugin;
+use App\Models\PluginRating;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class PluginRatingController extends Controller
+{
+    public function store(StorePluginRatingRequest $request, string $vendor, string $package): RedirectResponse
+    {
+        $plugin = Plugin::findByVendorPackageOrFail($vendor, $package);
+
+        $this->authorize('create', [PluginRating::class, $plugin]);
+
+        PluginRating::submit($plugin, $request->user(), (int) $request->validated('rating'));
+
+        return back()->with('success', 'Thanks for rating this plugin!');
+    }
+
+    public function destroy(Request $request, string $vendor, string $package): RedirectResponse
+    {
+        $plugin = Plugin::findByVendorPackageOrFail($vendor, $package);
+        $rating = PluginRating::findFor($plugin, $request->user());
+
+        abort_if(! $rating, 404);
+
+        $this->authorize('delete', $rating);
+
+        $rating->delete();
+
+        return back()->with('success', 'Your rating has been removed.');
+    }
+}

--- a/app/Http/Controllers/PluginReportController.php
+++ b/app/Http/Controllers/PluginReportController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\PluginReportCategory;
+use App\Http\Requests\StorePluginReportRequest;
+use App\Models\Plugin;
+use App\Models\PluginReport;
+use Illuminate\Http\RedirectResponse;
+
+final class PluginReportController extends Controller
+{
+    public function store(StorePluginReportRequest $request, string $vendor, string $package): RedirectResponse
+    {
+        $plugin = Plugin::findByVendorPackageOrFail($vendor, $package);
+
+        $this->authorize('create', [PluginReport::class, $plugin]);
+
+        $user = $request->user();
+
+        if (PluginReport::hasOpenFor($plugin, $user)) {
+            return back()->with('error', 'You already have an open report for this plugin — our team will follow up soon.');
+        }
+
+        PluginReport::file(
+            $plugin,
+            $user,
+            PluginReportCategory::from($request->validated('category')),
+            $request->validated('message')
+        );
+
+        return back()->with('success', 'Thanks — your report has been sent to the NativePHP team.');
+    }
+}

--- a/app/Http/Requests/StorePluginRatingRequest.php
+++ b/app/Http/Requests/StorePluginRatingRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class StorePluginRatingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'rating' => ['required', 'integer', 'between:1,5'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'rating.required' => 'Please select a star rating.',
+            'rating.between' => 'Ratings must be between 1 and 5 stars.',
+        ];
+    }
+}

--- a/app/Http/Requests/StorePluginReportRequest.php
+++ b/app/Http/Requests/StorePluginReportRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\PluginReportCategory;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class StorePluginReportRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'category' => ['required', Rule::enum(PluginReportCategory::class)],
+            'message' => ['required', 'string', 'max:5000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'category.required' => 'Please select a reason for this report.',
+            'message.required' => 'Please describe the issue.',
+            'message.max' => 'The message cannot be longer than 5000 characters.',
+        ];
+    }
+}

--- a/app/Livewire/Customer/Plugins/Show.php
+++ b/app/Livewire/Customer/Plugins/Show.php
@@ -204,7 +204,7 @@ class Show extends Component
         // Notify
         $user->notify(new PluginSubmitted($this->plugin));
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new PluginPendingReview($this->plugin));
 
         Flux::toast(variant: 'success', text: 'Your plugin has been submitted for review!');

--- a/app/Livewire/Customer/Support/Create.php
+++ b/app/Livewire/Customer/Support/Create.php
@@ -164,7 +164,7 @@ class Create extends Component
             $ticket->update(['attachments' => $attachments]);
         }
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new SupportTicketSubmitted($ticket));
 
         $this->redirect(route('customer.support.tickets.show', $ticket), navigate: false);

--- a/app/Livewire/Customer/Support/Show.php
+++ b/app/Livewire/Customer/Support/Show.php
@@ -81,7 +81,7 @@ class Show extends Component
             'attachments' => $attachments,
         ]);
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new SupportTicketUserReplied($this->supportTicket, $reply));
 
         $this->replyMessage = '';

--- a/app/Livewire/ShowcaseSubmissionForm.php
+++ b/app/Livewire/ShowcaseSubmissionForm.php
@@ -169,7 +169,7 @@ class ShowcaseSubmissionForm extends Component
                     'approved_by' => null,
                 ]);
 
-                Notification::route('mail', 'support@nativephp.com')
+                Notification::route('mail', config('mail.support_address'))
                     ->notify(new ShowcaseSubmitted($this->showcase, resubmitted: true));
 
                 return to_route('customer.showcase.index')
@@ -185,7 +185,7 @@ class ShowcaseSubmissionForm extends Component
             ...$data,
         ]);
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new ShowcaseSubmitted($showcase));
 
         return to_route('customer.showcase.index')

--- a/app/Livewire/WallOfLoveSubmissionForm.php
+++ b/app/Livewire/WallOfLoveSubmissionForm.php
@@ -103,7 +103,7 @@ class WallOfLoveSubmissionForm extends Component
             'testimonial' => $this->testimonial ?: null,
         ]);
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new WallOfLoveSubmitted($submission));
 
         return to_route('dashboard')->with('success', 'Thank you! Your submission has been received and is awaiting review.');

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -242,6 +242,22 @@ class Plugin extends Model
     }
 
     /**
+     * @return HasMany<PluginRating>
+     */
+    public function ratings(): HasMany
+    {
+        return $this->hasMany(PluginRating::class);
+    }
+
+    /**
+     * @return HasMany<PluginReport>
+     */
+    public function reports(): HasMany
+    {
+        return $this->hasMany(PluginReport::class);
+    }
+
+    /**
      * @return BelongsToMany<PluginBundle>
      */
     public function bundles(): BelongsToMany
@@ -677,6 +693,21 @@ class Plugin extends Model
         ];
     }
 
+    public function getIssuesUrl(): ?string
+    {
+        if (! $this->repository_url || ! str_contains($this->repository_url, 'github.com')) {
+            return null;
+        }
+
+        $repoInfo = $this->getRepositoryOwnerAndName();
+
+        if (! $repoInfo) {
+            return null;
+        }
+
+        return "https://github.com/{$repoInfo['owner']}/{$repoInfo['repo']}/issues";
+    }
+
     public function approve(int $approvedById): void
     {
         $previousStatus = $this->status;
@@ -854,10 +885,18 @@ class Plugin extends Model
             'causer_id' => $causerId ?? $this->user_id,
         ]);
 
-        Notification::route('mail', 'support@nativephp.com')
+        Notification::route('mail', config('mail.support_address'))
             ->notify(new PluginDeveloperReplied($this, $activity));
 
         return $activity;
+    }
+
+    public function recalculateRating(): void
+    {
+        $this->update([
+            'rating_count' => $this->ratings()->count(),
+            'rating_average' => $this->ratings()->avg('rating'),
+        ]);
     }
 
     public function updateDescription(string $description, int $updatedById): void
@@ -911,6 +950,8 @@ class Plugin extends Model
             'webhook_installed' => 'boolean',
             'review_checks' => 'array',
             'reviewed_at' => 'datetime',
+            'rating_average' => 'decimal:2',
+            'rating_count' => 'integer',
         ];
     }
 }

--- a/app/Models/PluginRating.php
+++ b/app/Models/PluginRating.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class PluginRating extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        self::saved(function (PluginRating $rating): void {
+            $rating->plugin->recalculateRating();
+        });
+
+        self::deleted(function (PluginRating $rating): void {
+            $rating->plugin->recalculateRating();
+        });
+    }
+
+    public static function findFor(Plugin $plugin, User $user): ?self
+    {
+        return self::query()
+            ->where('plugin_id', $plugin->id)
+            ->where('user_id', $user->id)
+            ->first();
+    }
+
+    public static function submit(Plugin $plugin, User $user, int $rating): self
+    {
+        return self::query()->updateOrCreate(
+            ['plugin_id' => $plugin->id, 'user_id' => $user->id],
+            ['rating' => $rating]
+        );
+    }
+
+    /**
+     * @return BelongsTo<Plugin, PluginRating>
+     */
+    public function plugin(): BelongsTo
+    {
+        return $this->belongsTo(Plugin::class);
+    }
+
+    /**
+     * @return BelongsTo<User, PluginRating>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'rating' => 'integer',
+        ];
+    }
+}

--- a/app/Models/PluginReport.php
+++ b/app/Models/PluginReport.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\PluginReportCategory;
+use App\Enums\PluginReportStatus;
+use App\Notifications\PluginReported;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Notification;
+
+final class PluginReport extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    /**
+     * @param  Builder<PluginReport>  $query
+     * @return Builder<PluginReport>
+     */
+    #[Scope]
+    protected function open(Builder $query): Builder
+    {
+        return $query->where('status', PluginReportStatus::Open);
+    }
+
+    public static function hasOpenFor(Plugin $plugin, User $user): bool
+    {
+        return self::query()
+            ->where('plugin_id', $plugin->id)
+            ->where('user_id', $user->id)
+            ->open()
+            ->exists();
+    }
+
+    public static function file(Plugin $plugin, User $user, PluginReportCategory $category, string $message): self
+    {
+        $report = self::query()->create([
+            'plugin_id' => $plugin->id,
+            'user_id' => $user->id,
+            'category' => $category,
+            'message' => $message,
+            'status' => PluginReportStatus::Open,
+        ]);
+
+        Notification::route('mail', config('mail.support_address'))
+            ->notify(new PluginReported($report));
+
+        return $report;
+    }
+
+    /**
+     * @return BelongsTo<Plugin, PluginReport>
+     */
+    public function plugin(): BelongsTo
+    {
+        return $this->belongsTo(Plugin::class);
+    }
+
+    /**
+     * @return BelongsTo<User, PluginReport>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<User, PluginReport>
+     */
+    public function resolvedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'resolved_by');
+    }
+
+    public function isOpen(): bool
+    {
+        return $this->status === PluginReportStatus::Open;
+    }
+
+    public function resolve(User $admin, ?string $note = null): void
+    {
+        $this->update([
+            'status' => PluginReportStatus::Resolved,
+            'resolution_note' => $note,
+            'resolved_by' => $admin->id,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    public function dismiss(User $admin, ?string $note = null): void
+    {
+        $this->update([
+            'status' => PluginReportStatus::Dismissed,
+            'resolution_note' => $note,
+            'resolved_by' => $admin->id,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'category' => PluginReportCategory::class,
+            'status' => PluginReportStatus::class,
+            'resolved_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -476,6 +476,16 @@ class User extends Authenticatable implements FilamentUser, HasName, MustVerifyE
         return false;
     }
 
+    public function canRatePlugin(Plugin $plugin): bool
+    {
+        return $plugin->user_id !== $this->id && $this->hasPluginAccess($plugin);
+    }
+
+    public function canReportPlugin(Plugin $plugin): bool
+    {
+        return $plugin->user_id !== $this->id;
+    }
+
     public function getGitHubToken(): ?string
     {
         if (! $this->github_token) {

--- a/app/Notifications/PluginReported.php
+++ b/app/Notifications/PluginReported.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Filament\Resources\PluginReportResource;
+use App\Models\PluginReport;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+
+final class PluginReported extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public PluginReport $report
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $report = $this->report->loadMissing(['plugin', 'user']);
+
+        return (new MailMessage)
+            ->subject('Plugin Reported: '.$report->plugin->name)
+            ->greeting('A plugin has been reported.')
+            ->line("**Plugin:** {$report->plugin->name}")
+            ->line('**Reported by:** '.$report->user->email)
+            ->line('**Reason:** '.$report->category->label())
+            ->line('**Message:**')
+            ->line(Str::limit($report->message, 500))
+            ->action('Review Report', PluginReportResource::getUrl('view', ['record' => $report]));
+    }
+}

--- a/app/Policies/PluginRatingPolicy.php
+++ b/app/Policies/PluginRatingPolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Plugin;
+use App\Models\PluginRating;
+use App\Models\User;
+
+final class PluginRatingPolicy
+{
+    public function create(User $user, Plugin $plugin): bool
+    {
+        return $user->canRatePlugin($plugin);
+    }
+
+    public function update(User $user, PluginRating $pluginRating): bool
+    {
+        return $user->id === $pluginRating->user_id;
+    }
+
+    public function delete(User $user, PluginRating $pluginRating): bool
+    {
+        return $user->id === $pluginRating->user_id || $user->isAdmin();
+    }
+}

--- a/app/Policies/PluginReportPolicy.php
+++ b/app/Policies/PluginReportPolicy.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Plugin;
+use App\Models\PluginReport;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+final class PluginReportPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function view(User $user, PluginReport $pluginReport): Response
+    {
+        return $user->isAdmin()
+            ? Response::allow()
+            : Response::denyAsNotFound('Report not found.');
+    }
+
+    public function create(User $user, Plugin $plugin): bool
+    {
+        return $user->canReportPlugin($plugin);
+    }
+}

--- a/config/mail.php
+++ b/config/mail.php
@@ -105,6 +105,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Support Address
+    |--------------------------------------------------------------------------
+    |
+    | The mailbox that admin-facing notifications (support tickets, plugin
+    | messages, plugin reports, showcase/wall-of-love submissions, etc.) are
+    | routed to via Notification::route('mail', ...).
+    |
+    */
+
+    'support_address' => env('MAIL_SUPPORT_ADDRESS', 'support@nativephp.com'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Markdown Mail Settings
     |--------------------------------------------------------------------------
     |

--- a/database/factories/PluginRatingFactory.php
+++ b/database/factories/PluginRatingFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Plugin;
+use App\Models\PluginRating;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PluginRating>
+ */
+class PluginRatingFactory extends Factory
+{
+    protected $model = PluginRating::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'plugin_id' => Plugin::factory(),
+            'user_id' => User::factory(),
+            'rating' => $this->faker->numberBetween(1, 5),
+        ];
+    }
+}

--- a/database/factories/PluginReportFactory.php
+++ b/database/factories/PluginReportFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PluginReportCategory;
+use App\Enums\PluginReportStatus;
+use App\Models\Plugin;
+use App\Models\PluginReport;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PluginReport>
+ */
+class PluginReportFactory extends Factory
+{
+    protected $model = PluginReport::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'plugin_id' => Plugin::factory(),
+            'user_id' => User::factory(),
+            'category' => $this->faker->randomElement(PluginReportCategory::cases()),
+            'message' => $this->faker->paragraph(),
+            'status' => PluginReportStatus::Open,
+        ];
+    }
+
+    public function resolved(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PluginReportStatus::Resolved,
+            'resolved_at' => now(),
+            'resolved_by' => User::factory(),
+        ]);
+    }
+
+    public function dismissed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PluginReportStatus::Dismissed,
+            'resolved_at' => now(),
+            'resolved_by' => User::factory(),
+        ]);
+    }
+}

--- a/database/migrations/2026_09_04_120000_create_plugin_ratings_table.php
+++ b/database/migrations/2026_09_04_120000_create_plugin_ratings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plugin_ratings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('plugin_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('rating');
+            $table->timestamps();
+
+            $table->unique(['plugin_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('plugin_ratings');
+    }
+};

--- a/database/migrations/2026_09_04_120001_add_rating_average_and_rating_count_to_plugins_table.php
+++ b/database/migrations/2026_09_04_120001_add_rating_average_and_rating_count_to_plugins_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->decimal('rating_average', 3, 2)->nullable()->after('works_in_jump');
+            $table->unsignedInteger('rating_count')->default(0)->after('rating_average');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table) {
+            $table->dropColumn(['rating_average', 'rating_count']);
+        });
+    }
+};

--- a/database/migrations/2026_09_04_120002_create_plugin_reports_table.php
+++ b/database/migrations/2026_09_04_120002_create_plugin_reports_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plugin_reports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('plugin_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('category');
+            $table->text('message');
+            $table->string('status')->default('open');
+            $table->text('resolution_note')->nullable();
+            $table->foreignId('resolved_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('resolved_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['plugin_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('plugin_reports');
+    }
+};

--- a/resources/views/components/plugin-card.blade.php
+++ b/resources/views/components/plugin-card.blade.php
@@ -61,10 +61,23 @@
         @endif
     </div>
 
-    <div class="mt-4 flex items-center gap-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400">
-        View details
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-        </svg>
+    <div class="mt-4 flex items-center justify-between gap-3">
+        <span class="flex items-center gap-1.5 text-sm font-medium text-indigo-600 dark:text-indigo-400">
+            View details
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+            </svg>
+        </span>
+
+        @if ($plugin->rating_count > 0)
+            <span
+                class="inline-flex items-center gap-1 text-xs"
+                title="{{ number_format($plugin->rating_average, 1) }} out of 5 stars from {{ $plugin->rating_count }} {{ Str::plural('rating', $plugin->rating_count) }}"
+            >
+                <x-heroicon-s-star class="size-3.5 text-amber-400" aria-hidden="true" />
+                <span class="font-medium text-gray-900 dark:text-white">{{ number_format($plugin->rating_average, 1) }}</span>
+                <span class="text-gray-500 dark:text-gray-400">({{ $plugin->rating_count }})</span>
+            </span>
+        @endif
     </div>
 </a>

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -95,8 +95,22 @@
                             {{ $plugin->description }}
                         </p>
                     @endif
-                    @if ($plugin->worksInJump())
-                        <div class="mt-3">
+                    <div class="mt-3 flex flex-wrap items-center gap-3">
+                        @if ($plugin->rating_count > 0)
+                            <span class="inline-flex items-center gap-1 text-sm" title="{{ number_format($plugin->rating_average, 1) }} out of 5 stars">
+                                <span class="flex text-amber-400" aria-hidden="true">
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        <x-heroicon-s-star class="size-4 {{ $i > round($plugin->rating_average) ? 'text-gray-300 dark:text-gray-600' : '' }}" />
+                                    @endfor
+                                </span>
+                                <span class="font-medium text-gray-900 dark:text-white">{{ number_format($plugin->rating_average, 1) }}</span>
+                                <span class="text-gray-500 dark:text-gray-400">({{ $plugin->rating_count }} {{ Str::plural('rating', $plugin->rating_count) }})</span>
+                            </span>
+                        @else
+                            <span class="text-sm text-gray-500 dark:text-gray-400">No ratings yet</span>
+                        @endif
+
+                        @if ($plugin->worksInJump())
                             <span
                                 class="inline-flex items-center gap-1.5 rounded-full bg-indigo-100 px-3 py-1 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
                                 title="This plugin runs in the Jump preview app without a native build"
@@ -104,14 +118,27 @@
                                 <x-heroicon-o-bolt class="size-3.5" aria-hidden="true" />
                                 Works in Jump
                             </span>
-                        </div>
-                    @endif
+                        @endif
+                    </div>
                 </div>
             </div>
         </header>
 
         {{-- Divider --}}
         <x-divider />
+
+        {{-- Session Messages --}}
+        @if (session('error'))
+            <div class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+                <p class="text-sm text-red-800 dark:text-red-200">{{ session('error') }}</p>
+            </div>
+        @endif
+
+        @if (session('success'))
+            <div class="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+                <p class="text-sm text-green-800 dark:text-green-200">{{ session('success') }}</p>
+            </div>
+        @endif
 
         <div class="mt-2 flex flex-col-reverse gap-8 lg:flex-row lg:items-start">
                 {{-- Main content - README --}}
@@ -572,6 +599,155 @@
                                 </li>
                             @endforeach
                         </ul>
+                    </div>
+                @endif
+
+                {{-- Rate this plugin --}}
+                @auth
+                    @if (auth()->user()->canRatePlugin($plugin))
+                        @php $myRating = \App\Models\PluginRating::findFor($plugin, auth()->user()); @endphp
+                        <div
+                            x-data="{ hover: 0, selected: {{ $myRating?->rating ?? 0 }} }"
+                            class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50"
+                        >
+                            <h2 class="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                {{ $myRating ? 'Your Rating' : 'Rate this Plugin' }}
+                            </h2>
+                            <form method="POST" action="{{ route('plugins.rating.store', $plugin->routeParams()) }}" class="mt-3">
+                                @csrf
+                                <input type="hidden" name="rating" x-model="selected" />
+                                <div class="flex items-center gap-1" x-on:mouseleave="hover = 0">
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        <button
+                                            type="submit"
+                                            x-on:mouseenter="hover = {{ $i }}"
+                                            x-on:click="selected = {{ $i }}"
+                                            class="p-0.5"
+                                            aria-label="Rate {{ $i }} out of 5 stars"
+                                        >
+                                            <x-heroicon-s-star
+                                                class="size-7 transition"
+                                                x-bind:class="(hover || selected) >= {{ $i }} ? 'text-amber-400' : 'text-gray-300 dark:text-gray-600'"
+                                            />
+                                        </button>
+                                    @endfor
+                                </div>
+                                @error('rating')
+                                    <p class="mt-2 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+                                @enderror
+                            </form>
+                            @if ($myRating)
+                                <form method="POST" action="{{ route('plugins.rating.destroy', $plugin->routeParams()) }}" class="mt-3">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-xs font-medium text-gray-500 underline hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+                                        Remove my rating
+                                    </button>
+                                </form>
+                            @endif
+                        </div>
+                    @endif
+                @else
+                    <div class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 text-center dark:border-gray-700 dark:bg-slate-800/50">
+                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                            <a href="{{ route('customer.login') }}" class="font-medium text-indigo-600 underline hover:text-indigo-700 dark:text-indigo-400">Log in</a>
+                            to rate this plugin.
+                        </p>
+                    </div>
+                @endauth
+
+                {{-- Report this plugin --}}
+                @if (auth()->check() && auth()->user()->canReportPlugin($plugin))
+                    <div
+                        x-data="{ open: {{ $errors->has('category') || $errors->has('message') ? 'true' : 'false' }} }"
+                        class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50"
+                    >
+                        <button
+                            type="button"
+                            x-on:click="open = !open"
+                            :aria-expanded="open"
+                            title="Not for bugs — for reporting malicious code or an unresponsive author"
+                            class="flex w-full items-center justify-between gap-2 text-left"
+                        >
+                            <span class="inline-flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400">
+                                <x-heroicon-o-flag class="size-4 shrink-0" aria-hidden="true" />
+                                Report this plugin
+                            </span>
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke-width="2"
+                                stroke="currentColor"
+                                class="size-4 shrink-0 text-gray-400 transition-transform duration-200"
+                                :class="{ 'rotate-180': open }"
+                                aria-hidden="true"
+                            >
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                            </svg>
+                        </button>
+
+                        <div x-show="open" x-collapse x-cloak class="mt-4 space-y-4">
+                            <div class="rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/30">
+                                <p class="text-xs text-amber-800 dark:text-amber-300">
+                                    This isn't for bugs or support requests &mdash; it's only for reporting a plugin that's
+                                    <strong>malicious</strong> or whose author is <strong>unresponsive</strong> to the NativePHP team.
+                                </p>
+                                @if ($plugin->getIssuesUrl())
+                                    <p class="mt-2 text-xs text-amber-800 dark:text-amber-300">
+                                        Found a bug instead?
+                                        <a href="{{ $plugin->getIssuesUrl() }}" target="_blank" class="font-medium underline hover:no-underline">
+                                            Report it on GitHub &rarr;
+                                        </a>
+                                    </p>
+                                @elseif ($plugin->support_channel)
+                                    <p class="mt-2 text-xs text-amber-800 dark:text-amber-300">
+                                        Found a bug instead? Use the Support link above to contact the plugin's author.
+                                    </p>
+                                @endif
+                            </div>
+
+                            <form method="POST" action="{{ route('plugins.report.store', $plugin->routeParams()) }}" class="space-y-3">
+                                @csrf
+                                <div>
+                                    <label for="report-category" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Reason</label>
+                                    <select
+                                        id="report-category"
+                                        name="category"
+                                        required
+                                        class="mt-1 block w-full rounded-lg border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-slate-900 dark:text-white"
+                                    >
+                                        @foreach (\App\Enums\PluginReportCategory::cases() as $category)
+                                            <option value="{{ $category->value }}" @selected(old('category') === $category->value)>{{ $category->label() }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('category')
+                                        <p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+                                <div>
+                                    <label for="report-message" class="block text-xs font-medium text-gray-700 dark:text-gray-300">Details</label>
+                                    <textarea
+                                        id="report-message"
+                                        name="message"
+                                        rows="3"
+                                        required
+                                        maxlength="5000"
+                                        placeholder="What's going on?"
+                                        class="mt-1 block w-full rounded-lg border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-slate-900 dark:text-white"
+                                    >{{ old('message') }}</textarea>
+                                    @error('message')
+                                        <p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+                                <button
+                                    type="submit"
+                                    class="w-full rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                                >
+                                    Send Report to NativePHP
+                                </button>
+                            </form>
+                        </div>
                     </div>
                 @endif
 

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -106,8 +106,6 @@
                                 <span class="font-medium text-gray-900 dark:text-white">{{ number_format($plugin->rating_average, 1) }}</span>
                                 <span class="text-gray-500 dark:text-gray-400">({{ $plugin->rating_count }} {{ Str::plural('rating', $plugin->rating_count) }})</span>
                             </span>
-                        @else
-                            <span class="text-sm text-gray-500 dark:text-gray-400">No ratings yet</span>
                         @endif
 
                         @if ($plugin->worksInJump())
@@ -650,7 +648,7 @@
                 @else
                     <div class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 text-center dark:border-gray-700 dark:bg-slate-800/50">
                         <p class="text-sm text-gray-600 dark:text-gray-400">
-                            <a href="{{ route('customer.login') }}" class="font-medium text-indigo-600 underline hover:text-indigo-700 dark:text-indigo-400">Log in</a>
+                            <a href="{{ route('customer.login', ['redirect' => route('plugins.show', $plugin->routeParams(), false)]) }}" class="font-medium text-indigo-600 underline hover:text-indigo-700 dark:text-indigo-400">Log in</a>
                             to rate this plugin.
                         </p>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ use App\Http\Controllers\LicenseRenewalController;
 use App\Http\Controllers\NotificationUnsubscribeController;
 use App\Http\Controllers\OpenCollectiveWebhookController;
 use App\Http\Controllers\PluginDirectoryController;
+use App\Http\Controllers\PluginRatingController;
+use App\Http\Controllers\PluginReportController;
 use App\Http\Controllers\PluginWebhookController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ShowBlogController;
@@ -243,6 +245,12 @@ Route::middleware(EnsureFeaturesAreActive::using(ShowPlugins::class))->group(fun
     Route::get('plugins/marketplace', PluginDirectory::class)->name('plugins.marketplace');
     Route::get('plugins/{vendor}/{package}', [PluginDirectoryController::class, 'show'])->name('plugins.show');
     Route::get('plugins/{vendor}/{package}/license', [PluginDirectoryController::class, 'license'])->name('plugins.license');
+
+    Route::middleware('auth')->group(function (): void {
+        Route::post('plugins/{vendor}/{package}/rating', [PluginRatingController::class, 'store'])->name('plugins.rating.store');
+        Route::delete('plugins/{vendor}/{package}/rating', [PluginRatingController::class, 'destroy'])->name('plugins.rating.destroy');
+        Route::post('plugins/{vendor}/{package}/report', [PluginReportController::class, 'store'])->name('plugins.report.store');
+    });
 });
 
 Route::view('sponsor', 'sponsoring')->name('sponsoring');

--- a/tests/Feature/Filament/PluginRatingsRelationManagerTest.php
+++ b/tests/Feature/Filament/PluginRatingsRelationManagerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\PluginResource\Pages\EditPlugin;
+use App\Filament\Resources\PluginResource\RelationManagers\RatingsRelationManager;
+use App\Models\Plugin;
+use App\Models\PluginRating;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginRatingsRelationManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private Plugin $plugin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $this->plugin = Plugin::factory()->approved()->free()->create();
+    }
+
+    public function test_it_lists_ratings_for_the_plugin(): void
+    {
+        PluginRating::submit($this->plugin, User::factory()->create(['email' => 'rater@example.com']), 5);
+
+        Livewire::actingAs($this->admin)
+            ->test(RatingsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->assertSuccessful()
+            ->assertSee('rater@example.com')
+            ->assertCountTableRecords(1);
+    }
+
+    public function test_admin_can_delete_an_abusive_rating_and_the_average_recalculates(): void
+    {
+        PluginRating::submit($this->plugin, User::factory()->create(), 5);
+        $rating = PluginRating::submit($this->plugin, User::factory()->create(), 1);
+
+        $this->plugin->refresh();
+        $this->assertEquals(3.00, $this->plugin->rating_average);
+
+        Livewire::actingAs($this->admin)
+            ->test(RatingsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->callTableAction('delete', $rating);
+
+        $this->assertDatabaseMissing('plugin_ratings', ['id' => $rating->id]);
+
+        $this->plugin->refresh();
+        $this->assertEquals(5.00, $this->plugin->rating_average);
+        $this->assertEquals(1, $this->plugin->rating_count);
+    }
+
+    public function test_it_shows_zero_ratings_for_a_plugin_with_none(): void
+    {
+        Livewire::actingAs($this->admin)
+            ->test(RatingsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->assertCountTableRecords(0);
+    }
+}

--- a/tests/Feature/Filament/PluginReportResourceTest.php
+++ b/tests/Feature/Filament/PluginReportResourceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\PluginReportCategory;
+use App\Enums\PluginReportStatus;
+use App\Filament\Resources\PluginReportResource;
+use App\Filament\Resources\PluginReportResource\Pages\ListPluginReports;
+use App\Filament\Resources\PluginReportResource\Pages\ViewPluginReport;
+use App\Models\Plugin;
+use App\Models\PluginReport;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginReportResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+    }
+
+    public function test_list_page_renders_successfully(): void
+    {
+        PluginReport::factory()->count(3)->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginReports::class)
+            ->assertSuccessful();
+    }
+
+    public function test_list_page_shows_plugin_and_reporter(): void
+    {
+        $plugin = Plugin::factory()->create(['name' => 'acme/super-plugin']);
+        $reporter = User::factory()->create(['email' => 'reporter@example.com']);
+
+        PluginReport::factory()->create([
+            'plugin_id' => $plugin->id,
+            'user_id' => $reporter->id,
+            'category' => PluginReportCategory::MaliciousCode,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginReports::class)
+            ->assertSuccessful()
+            ->assertSee('acme/super-plugin')
+            ->assertSee('reporter@example.com');
+    }
+
+    public function test_non_admin_cannot_view_any_reports(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertFalse($user->can('viewAny', PluginReport::class));
+    }
+
+    public function test_view_page_renders_successfully(): void
+    {
+        $report = PluginReport::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ViewPluginReport::class, ['record' => $report->getRouteKey()])
+            ->assertSuccessful();
+    }
+
+    public function test_resolve_action_marks_the_report_resolved(): void
+    {
+        $report = PluginReport::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginReports::class)
+            ->callTableAction('resolve', $report, data: [
+                'resolution_note' => 'Investigated, plugin is fine.',
+            ]);
+
+        $report->refresh();
+        $this->assertEquals(PluginReportStatus::Resolved, $report->status);
+        $this->assertEquals($this->admin->id, $report->resolved_by);
+        $this->assertNotNull($report->resolved_at);
+        $this->assertEquals('Investigated, plugin is fine.', $report->resolution_note);
+    }
+
+    public function test_dismiss_action_marks_the_report_dismissed(): void
+    {
+        $report = PluginReport::factory()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginReports::class)
+            ->callTableAction('dismiss', $report, data: [
+                'resolution_note' => 'Not actionable.',
+            ]);
+
+        $report->refresh();
+        $this->assertEquals(PluginReportStatus::Dismissed, $report->status);
+    }
+
+    public function test_resolve_action_is_hidden_for_already_resolved_reports(): void
+    {
+        $report = PluginReport::factory()->resolved()->create();
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginReports::class)
+            ->assertTableActionHidden('resolve', $report);
+    }
+
+    public function test_navigation_badge_counts_only_open_reports(): void
+    {
+        PluginReport::factory()->count(2)->create();
+        PluginReport::factory()->resolved()->create();
+
+        $this->assertEquals('2', PluginReportResource::getNavigationBadge());
+    }
+}

--- a/tests/Feature/PluginRatingTest.php
+++ b/tests/Feature/PluginRatingTest.php
@@ -3,12 +3,14 @@
 namespace Tests\Feature;
 
 use App\Features\ShowPlugins;
+use App\Livewire\PluginDirectory;
 use App\Models\Plugin;
 use App\Models\PluginLicense;
 use App\Models\PluginRating;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Pennant\Feature;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class PluginRatingTest extends TestCase
@@ -160,5 +162,99 @@ class PluginRatingTest extends TestCase
         $plugin->refresh();
         $this->assertEquals(4.00, $plugin->rating_average);
         $this->assertEquals(2, $plugin->rating_count);
+    }
+
+    public function test_plugin_page_says_nothing_about_ratings_until_there_is_one(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertOk()
+            ->assertDontSee('No ratings yet')
+            ->assertDontSee('out of 5 stars');
+    }
+
+    public function test_plugin_page_shows_the_average_once_the_plugin_has_a_rating(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        PluginRating::submit($plugin, User::factory()->create(), 4);
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertOk()
+            ->assertSee('4.0')
+            ->assertSee('(1 rating)');
+    }
+
+    public function test_plugin_card_shows_the_rating_when_the_plugin_has_one(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        PluginRating::submit($plugin, User::factory()->create(), 5);
+        PluginRating::submit($plugin, User::factory()->create(), 4);
+
+        Livewire::test(PluginDirectory::class)
+            ->assertSee('4.5')
+            ->assertSee('4.5 out of 5 stars from 2 ratings');
+    }
+
+    public function test_plugin_card_hides_the_rating_when_the_plugin_has_none(): void
+    {
+        Plugin::factory()->approved()->free()->create();
+
+        Livewire::test(PluginDirectory::class)
+            ->assertDontSee('out of 5 stars');
+    }
+
+    public function test_login_link_on_the_plugin_page_carries_the_plugin_page_as_the_destination(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        $this->get(route('plugins.show', $plugin->routeParams()))
+            ->assertOk()
+            ->assertSee(route('customer.login', [
+                'redirect' => route('plugins.show', $plugin->routeParams(), false),
+            ]));
+    }
+
+    public function test_user_is_returned_to_the_plugin_page_after_logging_in_to_rate_it(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+        $user = User::factory()->create();
+
+        $this->get(route('customer.login', [
+            'redirect' => route('plugins.show', $plugin->routeParams(), false),
+        ]))->assertOk();
+
+        $this->post(route('customer.login'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('plugins.show', $plugin->routeParams()));
+    }
+
+    public function test_login_redirect_ignores_a_destination_outside_the_site(): void
+    {
+        $user = User::factory()->create();
+
+        $this->get(route('customer.login', ['redirect' => 'https://evil.example.com/phish']))
+            ->assertOk();
+
+        $this->post(route('customer.login'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('dashboard'));
+    }
+
+    public function test_login_redirect_ignores_a_protocol_relative_destination(): void
+    {
+        $user = User::factory()->create();
+
+        $this->get(route('customer.login', ['redirect' => '//evil.example.com/phish']))
+            ->assertOk();
+
+        $this->post(route('customer.login'), [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertRedirect(route('dashboard'));
     }
 }

--- a/tests/Feature/PluginRatingTest.php
+++ b/tests/Feature/PluginRatingTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginLicense;
+use App\Models\PluginRating;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginRatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_guest_is_redirected_to_login_when_rating(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        $response = $this->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 5,
+        ]);
+
+        $response->assertRedirect(route('customer.login'));
+        $this->assertDatabaseCount('plugin_ratings', 0);
+    }
+
+    public function test_logged_in_user_can_rate_a_free_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 4,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('plugin_ratings', [
+            'plugin_id' => $plugin->id,
+            'user_id' => $user->id,
+            'rating' => 4,
+        ]);
+
+        $plugin->refresh();
+        $this->assertEquals(4.00, $plugin->rating_average);
+        $this->assertEquals(1, $plugin->rating_count);
+    }
+
+    public function test_user_cannot_rate_their_own_plugin(): void
+    {
+        $owner = User::factory()->create();
+        $plugin = Plugin::factory()->approved()->free()->for($owner)->create();
+
+        $response = $this->actingAs($owner)->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 5,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('plugin_ratings', 0);
+    }
+
+    public function test_user_without_a_license_cannot_rate_a_paid_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 5,
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('plugin_ratings', 0);
+    }
+
+    public function test_user_with_a_license_can_rate_a_paid_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->paid()->create();
+        $user = User::factory()->create();
+
+        PluginLicense::factory()->for($user)->for($plugin)->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 3,
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('plugin_ratings', [
+            'plugin_id' => $plugin->id,
+            'user_id' => $user->id,
+            'rating' => 3,
+        ]);
+    }
+
+    public function test_rating_again_updates_the_existing_rating_instead_of_creating_a_new_one(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), ['rating' => 2]);
+        $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), ['rating' => 5]);
+
+        $this->assertDatabaseCount('plugin_ratings', 1);
+        $this->assertDatabaseHas('plugin_ratings', [
+            'plugin_id' => $plugin->id,
+            'user_id' => $user->id,
+            'rating' => 5,
+        ]);
+
+        $plugin->refresh();
+        $this->assertEquals(5.00, $plugin->rating_average);
+        $this->assertEquals(1, $plugin->rating_count);
+    }
+
+    public function test_rating_is_rejected_outside_the_1_to_5_range(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), [
+            'rating' => 6,
+        ]);
+
+        $response->assertSessionHasErrors('rating');
+        $this->assertDatabaseCount('plugin_ratings', 0);
+    }
+
+    public function test_user_can_remove_their_own_rating(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('plugins.rating.store', $plugin->routeParams()), ['rating' => 4]);
+
+        $response = $this->actingAs($user)->delete(route('plugins.rating.destroy', $plugin->routeParams()));
+
+        $response->assertRedirect();
+        $this->assertDatabaseCount('plugin_ratings', 0);
+
+        $plugin->refresh();
+        $this->assertNull($plugin->rating_average);
+        $this->assertEquals(0, $plugin->rating_count);
+    }
+
+    public function test_average_rating_recalculates_across_multiple_users(): void
+    {
+        $plugin = Plugin::factory()->approved()->free()->create();
+
+        PluginRating::submit($plugin, User::factory()->create(), 5);
+        PluginRating::submit($plugin, User::factory()->create(), 3);
+
+        $plugin->refresh();
+        $this->assertEquals(4.00, $plugin->rating_average);
+        $this->assertEquals(2, $plugin->rating_count);
+    }
+}

--- a/tests/Feature/PluginReportTest.php
+++ b/tests/Feature/PluginReportTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PluginReportCategory;
+use App\Enums\PluginReportStatus;
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginReport;
+use App\Models\User;
+use App\Notifications\PluginReported;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_guest_is_redirected_to_login_when_reporting(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        $response = $this->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => PluginReportCategory::MaliciousCode->value,
+            'message' => 'This plugin exfiltrates data.',
+        ]);
+
+        $response->assertRedirect(route('customer.login'));
+        $this->assertDatabaseCount('plugin_reports', 0);
+    }
+
+    public function test_logged_in_user_can_report_a_plugin_and_admins_are_notified(): void
+    {
+        Notification::fake();
+
+        $plugin = Plugin::factory()->approved()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => PluginReportCategory::UnresponsiveAuthor->value,
+            'message' => "I've messaged the author for weeks with no response.",
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('plugin_reports', [
+            'plugin_id' => $plugin->id,
+            'user_id' => $user->id,
+            'category' => PluginReportCategory::UnresponsiveAuthor->value,
+            'status' => PluginReportStatus::Open->value,
+        ]);
+
+        Notification::assertSentOnDemand(
+            PluginReported::class,
+            fn (PluginReported $notification, array $channels, object $notifiable): bool => $notifiable->routes['mail'] === config('mail.support_address')
+                && $notification->report->plugin->is($plugin)
+        );
+    }
+
+    public function test_user_cannot_report_their_own_plugin(): void
+    {
+        $owner = User::factory()->create();
+        $plugin = Plugin::factory()->approved()->for($owner)->create();
+
+        $response = $this->actingAs($owner)->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => PluginReportCategory::Other->value,
+            'message' => 'Testing self-report.',
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('plugin_reports', 0);
+    }
+
+    public function test_report_requires_a_valid_category_and_message(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => 'not-a-real-category',
+            'message' => '',
+        ]);
+
+        $response->assertSessionHasErrors(['category', 'message']);
+        $this->assertDatabaseCount('plugin_reports', 0);
+    }
+
+    public function test_user_cannot_file_a_second_open_report_for_the_same_plugin(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+        $user = User::factory()->create();
+
+        PluginReport::file($plugin, $user, PluginReportCategory::MaliciousCode, 'First report.');
+
+        $response = $this->actingAs($user)->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => PluginReportCategory::MaliciousCode->value,
+            'message' => 'Second report while the first is still open.',
+        ]);
+
+        $response->assertSessionHas('error');
+        $this->assertDatabaseCount('plugin_reports', 1);
+    }
+
+    public function test_user_can_file_a_new_report_once_their_previous_one_is_resolved(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+        $user = User::factory()->create();
+        $admin = User::factory()->create();
+
+        $firstReport = PluginReport::file($plugin, $user, PluginReportCategory::MaliciousCode, 'First report.');
+        $firstReport->resolve($admin);
+
+        $response = $this->actingAs($user)->post(route('plugins.report.store', $plugin->routeParams()), [
+            'category' => PluginReportCategory::MaliciousCode->value,
+            'message' => 'Second report after the first was resolved.',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseCount('plugin_reports', 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Logged-in users can leave a 1–5 star rating on a plugin they own or have access to (free plugins: any logged-in user; paid: requires a license/access, reusing `User::hasPluginAccess()`) — one rating per user, editable, removable.
- Logged-in users can report a plugin as malicious or its author as unresponsive — a private, admin-only channel, distinct from the existing developer support/messaging flow. One open report per user per plugin; a new one can be filed once the prior one is resolved or dismissed.
- Admins get a `Plugin Reports` resource (Filament) with resolve/dismiss actions, a nav badge for open reports, and an open-reports column on the Plugins list. Ratings can be moderated (deleted) from a new relation manager on the Plugin resource.
- The public plugin page shows the star average/count, a rating widget, and a collapsible "Report this plugin" panel that's explicitly not for bugs — it links out to the plugin's GitHub Issues (or its support channel) first, before showing the report form.
- Notification support address (`support@nativephp.com`) is pulled into `config('mail.support_address')` instead of being hardcoded in 7 different places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)