### PR TITLE
Add admin companies page and new-domain signup alerts

### DIFF
--- a/app/Filament/Pages/Companies.php
+++ b/app/Filament/Pages/Companies.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Resources\UserResource;
+use App\Services\CompanyAggregator;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\EmbeddedTable;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class Companies extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static \BackedEnum|string|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    protected static ?string $navigationLabel = 'Companies';
+
+    protected static ?string $title = 'Companies';
+
+    protected static ?int $navigationSort = 2;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->records(function (
+                ?string $search,
+                ?string $sortColumn,
+                ?string $sortDirection,
+                int $page,
+                int $recordsPerPage,
+            ): LengthAwarePaginator {
+                $records = app(CompanyAggregator::class)->aggregate();
+
+                $records = $records
+                    ->when(
+                        filled($search),
+                        fn (Collection $data): Collection => $data->filter(
+                            fn (array $record): bool => str_contains(
+                                Str::lower($record['domain']),
+                                Str::lower($search),
+                            ),
+                        ),
+                    );
+
+                if (filled($sortColumn)) {
+                    $records = $records->sortBy(
+                        $sortColumn,
+                        SORT_REGULAR,
+                        ($sortDirection ?? 'desc') === 'desc',
+                    );
+                } else {
+                    $records = $records->sortByDesc('users_count');
+                }
+
+                $records = $records->values();
+                $total = $records->count();
+
+                $pageItems = $records
+                    ->forPage($page, $recordsPerPage)
+                    ->mapWithKeys(fn (array $record): array => [$record['domain'] => $record]);
+
+                return new LengthAwarePaginator(
+                    items: $pageItems,
+                    total: $total,
+                    perPage: $recordsPerPage,
+                    currentPage: $page,
+                );
+            })
+            ->columns([
+                TextColumn::make('domain')
+                    ->label('Domain')
+                    ->sortable()
+                    ->copyable(),
+                TextColumn::make('users_count')
+                    ->label('Users')
+                    ->sortable()
+                    ->numeric(),
+                TextColumn::make('earliest_signup')
+                    ->label('Earliest signup')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('latest_signup')
+                    ->label('Latest signup')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('users_count', 'desc')
+            ->searchable()
+            ->actions([
+                Action::make('viewUsers')
+                    ->label('Users')
+                    ->icon('heroicon-o-users')
+                    ->color('gray')
+                    ->url(fn (array $record): string => UserResource::getUrl('index', [
+                        'tableSearch' => $record['domain'],
+                    ])),
+            ])
+            ->paginated([10, 25, 50, 100]);
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                EmbeddedTable::make(),
+            ]);
+    }
+}

--- a/app/Listeners/NotifyAccountsOfNewCompanyDomain.php
+++ b/app/Listeners/NotifyAccountsOfNewCompanyDomain.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Notifications\NewCompanyDomainRegistered;
+use App\Services\CompanyAggregator;
+use App\Support\ConsumerEmailDomains;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Notification;
+
+class NotifyAccountsOfNewCompanyDomain
+{
+    public function __construct(
+        public CompanyAggregator $companies,
+    ) {}
+
+    public function handle(Registered $event): void
+    {
+        $user = $event->user;
+        $domain = ConsumerEmailDomains::domainFromEmail($user->email);
+
+        if (! ConsumerEmailDomains::isCompanyDomain($domain)) {
+            return;
+        }
+
+        if ($this->companies->countUsersForDomain($domain) !== 1) {
+            return;
+        }
+
+        Notification::route('mail', config('companies.accounts_email'))
+            ->notify(new NewCompanyDomainRegistered($user, $domain));
+    }
+}

--- a/app/Notifications/NewCompanyDomainRegistered.php
+++ b/app/Notifications/NewCompanyDomainRegistered.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewCompanyDomainRegistered extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public User $user,
+        public string $domain,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New company domain: '.$this->domain)
+            ->greeting('A new company domain just signed up.')
+            ->line("**Domain:** {$this->domain}")
+            ->line("**Name:** {$this->user->name}")
+            ->line("**Email:** {$this->user->email}")
+            ->line('**Signed up:** '.$this->user->created_at?->toDayDateTimeString());
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Listeners\NotifyAccountsOfNewCompanyDomain;
 use App\Listeners\StripeWebhookHandledListener;
 use App\Listeners\StripeWebhookReceivedListener;
 use App\Listeners\SuppressMailNotificationListener;
@@ -23,6 +24,7 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+            NotifyAccountsOfNewCompanyDomain::class,
         ],
         WebhookReceived::class => [
             StripeWebhookReceivedListener::class,

--- a/app/Services/CompanyAggregator.php
+++ b/app/Services/CompanyAggregator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Support\ConsumerEmailDomains;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class CompanyAggregator
+{
+    /**
+     * @return Collection<string, array{domain: string, users_count: int, earliest_signup: mixed, latest_signup: mixed}>
+     */
+    public function aggregate(): Collection
+    {
+        $domainExpression = $this->domainExpression();
+
+        $rows = User::query()
+            ->select([
+                DB::raw("{$domainExpression} as domain"),
+                DB::raw('COUNT(*) as users_count'),
+                DB::raw('MIN(created_at) as earliest_signup'),
+                DB::raw('MAX(created_at) as latest_signup'),
+            ])
+            ->whereNotNull('email')
+            ->where('email', 'like', '%@%')
+            ->groupBy(DB::raw($domainExpression))
+            ->get();
+
+        return $rows
+            ->filter(fn ($row): bool => ConsumerEmailDomains::isCompanyDomain($row->domain))
+            ->mapWithKeys(fn ($row): array => [
+                $row->domain => [
+                    'domain' => $row->domain,
+                    'users_count' => (int) $row->users_count,
+                    'earliest_signup' => $row->earliest_signup,
+                    'latest_signup' => $row->latest_signup,
+                ],
+            ]);
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function usersForDomain(string $domain): Collection
+    {
+        $domain = strtolower($domain);
+        $domainExpression = $this->domainExpression();
+
+        return User::query()
+            ->whereRaw("{$domainExpression} = ?", [$domain])
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    public function countUsersForDomain(string $domain): int
+    {
+        $domain = strtolower($domain);
+        $domainExpression = $this->domainExpression();
+
+        return User::query()
+            ->whereRaw("{$domainExpression} = ?", [$domain])
+            ->count();
+    }
+
+    protected function domainExpression(): string
+    {
+        return match (DB::connection()->getDriverName()) {
+            'sqlite' => "lower(substr(email, instr(email, '@') + 1))",
+            default => "LOWER(SUBSTRING_INDEX(email, '@', -1))",
+        };
+    }
+}

--- a/app/Support/ConsumerEmailDomains.php
+++ b/app/Support/ConsumerEmailDomains.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+class ConsumerEmailDomains
+{
+    public static function extract(?string $email): ?string
+    {
+        if (! filled($email) || ! str_contains($email, '@')) {
+            return null;
+        }
+
+        $domain = strtolower(trim(Str::afterLast($email, '@')));
+
+        return $domain !== '' ? $domain : null;
+    }
+
+    public static function isConsumer(?string $domain): bool
+    {
+        if (! filled($domain)) {
+            return true;
+        }
+
+        $domain = strtolower($domain);
+
+        if (in_array($domain, config('companies.consumer_domains', []), true)) {
+            return true;
+        }
+
+        foreach (config('companies.consumer_domain_prefixes', []) as $prefix) {
+            if (str_starts_with($domain, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function isCompanyDomain(?string $domain): bool
+    {
+        return filled($domain) && ! static::isConsumer($domain);
+    }
+
+    public static function domainFromEmail(?string $email): ?string
+    {
+        return static::extract($email);
+    }
+}

--- a/config/companies.php
+++ b/config/companies.php
@@ -1,0 +1,102 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Accounts notification address
+    |--------------------------------------------------------------------------
+    |
+    | When a user registers with a new non-consumer email domain, a short
+    | notification is sent to this address.
+    |
+    */
+
+    'accounts_email' => env('COMPANIES_ACCOUNTS_EMAIL', 'accounts@nativephp.com'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Consumer / free mailbox domains
+    |--------------------------------------------------------------------------
+    |
+    | Exact domains that should never be treated as company domains.
+    |
+    */
+
+    'consumer_domains' => [
+        'gmail.com',
+        'googlemail.com',
+        'outlook.com',
+        'live.com',
+        'msn.com',
+        'icloud.com',
+        'me.com',
+        'mac.com',
+        'aol.com',
+        'protonmail.com',
+        'proton.me',
+        'hey.com',
+        'mail.com',
+        'qq.com',
+        '163.com',
+        '126.com',
+        'yeah.net',
+        'ymail.com',
+        'rocketmail.com',
+        'mail.ru',
+        'inbox.com',
+        'fastmail.com',
+        'fastmail.fm',
+        'tutanota.com',
+        'tuta.io',
+        'zoho.com',
+        'zohomail.com',
+        'gmx.com',
+        'gmx.net',
+        'gmx.de',
+        'gmx.at',
+        'gmx.ch',
+        'gmx.fr',
+        'gmx.co.uk',
+        'hotmail.com',
+        'hotmail.co.uk',
+        'hotmail.fr',
+        'hotmail.de',
+        'hotmail.it',
+        'hotmail.es',
+        'hotmail.ca',
+        'yahoo.com',
+        'yahoo.co.uk',
+        'yahoo.fr',
+        'yahoo.de',
+        'yahoo.it',
+        'yahoo.es',
+        'yahoo.ca',
+        'yahoo.com.au',
+        'yahoo.co.in',
+        'yahoo.co.jp',
+        'yandex.com',
+        'yandex.ru',
+        'yandex.ua',
+        'yandex.by',
+        'yandex.kz',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Consumer domain prefixes
+    |--------------------------------------------------------------------------
+    |
+    | Domains that start with these prefixes (e.g. yahoo.co.uk, hotmail.fr,
+    | gmx.de, yandex.ru) are also treated as consumer mailboxes.
+    |
+    */
+
+    'consumer_domain_prefixes' => [
+        'yahoo.',
+        'hotmail.',
+        'gmx.',
+        'yandex.',
+    ],
+
+];

--- a/tests/Feature/CompaniesAdminTest.php
+++ b/tests/Feature/CompaniesAdminTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Pages\Companies;
+use App\Models\User;
+use App\Services\CompanyAggregator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CompaniesAdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@nativephp.com']);
+        config(['filament.users' => ['admin@nativephp.com']]);
+    }
+
+    public function test_aggregator_groups_users_by_company_domain_and_excludes_consumer_domains(): void
+    {
+        User::factory()->create(['email' => 'a@acme.com', 'created_at' => now()->subDays(3)]);
+        User::factory()->create(['email' => 'b@acme.com', 'created_at' => now()->subDay()]);
+        User::factory()->create(['email' => 'c@widgets.io', 'created_at' => now()]);
+        User::factory()->create(['email' => 'person@gmail.com']);
+        User::factory()->create(['email' => 'person@yahoo.co.uk']);
+
+        $companies = app(CompanyAggregator::class)->aggregate();
+
+        $this->assertTrue($companies->has('acme.com'));
+        $this->assertTrue($companies->has('widgets.io'));
+        $this->assertFalse($companies->has('gmail.com'));
+        $this->assertFalse($companies->has('yahoo.co.uk'));
+        $this->assertSame(2, $companies['acme.com']['users_count']);
+        $this->assertSame(1, $companies['widgets.io']['users_count']);
+    }
+
+    public function test_admin_companies_page_lists_company_domains_and_excludes_consumer_mailboxes(): void
+    {
+        User::factory()->create(['email' => 'a@acme.com']);
+        User::factory()->create(['email' => 'b@acme.com']);
+        User::factory()->create(['email' => 'c@widgets.io']);
+        User::factory()->create(['email' => 'd@gmail.com']);
+
+        Livewire::actingAs($this->admin)
+            ->test(Companies::class)
+            ->assertCanSeeTableRecords(['acme.com', 'widgets.io'])
+            ->assertCanNotSeeTableRecords(['gmail.com'])
+            ->assertSee('acme.com')
+            ->assertSee('widgets.io')
+            ->assertDontSee('gmail.com');
+    }
+
+    public function test_admin_companies_page_is_accessible_to_admins(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(Companies::getUrl())
+            ->assertOk()
+            ->assertSee('Companies');
+    }
+}

--- a/tests/Feature/NewCompanyDomainRegistrationTest.php
+++ b/tests/Feature/NewCompanyDomainRegistrationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\NewCompanyDomainRegistered;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class NewCompanyDomainRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function registrationPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@acme.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ], $overrides);
+    }
+
+    public function test_first_company_domain_signup_emails_accounts(): void
+    {
+        Notification::fake();
+        config(['services.turnstile.secret_key' => null]);
+
+        $response = $this->post('/register', $this->registrationPayload());
+
+        $response->assertRedirect(route('dashboard'));
+        $this->assertAuthenticated();
+
+        Notification::assertSentOnDemand(
+            NewCompanyDomainRegistered::class,
+            function (NewCompanyDomainRegistered $notification, array $channels, object $notifiable): bool {
+                return $notifiable->routes['mail'] === 'accounts@nativephp.com'
+                    && $notification->domain === 'acme.com'
+                    && $notification->user->email === 'ada@acme.com';
+            }
+        );
+    }
+
+    public function test_second_user_on_same_company_domain_does_not_email_accounts(): void
+    {
+        Notification::fake();
+        config(['services.turnstile.secret_key' => null]);
+
+        User::factory()->create(['email' => 'first@acme.com']);
+
+        $response = $this->post('/register', $this->registrationPayload([
+            'email' => 'second@acme.com',
+        ]));
+
+        $response->assertRedirect(route('dashboard'));
+
+        Notification::assertSentOnDemandTimes(NewCompanyDomainRegistered::class, 0);
+    }
+
+    public function test_gmail_signup_does_not_email_accounts(): void
+    {
+        Notification::fake();
+        config(['services.turnstile.secret_key' => null]);
+
+        $response = $this->post('/register', $this->registrationPayload([
+            'email' => 'person@gmail.com',
+        ]));
+
+        $response->assertRedirect(route('dashboard'));
+
+        Notification::assertSentOnDemandTimes(NewCompanyDomainRegistered::class, 0);
+    }
+}

--- a/tests/Unit/ConsumerEmailDomainsTest.php
+++ b/tests/Unit/ConsumerEmailDomainsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\ConsumerEmailDomains;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class ConsumerEmailDomainsTest extends TestCase
+{
+    public function test_it_extracts_a_lowercase_domain_from_an_email(): void
+    {
+        $this->assertSame('acme.com', ConsumerEmailDomains::extract('Ada@Acme.com'));
+    }
+
+    public function test_it_returns_null_for_invalid_emails(): void
+    {
+        $this->assertNull(ConsumerEmailDomains::extract(null));
+        $this->assertNull(ConsumerEmailDomains::extract(''));
+        $this->assertNull(ConsumerEmailDomains::extract('not-an-email'));
+    }
+
+    #[DataProvider('consumerDomains')]
+    public function test_it_recognizes_consumer_domains(string $domain): void
+    {
+        $this->assertTrue(ConsumerEmailDomains::isConsumer($domain));
+        $this->assertFalse(ConsumerEmailDomains::isCompanyDomain($domain));
+    }
+
+    #[DataProvider('companyDomains')]
+    public function test_it_recognizes_company_domains(string $domain): void
+    {
+        $this->assertFalse(ConsumerEmailDomains::isConsumer($domain));
+        $this->assertTrue(ConsumerEmailDomains::isCompanyDomain($domain));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function consumerDomains(): array
+    {
+        return [
+            'gmail' => ['gmail.com'],
+            'googlemail' => ['googlemail.com'],
+            'yahoo prefix' => ['yahoo.co.uk'],
+            'hotmail prefix' => ['hotmail.fr'],
+            'outlook' => ['outlook.com'],
+            'icloud' => ['icloud.com'],
+            'proton' => ['proton.me'],
+            'gmx prefix' => ['gmx.de'],
+            'yandex prefix' => ['yandex.ru'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function companyDomains(): array
+    {
+        return [
+            'acme' => ['acme.com'],
+            'nativephp' => ['nativephp.com'],
+            'laravel' => ['laravel.com'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Filament admin **Companies** page that aggregates users by email domain (user count, earliest/latest signup), excluding consumer mailbox domains, with a Users action that deep-links into the User resource filtered by domain.
- On registration (`Illuminate\Auth\Events\Registered`, fired from `CustomerAuthController` and other signup paths), emails `accounts@nativephp.com` when the domain is a new non-consumer company domain (first user only).
- Consumer denylist lives in `config/companies.php` (exact domains + prefixes like `yahoo.`, `hotmail.`, `gmx.`, `yandex.`), wrapped by `App\Support\ConsumerEmailDomains`.

## Test plan
- [x] `php artisan test --compact tests/Unit/ConsumerEmailDomainsTest.php tests/Feature/CompaniesAdminTest.php tests/Feature/NewCompanyDomainRegistrationTest.php` (20 passed)
- [ ] Visit `/admin/companies` as an admin and confirm company domains list with counts; gmail/yahoo-style domains absent
- [ ] Register `you@some-new-company.test` and confirm accounts@ receives the short “new company domain” mail
- [ ] Register a second user on the same domain and confirm no second “new company” mail
- [ ] Register with `@gmail.com` and confirm no accounts mail