### PR TITLE
Add plugin permission manifests, admin review gating, and version changelog

### DIFF
--- a/app/Enums/AndroidPermission.php
+++ b/app/Enums/AndroidPermission.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AndroidPermission: string
+{
+    case Camera = 'android.permission.CAMERA';
+    case RecordAudio = 'android.permission.RECORD_AUDIO';
+    case AccessFineLocation = 'android.permission.ACCESS_FINE_LOCATION';
+    case AccessCoarseLocation = 'android.permission.ACCESS_COARSE_LOCATION';
+    case AccessBackgroundLocation = 'android.permission.ACCESS_BACKGROUND_LOCATION';
+    case ReadContacts = 'android.permission.READ_CONTACTS';
+    case WriteContacts = 'android.permission.WRITE_CONTACTS';
+    case ReadCalendar = 'android.permission.READ_CALENDAR';
+    case WriteCalendar = 'android.permission.WRITE_CALENDAR';
+    case BluetoothConnect = 'android.permission.BLUETOOTH_CONNECT';
+    case BluetoothScan = 'android.permission.BLUETOOTH_SCAN';
+    case ReadMediaImages = 'android.permission.READ_MEDIA_IMAGES';
+    case ReadExternalStorage = 'android.permission.READ_EXTERNAL_STORAGE';
+    case BodySensors = 'android.permission.BODY_SENSORS';
+    case ActivityRecognition = 'android.permission.ACTIVITY_RECOGNITION';
+    case Internet = 'android.permission.INTERNET';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Camera => 'Camera',
+            self::RecordAudio => 'Microphone',
+            self::AccessFineLocation => 'Precise Location',
+            self::AccessCoarseLocation => 'Approximate Location',
+            self::AccessBackgroundLocation => 'Background Location',
+            self::ReadContacts => 'Read Contacts',
+            self::WriteContacts => 'Write Contacts',
+            self::ReadCalendar => 'Read Calendar',
+            self::WriteCalendar => 'Write Calendar',
+            self::BluetoothConnect => 'Bluetooth',
+            self::BluetoothScan => 'Bluetooth Scanning',
+            self::ReadMediaImages => 'Photo Library',
+            self::ReadExternalStorage => 'Device Storage',
+            self::BodySensors => 'Body Sensors',
+            self::ActivityRecognition => 'Motion & Fitness',
+            self::Internet => 'Internet Access',
+        };
+    }
+
+    public function iosUsageDescriptionKey(): ?string
+    {
+        return match ($this) {
+            self::Camera => 'NSCameraUsageDescription',
+            self::RecordAudio => 'NSMicrophoneUsageDescription',
+            self::AccessFineLocation, self::AccessCoarseLocation => 'NSLocationWhenInUseUsageDescription',
+            self::AccessBackgroundLocation => 'NSLocationAlwaysAndWhenInUseUsageDescription',
+            self::ReadContacts, self::WriteContacts => 'NSContactsUsageDescription',
+            self::ReadCalendar, self::WriteCalendar => 'NSCalendarsUsageDescription',
+            self::BluetoothConnect, self::BluetoothScan => 'NSBluetoothAlwaysUsageDescription',
+            self::ReadMediaImages, self::ReadExternalStorage => 'NSPhotoLibraryUsageDescription',
+            self::BodySensors, self::ActivityRecognition => 'NSMotionUsageDescription',
+            self::Internet => null,
+        };
+    }
+}

--- a/app/Enums/IosBackgroundMode.php
+++ b/app/Enums/IosBackgroundMode.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum IosBackgroundMode: string
+{
+    case Audio = 'audio';
+    case Fetch = 'fetch';
+    case Processing = 'processing';
+    case Location = 'location';
+    case RemoteNotification = 'remote-notification';
+    case BluetoothCentral = 'bluetooth-central';
+    case BluetoothPeripheral = 'bluetooth-peripheral';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Audio => 'Background Audio',
+            self::Fetch => 'Background Fetch',
+            self::Processing => 'Background Processing',
+            self::Location => 'Background Location',
+            self::RemoteNotification => 'Push Notifications',
+            self::BluetoothCentral => 'Bluetooth (Central)',
+            self::BluetoothPeripheral => 'Bluetooth (Peripheral)',
+        };
+    }
+}

--- a/app/Enums/PermissionExpansionMode.php
+++ b/app/Enums/PermissionExpansionMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PermissionExpansionMode: string
+{
+    case Flag = 'flag';
+    case Gate = 'gate';
+}

--- a/app/Enums/PluginActivityType.php
+++ b/app/Enums/PluginActivityType.php
@@ -15,6 +15,7 @@ enum PluginActivityType: string
     case ReturnedToDraft = 'returned_to_draft';
     case MessageToDeveloper = 'message_to_developer';
     case MessageFromDeveloper = 'message_from_developer';
+    case PermissionsExpanded = 'permissions_expanded';
 
     /**
      * Types that represent a message in the admin <-> developer conversation.
@@ -38,6 +39,7 @@ enum PluginActivityType: string
             self::ReturnedToDraft => 'Returned to Draft',
             self::MessageToDeveloper => 'Message Sent',
             self::MessageFromDeveloper => 'Developer Reply',
+            self::PermissionsExpanded => 'Permissions Expanded',
         };
     }
 
@@ -65,6 +67,7 @@ enum PluginActivityType: string
             self::ReturnedToDraft => 'warning',
             self::MessageToDeveloper => 'primary',
             self::MessageFromDeveloper => 'info',
+            self::PermissionsExpanded => 'warning',
         };
     }
 
@@ -79,6 +82,7 @@ enum PluginActivityType: string
             self::Rejected => 'red',
             self::MessageToDeveloper => 'purple',
             self::MessageFromDeveloper => 'sky',
+            self::PermissionsExpanded => 'amber',
             default => 'zinc',
         };
     }
@@ -95,6 +99,7 @@ enum PluginActivityType: string
             self::ReturnedToDraft => 'heroicon-o-arrow-uturn-left',
             self::MessageToDeveloper => 'heroicon-o-chat-bubble-left-right',
             self::MessageFromDeveloper => 'heroicon-o-chat-bubble-left-ellipsis',
+            self::PermissionsExpanded => 'heroicon-o-shield-exclamation',
         };
     }
 

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -179,6 +179,20 @@ class PluginResource extends Resource
                             ->content(fn (?Plugin $record) => ($record?->review_checks['has_android_min_version'] ?? false)
                                 ? '✅ '.($record->review_checks['android_min_version'] ?? '')
                                 : '❌ Missing'),
+
+                        Forms\Components\Placeholder::make('review_permission_parity')
+                            ->label('App Store Permission Parity')
+                            ->content(function (?Plugin $record) {
+                                $missing = $record?->review_checks['missing_permission_parity'] ?? [];
+
+                                if (empty($missing)) {
+                                    return '✅ All Android permissions have a matching iOS usage description';
+                                }
+
+                                return '❌ Missing: '.collect($missing)
+                                    ->map(fn (array $issue) => "{$issue['permission']} → {$issue['expected_key']}")
+                                    ->implode(', ');
+                            }),
                     ])
                     ->headerActions([
                         Action::make('emailReviewChecks')
@@ -544,6 +558,7 @@ class PluginResource extends Resource
             RelationManagers\PricesRelationManager::class,
             RelationManagers\LicensesRelationManager::class,
             RelationManagers\ActivitiesRelationManager::class,
+            RelationManagers\VersionsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/PluginResource/RelationManagers/VersionsRelationManager.php
+++ b/app/Filament/Resources/PluginResource/RelationManagers/VersionsRelationManager.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PluginResource\RelationManagers;
+
+use App\Models\PluginVersion;
+use Filament\Actions;
+use Filament\Notifications\Notification;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+
+final class VersionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'versions';
+
+    protected static ?string $title = 'Versions';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('version')
+                    ->searchable()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('tag_name')
+                    ->label('Tag')
+                    ->searchable(),
+
+                Tables\Columns\IconColumn::make('permissions_expanded')
+                    ->label('Permissions Expanded')
+                    ->boolean(),
+
+                Tables\Columns\IconColumn::make('requires_review')
+                    ->label('Pending Review')
+                    ->boolean()
+                    ->trueColor('danger'),
+
+                Tables\Columns\TextColumn::make('approvedBy.email')
+                    ->label('Approved By')
+                    ->placeholder('—'),
+
+                Tables\Columns\TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->actions([
+                Actions\Action::make('viewManifest')
+                    ->label('View Permissions')
+                    ->icon('heroicon-o-shield-check')
+                    ->color('gray')
+                    ->visible(fn (PluginVersion $record): bool => filled($record->manifest_permissions))
+                    ->modalHeading(fn (PluginVersion $record): string => "Permissions — {$record->version}")
+                    ->modalContent(fn (PluginVersion $record) => view(
+                        'filament.resources.plugin-resource.manifest-permissions',
+                        ['manifest' => $record->manifest_permissions]
+                    ))
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Close'),
+
+                Actions\Action::make('approve')
+                    ->label('Approve')
+                    ->icon('heroicon-o-check-circle')
+                    ->color('success')
+                    ->visible(fn (PluginVersion $record): bool => $record->requires_review)
+                    ->requiresConfirmation()
+                    ->modalDescription('This version will become the plugin\'s current visible version.')
+                    ->action(function (PluginVersion $record): void {
+                        $record->approve(Auth::user());
+
+                        $latest = $record->plugin->versions()->visible()->latest('published_at')->first();
+
+                        if ($latest) {
+                            $record->plugin->update(['latest_version' => $latest->version]);
+                        }
+
+                        Notification::make()
+                            ->title("Version {$record->version} approved")
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([])
+            ->defaultSort('published_at', 'desc')
+            ->paginated([10, 25, 50]);
+    }
+}

--- a/app/Http/Controllers/PluginDirectoryController.php
+++ b/app/Http/Controllers/PluginDirectoryController.php
@@ -72,6 +72,9 @@ class PluginDirectoryController extends Controller
         $bestPrice = $plugin->getBestPriceForUser($user);
         $regularPrice = $plugin->getRegularPrice();
 
+        $currentManifest = $plugin->versions()->visible()->latest('published_at')->first()?->manifest_permissions;
+        $versionHistory = $plugin->versions()->visible()->orderByDesc('published_at')->limit(15)->get();
+
         $this->setPluginSeo($plugin);
 
         return view('plugin-show', [
@@ -81,6 +84,8 @@ class PluginDirectoryController extends Controller
             'regularPrice' => $regularPrice,
             'hasDiscount' => $bestPrice && $regularPrice && $bestPrice->id !== $regularPrice->id,
             'isAdminPreview' => (! $plugin->isApproved() || ! $plugin->is_active) && ($isAdmin || $isOwner),
+            'currentManifest' => $currentManifest,
+            'versionHistory' => $versionHistory,
         ]);
     }
 

--- a/app/Jobs/ReviewPluginRepository.php
+++ b/app/Jobs/ReviewPluginRepository.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Plugin;
+use App\Services\PluginManifestParser;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -21,7 +22,7 @@ class ReviewPluginRepository implements ShouldQueue
 
     public function __construct(public Plugin $plugin) {}
 
-    public function handle(): array
+    public function handle(PluginManifestParser $manifestParser): array
     {
         $repo = $this->plugin->getRepositoryOwnerAndName();
 
@@ -38,6 +39,8 @@ class ReviewPluginRepository implements ShouldQueue
             'ios_min_version' => null,
             'has_android_min_version' => false,
             'android_min_version' => null,
+            'permission_parity_complete' => true,
+            'missing_permission_parity' => [],
         ];
 
         if (! $repo) {
@@ -70,11 +73,13 @@ class ReviewPluginRepository implements ShouldQueue
         $composerJson = $this->fetchComposerJson($owner, $repoName, $token);
         $nativephpJson = $this->fetchNativephpJson($owner, $repoName, $token);
 
+        $supportsIos = $this->checkDirectoryHasFiles($tree, 'resources/ios/');
+
         $checks = [
             'has_license_file' => $this->checkHasLicenseFile($tree),
             'has_release_version' => false,
             'release_version' => null,
-            'supports_ios' => $this->checkDirectoryHasFiles($tree, 'resources/ios/'),
+            'supports_ios' => $supportsIos,
             'supports_android' => $this->checkDirectoryHasFiles($tree, 'resources/android/'),
             'supports_js' => $this->checkDirectoryHasFiles($tree, 'resources/js/'),
             'requires_mobile_sdk' => false,
@@ -83,6 +88,8 @@ class ReviewPluginRepository implements ShouldQueue
             'ios_min_version' => null,
             'has_android_min_version' => false,
             'android_min_version' => null,
+            'permission_parity_complete' => true,
+            'missing_permission_parity' => [],
         ];
 
         $latestTag = $this->fetchLatestTag($owner, $repoName, $token);
@@ -91,21 +98,24 @@ class ReviewPluginRepository implements ShouldQueue
             $checks['release_version'] = $latestTag;
         }
 
-        if ($composerJson) {
-            $mobileConstraint = $composerJson['require']['nativephp/mobile'] ?? null;
-            $checks['requires_mobile_sdk'] = $mobileConstraint !== null;
-            $checks['mobile_sdk_constraint'] = $mobileConstraint;
-        }
+        $mobileConstraint = $manifestParser->sdkConstraint($composerJson);
+        $checks['requires_mobile_sdk'] = $mobileConstraint !== null;
+        $checks['mobile_sdk_constraint'] = $mobileConstraint;
 
-        if ($nativephpJson) {
-            $iosMinVersion = $nativephpJson['ios']['min_version'] ?? null;
-            $checks['has_ios_min_version'] = $iosMinVersion !== null;
-            $checks['ios_min_version'] = $iosMinVersion;
+        $iosMinVersion = $manifestParser->iosMinVersion($nativephpJson);
+        $checks['has_ios_min_version'] = $iosMinVersion !== null;
+        $checks['ios_min_version'] = $iosMinVersion;
 
-            $androidMinVersion = $nativephpJson['android']['min_version'] ?? null;
-            $checks['has_android_min_version'] = $androidMinVersion !== null;
-            $checks['android_min_version'] = $androidMinVersion;
-        }
+        $androidMinVersion = $manifestParser->androidMinVersion($nativephpJson);
+        $checks['has_android_min_version'] = $androidMinVersion !== null;
+        $checks['android_min_version'] = $androidMinVersion;
+
+        $missingParity = $manifestParser->missingUsageDescriptions(
+            $manifestParser->permissionManifest($nativephpJson),
+            $supportsIos
+        );
+        $checks['permission_parity_complete'] = $missingParity === [];
+        $checks['missing_permission_parity'] = $missingParity;
 
         $this->plugin->update([
             'review_checks' => $checks,

--- a/app/Jobs/SyncPluginReleases.php
+++ b/app/Jobs/SyncPluginReleases.php
@@ -2,9 +2,13 @@
 
 namespace App\Jobs;
 
+use App\Enums\PermissionExpansionMode;
+use App\Enums\PluginActivityType;
 use App\Models\Plugin;
 use App\Models\PluginVersion;
+use App\Services\PluginManifestParser;
 use App\Services\SatisService;
+use App\Support\CommonMark\CommonMark;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -28,7 +32,7 @@ class SyncPluginReleases implements ShouldQueue
         public bool $triggerSatisBuild = true
     ) {}
 
-    public function handle(SatisService $satisService): void
+    public function handle(SatisService $satisService, PluginManifestParser $manifestParser): void
     {
         Log::info('[SyncPluginReleases] Starting sync', [
             'plugin_id' => $this->plugin->id,
@@ -71,7 +75,7 @@ class SyncPluginReleases implements ShouldQueue
         $skippedCount = 0;
 
         foreach ($releases as $release) {
-            if ($this->processRelease($release)) {
+            if ($this->processRelease($release, $repo['owner'], $repo['repo'], $token, $manifestParser)) {
                 $newCount++;
             } else {
                 $skippedCount++;
@@ -81,7 +85,7 @@ class SyncPluginReleases implements ShouldQueue
         $updateData = ['last_synced_at' => now()];
 
         if ($this->hasNewReleases) {
-            $latestVersion = $this->plugin->versions()->latest('published_at')->first();
+            $latestVersion = $this->plugin->versions()->visible()->latest('published_at')->first();
 
             if ($latestVersion) {
                 $updateData['latest_version'] = $latestVersion->version;
@@ -162,7 +166,7 @@ class SyncPluginReleases implements ShouldQueue
         return $response->json() ?? [];
     }
 
-    protected function processRelease(array $release): bool
+    protected function processRelease(array $release, string $owner, string $repo, ?string $token, PluginManifestParser $manifestParser): bool
     {
         $tagName = $release['tag_name'];
         $version = ltrim($tagName, 'v');
@@ -180,14 +184,25 @@ class SyncPluginReleases implements ShouldQueue
             return false;
         }
 
+        $previousManifest = $this->plugin->versions()->visible()->latest('published_at')->first()?->manifest_permissions;
+
+        $nativephpJson = $this->fetchNativephpJsonAtRef($owner, $repo, $tagName, $token);
+        $manifest = $manifestParser->permissionManifest($nativephpJson);
+        $expanded = $manifestParser->hasExpandedPermissions($previousManifest, $manifest);
+        $requiresReview = $expanded && PermissionExpansionMode::from(config('plugins.permission_expansion_mode')) === PermissionExpansionMode::Gate;
+
         PluginVersion::create([
             'plugin_id' => $this->plugin->id,
             'version' => $version,
             'tag_name' => $tagName,
             'release_notes' => $release['body'] ?? null,
+            'release_notes_html' => filled($release['body'] ?? null) ? CommonMark::convertToHtml($release['body']) : null,
             'github_release_id' => (string) $release['id'],
             'commit_sha' => $release['target_commitish'] ?? null,
             'published_at' => $release['published_at'] ? now()->parse($release['published_at']) : null,
+            'manifest_permissions' => $manifest,
+            'permissions_expanded' => $expanded,
+            'requires_review' => $requiresReview,
         ]);
 
         Log::info('[SyncPluginReleases] Created new version', [
@@ -197,10 +212,50 @@ class SyncPluginReleases implements ShouldQueue
             'tag' => $tagName,
             'commit_sha' => $release['target_commitish'] ?? null,
             'published_at' => $release['published_at'] ?? null,
+            'permissions_expanded' => $expanded,
+            'requires_review' => $requiresReview,
         ]);
+
+        if ($expanded) {
+            $this->plugin->activities()->create([
+                'type' => PluginActivityType::PermissionsExpanded,
+                'from_status' => $this->plugin->status->value,
+                'to_status' => $this->plugin->status->value,
+                'note' => $requiresReview
+                    ? "Version {$version} adds new permissions/entitlements and is held for admin review."
+                    : "Version {$version} adds new permissions/entitlements.",
+                'causer_id' => null,
+            ]);
+        }
 
         $this->hasNewReleases = true;
 
         return true;
+    }
+
+    protected function fetchNativephpJsonAtRef(string $owner, string $repo, string $ref, ?string $token): ?array
+    {
+        $request = Http::timeout(15);
+
+        if ($token) {
+            $request = $request->withToken($token);
+        }
+
+        $response = $request->get("https://api.github.com/repos/{$owner}/{$repo}/contents/nativephp.json", [
+            'ref' => $ref,
+        ]);
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        $content = $response->json('content');
+        $encoding = $response->json('encoding');
+
+        if ($encoding !== 'base64' || ! $content) {
+            return null;
+        }
+
+        return json_decode(base64_decode($content), true);
     }
 }

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -277,6 +277,14 @@ class Plugin extends Model
         return $this->hasOne(PluginVersion::class)->where('is_packaged', true)->latest('published_at');
     }
 
+    /**
+     * @return HasOne<PluginVersion>
+     */
+    public function latestVisibleVersion(): HasOne
+    {
+        return $this->hasOne(PluginVersion::class)->visible()->latest('published_at');
+    }
+
     public function isPending(): bool
     {
         return $this->status === PluginStatus::Pending;

--- a/app/Models/PluginVersion.php
+++ b/app/Models/PluginVersion.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,11 +15,29 @@ class PluginVersion extends Model
     protected $guarded = [];
 
     /**
+     * @param  Builder<PluginVersion>  $query
+     * @return Builder<PluginVersion>
+     */
+    #[Scope]
+    protected function visible(Builder $query): Builder
+    {
+        return $query->where('requires_review', false);
+    }
+
+    /**
      * @return BelongsTo<Plugin, PluginVersion>
      */
     public function plugin(): BelongsTo
     {
         return $this->belongsTo(Plugin::class);
+    }
+
+    /**
+     * @return BelongsTo<User, PluginVersion>
+     */
+    public function approvedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by');
     }
 
     public function isPackaged(): bool
@@ -35,12 +55,25 @@ class PluginVersion extends Model
         return $this->storage_path ?? '';
     }
 
+    public function approve(User $admin): void
+    {
+        $this->update([
+            'requires_review' => false,
+            'approved_by' => $admin->id,
+            'approved_at' => now(),
+        ]);
+    }
+
     protected function casts(): array
     {
         return [
             'is_packaged' => 'boolean',
             'packaged_at' => 'datetime',
             'published_at' => 'datetime',
+            'manifest_permissions' => 'array',
+            'permissions_expanded' => 'boolean',
+            'requires_review' => 'boolean',
+            'approved_at' => 'datetime',
         ];
     }
 }

--- a/app/Services/PluginManifestParser.php
+++ b/app/Services/PluginManifestParser.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\AndroidPermission;
+
+final class PluginManifestParser
+{
+    public function sdkConstraint(?array $composerData): ?string
+    {
+        return $composerData['require']['nativephp/mobile'] ?? null;
+    }
+
+    public function iosMinVersion(?array $nativephpData): ?string
+    {
+        return $nativephpData['ios']['min_version'] ?? null;
+    }
+
+    public function androidMinVersion(?array $nativephpData): ?string
+    {
+        $minVersion = $nativephpData['android']['min_version'] ?? null;
+
+        return $minVersion === null ? null : (string) $minVersion;
+    }
+
+    /**
+     * @return array{android_permissions: array<int, string>, android_features: array<int, array<string, mixed>>, ios_capabilities: array<int, string>, ios_entitlements: array<string, mixed>, ios_background_modes: array<int, string>, ios_info_plist: array<string, mixed>}
+     */
+    public function permissionManifest(?array $nativephpData): array
+    {
+        return [
+            'android_permissions' => $nativephpData['android']['permissions'] ?? [],
+            'android_features' => $nativephpData['android']['features'] ?? [],
+            'ios_capabilities' => $nativephpData['ios']['capabilities'] ?? [],
+            'ios_entitlements' => $nativephpData['ios']['entitlements'] ?? [],
+            'ios_background_modes' => $nativephpData['ios']['background_modes'] ?? [],
+            'ios_info_plist' => $nativephpData['ios']['info_plist'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array{android_permissions?: array<int, string>, ios_info_plist?: array<string, mixed>}  $permissionManifest
+     * @return array<int, array{permission: string, expected_key: string}>
+     */
+    public function missingUsageDescriptions(array $permissionManifest, bool $supportsIos): array
+    {
+        if (! $supportsIos) {
+            return [];
+        }
+
+        $declaredKeys = array_keys($permissionManifest['ios_info_plist'] ?? []);
+        $missing = [];
+
+        foreach ($permissionManifest['android_permissions'] ?? [] as $permission) {
+            $expectedKey = AndroidPermission::tryFrom($permission)?->iosUsageDescriptionKey();
+
+            if ($expectedKey !== null && ! in_array($expectedKey, $declaredKeys, true)) {
+                $missing[] = ['permission' => $permission, 'expected_key' => $expectedKey];
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * @param  array{android_permissions?: array<int, string>, ios_capabilities?: array<int, string>, ios_background_modes?: array<int, string>, ios_entitlements?: array<string, mixed>}|null  $previous
+     * @param  array{android_permissions?: array<int, string>, ios_capabilities?: array<int, string>, ios_background_modes?: array<int, string>, ios_entitlements?: array<string, mixed>}  $current
+     */
+    public function hasExpandedPermissions(?array $previous, array $current): bool
+    {
+        if ($previous === null) {
+            return false;
+        }
+
+        foreach (['android_permissions', 'ios_capabilities', 'ios_background_modes'] as $listKey) {
+            if (array_diff($current[$listKey] ?? [], $previous[$listKey] ?? []) !== []) {
+                return true;
+            }
+        }
+
+        return array_diff(
+            array_keys($current['ios_entitlements'] ?? []),
+            array_keys($previous['ios_entitlements'] ?? [])
+        ) !== [];
+    }
+}

--- a/app/Services/PluginSyncService.php
+++ b/app/Services/PluginSyncService.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\Log;
 
 class PluginSyncService
 {
+    public function __construct(
+        protected PluginManifestParser $manifestParser
+    ) {}
+
     public function sync(Plugin $plugin): bool
     {
         Log::info('[PluginSync] Starting sync', ['plugin_id' => $plugin->id, 'name' => $plugin->name]);
@@ -86,12 +90,12 @@ class PluginSyncService
         }
 
         if ($nativephpData) {
-            $updateData['ios_version'] = $this->extractIosVersion($nativephpData);
-            $updateData['android_version'] = $this->extractAndroidVersion($nativephpData);
+            $updateData['ios_version'] = $this->manifestParser->iosMinVersion($nativephpData);
+            $updateData['android_version'] = $this->manifestParser->androidMinVersion($nativephpData);
         }
 
         if ($composerData) {
-            $updateData['mobile_min_version'] = $composerData['require']['nativephp/mobile'] ?? null;
+            $updateData['mobile_min_version'] = $this->manifestParser->sdkConstraint($composerData);
         }
 
         if ($readme) {
@@ -200,16 +204,6 @@ class PluginSyncService
         }
 
         return config('services.github.token');
-    }
-
-    protected function extractIosVersion(array $nativephpData): ?string
-    {
-        return $nativephpData['ios']['min_version'] ?? null;
-    }
-
-    protected function extractAndroidVersion(array $nativephpData): ?string
-    {
-        return $nativephpData['android']['min_version'] ?? null;
     }
 
     protected function fetchLicenseFile(string $owner, string $repo, ?string $token): ?string

--- a/app/Support/CommonMark/CommonMark.php
+++ b/app/Support/CommonMark/CommonMark.php
@@ -7,6 +7,7 @@ use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\DisallowedRawHtml\DisallowedRawHtmlExtension;
 use League\CommonMark\Extension\Embed\Bridge\OscaroteroEmbedAdapter;
 use League\CommonMark\Extension\Embed\Embed as EmbedNode;
 use League\CommonMark\Extension\Embed\EmbedExtension;
@@ -51,6 +52,7 @@ class CommonMark
             $environment = new Environment($config);
 
             $environment->addExtension(new CommonMarkCoreExtension);
+            $environment->addExtension(new DisallowedRawHtmlExtension);
             $environment->addExtension(new GithubFlavoredMarkdownExtension);
             static::$headingRenderer = new HeadingRenderer;
             $environment->addRenderer(Heading::class, static::$headingRenderer);

--- a/app/Support/PluginPermissionLabels.php
+++ b/app/Support/PluginPermissionLabels.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\AndroidPermission;
+use App\Enums\IosBackgroundMode;
+use Illuminate\Support\Str;
+
+final class PluginPermissionLabels
+{
+    public static function androidPermission(string $permission): string
+    {
+        return AndroidPermission::tryFrom($permission)?->label() ?? Str::of($permission)
+            ->after('android.permission.')
+            ->replace('_', ' ')
+            ->title()
+            ->toString();
+    }
+
+    public static function iosBackgroundMode(string $mode): string
+    {
+        return IosBackgroundMode::tryFrom($mode)?->label() ?? Str::title(str_replace('-', ' ', $mode));
+    }
+
+    public static function iosCapability(string $capability): string
+    {
+        return Str::title(str_replace('-', ' ', $capability));
+    }
+
+    public static function iosEntitlement(string $entitlement): string
+    {
+        return Str::of($entitlement)->afterLast('.')->replace('-', ' ')->title()->toString();
+    }
+}

--- a/config/plugins.php
+++ b/config/plugins.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Expansion Mode
+    |--------------------------------------------------------------------------
+    |
+    | Controls what happens when a plugin version declares native permissions,
+    | entitlements, capabilities, or background modes that its previous version
+    | didn't have. See App\Enums\PermissionExpansionMode.
+    |
+    | "flag" — the new version is logged on the plugin's activity timeline and
+    |          published immediately, same as today.
+    | "gate" — the new version is withheld from being the plugin's current/
+    |          visible version until an admin approves it in Filament.
+    |
+    */
+
+    'permission_expansion_mode' => env('PLUGIN_PERMISSION_EXPANSION_MODE', 'flag'),
+
+];

--- a/database/migrations/2026_09_05_090000_add_manifest_review_to_plugin_versions_table.php
+++ b/database/migrations/2026_09_05_090000_add_manifest_review_to_plugin_versions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('plugin_versions', function (Blueprint $table) {
+            $table->text('release_notes_html')->nullable()->after('release_notes');
+            $table->json('manifest_permissions')->nullable()->after('release_notes_html');
+            $table->boolean('permissions_expanded')->default(false)->after('manifest_permissions');
+            $table->boolean('requires_review')->default(false)->after('permissions_expanded');
+            $table->foreignId('approved_by')->nullable()->after('requires_review')->constrained('users')->nullOnDelete();
+            $table->timestamp('approved_at')->nullable()->after('approved_by');
+
+            $table->index('requires_review');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('plugin_versions', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('approved_by');
+            $table->dropColumn(['release_notes_html', 'manifest_permissions', 'permissions_expanded', 'requires_review', 'approved_at']);
+        });
+    }
+};

--- a/resources/views/filament/resources/plugin-resource/manifest-permissions.blade.php
+++ b/resources/views/filament/resources/plugin-resource/manifest-permissions.blade.php
@@ -1,0 +1,38 @@
+@php
+    $manifest = $manifest ?? [];
+@endphp
+
+<div class="space-y-4">
+    @foreach ([
+        'android_permissions' => 'Android Permissions',
+        'android_features' => 'Android Features',
+        'ios_capabilities' => 'iOS Capabilities',
+        'ios_background_modes' => 'iOS Background Modes',
+    ] as $key => $label)
+        @if (! empty($manifest[$key]))
+            <div>
+                <p class="text-sm font-semibold text-gray-700 dark:text-gray-300">{{ $label }}</p>
+                <ul class="mt-1 list-inside list-disc text-sm text-gray-600 dark:text-gray-400">
+                    @foreach ($manifest[$key] as $item)
+                        <li>{{ is_array($item) ? ($item['name'] ?? json_encode($item)) : $item }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+    @endforeach
+
+    @if (! empty($manifest['ios_entitlements']))
+        <div>
+            <p class="text-sm font-semibold text-gray-700 dark:text-gray-300">iOS Entitlements</p>
+            <ul class="mt-1 list-inside list-disc text-sm text-gray-600 dark:text-gray-400">
+                @foreach ($manifest['ios_entitlements'] as $entitlement => $value)
+                    <li>{{ $entitlement }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    @if (empty(array_filter($manifest)))
+        <p class="text-sm text-gray-500 dark:text-gray-400">This version declares no native permissions, entitlements, or background modes.</p>
+    @endif
+</div>

--- a/resources/views/plugin-show.blade.php
+++ b/resources/views/plugin-show.blade.php
@@ -575,6 +575,90 @@
                     </div>
                 @endif
 
+                {{-- What this plugin can access --}}
+                @if ($currentManifest && array_filter($currentManifest))
+                    <div class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50">
+                        <h2 class="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                            <x-heroicon-o-shield-check class="size-4 shrink-0" aria-hidden="true" />
+                            What This Plugin Can Access
+                        </h2>
+                        <ul class="mt-3 space-y-1.5">
+                            @foreach ($currentManifest['android_permissions'] ?? [] as $permission)
+                                <li class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                    <span class="size-1.5 shrink-0 rounded-full bg-indigo-400"></span>
+                                    {{ \App\Support\PluginPermissionLabels::androidPermission($permission) }}
+                                </li>
+                            @endforeach
+
+                            @foreach ($currentManifest['ios_background_modes'] ?? [] as $mode)
+                                <li class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                    <span class="size-1.5 shrink-0 rounded-full bg-indigo-400"></span>
+                                    {{ \App\Support\PluginPermissionLabels::iosBackgroundMode($mode) }}
+                                </li>
+                            @endforeach
+
+                            @foreach ($currentManifest['ios_capabilities'] ?? [] as $capability)
+                                <li class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                    <span class="size-1.5 shrink-0 rounded-full bg-indigo-400"></span>
+                                    {{ \App\Support\PluginPermissionLabels::iosCapability($capability) }}
+                                </li>
+                            @endforeach
+                        </ul>
+                        <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
+                            Declared by the plugin author and applied to your app at build time.
+                        </p>
+                    </div>
+                @endif
+
+                {{-- Version history --}}
+                @if ($versionHistory->isNotEmpty())
+                    <div
+                        x-data="{ open: false }"
+                        class="mt-4 rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-slate-800/50"
+                    >
+                        <button
+                            type="button"
+                            x-on:click="open = !open"
+                            :aria-expanded="open"
+                            class="flex w-full items-center justify-between gap-2 text-left"
+                        >
+                            <span class="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Version History
+                            </span>
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke-width="2"
+                                stroke="currentColor"
+                                class="size-4 shrink-0 text-gray-400 transition-transform duration-200"
+                                :class="{ 'rotate-180': open }"
+                                aria-hidden="true"
+                            >
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                            </svg>
+                        </button>
+
+                        <div x-show="open" x-collapse x-cloak class="mt-4 space-y-4">
+                            @foreach ($versionHistory as $version)
+                                <div class="border-l-2 border-gray-200 pl-3 dark:border-gray-700">
+                                    <div class="flex items-baseline gap-2">
+                                        <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ $version->version }}</span>
+                                        @if ($version->published_at)
+                                            <span class="text-xs text-gray-500 dark:text-gray-400">{{ $version->published_at->format('M j, Y') }}</span>
+                                        @endif
+                                    </div>
+                                    @if ($version->release_notes_html)
+                                        <div class="prose prose-sm prose-gallery mt-1 max-w-none text-gray-600 dark:text-gray-400">
+                                            {!! $version->release_notes_html !!}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
             </aside>
         </div>
     </section>

--- a/tests/Feature/CommonMarkSanitizationTest.php
+++ b/tests/Feature/CommonMarkSanitizationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\CommonMark\CommonMark;
+use Tests\TestCase;
+
+class CommonMarkSanitizationTest extends TestCase
+{
+    public function test_it_neutralizes_a_raw_script_tag(): void
+    {
+        $html = CommonMark::convertToHtml("Look at this:\n\n<script>alert('xss')</script>");
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script>', $html);
+    }
+
+    public function test_it_neutralizes_an_inline_script_tag(): void
+    {
+        $html = CommonMark::convertToHtml('Inline <script>alert(1)</script> markup.');
+
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    public function test_it_neutralizes_a_style_tag(): void
+    {
+        $html = CommonMark::convertToHtml('<style>body { display: none; }</style>');
+
+        $this->assertStringNotContainsString('<style>', $html);
+    }
+
+    public function test_it_still_renders_ordinary_markdown_formatting(): void
+    {
+        $html = CommonMark::convertToHtml('**Fixed** a crash on launch.');
+
+        $this->assertStringContainsString('<strong>Fixed</strong>', $html);
+    }
+}

--- a/tests/Feature/Filament/PluginVersionsRelationManagerTest.php
+++ b/tests/Feature/Filament/PluginVersionsRelationManagerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\PluginResource\Pages\EditPlugin;
+use App\Filament\Resources\PluginResource\RelationManagers\VersionsRelationManager;
+use App\Models\Plugin;
+use App\Models\PluginVersion;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PluginVersionsRelationManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private Plugin $plugin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->create(['email' => 'admin@test.com']);
+        config(['filament.users' => ['admin@test.com']]);
+
+        $this->plugin = Plugin::factory()->approved()->create();
+    }
+
+    public function test_it_lists_versions_for_the_plugin(): void
+    {
+        PluginVersion::create([
+            'plugin_id' => $this->plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(VersionsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->assertSuccessful()
+            ->assertCountTableRecords(1);
+    }
+
+    public function test_approve_action_clears_the_review_flag_and_advances_latest_version(): void
+    {
+        $version = PluginVersion::create([
+            'plugin_id' => $this->plugin->id,
+            'version' => '2.0.0',
+            'tag_name' => 'v2.0.0',
+            'github_release_id' => '2',
+            'published_at' => now(),
+            'permissions_expanded' => true,
+            'requires_review' => true,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(VersionsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->callTableAction('approve', $version);
+
+        $version->refresh();
+        $this->plugin->refresh();
+
+        $this->assertFalse($version->requires_review);
+        $this->assertEquals($this->admin->id, $version->approved_by);
+        $this->assertNotNull($version->approved_at);
+        $this->assertEquals('2.0.0', $this->plugin->latest_version);
+    }
+
+    public function test_approve_action_is_hidden_for_versions_that_do_not_require_review(): void
+    {
+        $version = PluginVersion::create([
+            'plugin_id' => $this->plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+            'requires_review' => false,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(VersionsRelationManager::class, [
+                'ownerRecord' => $this->plugin,
+                'pageClass' => EditPlugin::class,
+            ])
+            ->assertTableActionHidden('approve', $version);
+    }
+}

--- a/tests/Feature/Jobs/ReviewPluginRepositoryTest.php
+++ b/tests/Feature/Jobs/ReviewPluginRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Jobs;
 
 use App\Jobs\ReviewPluginRepository;
 use App\Models\Plugin;
+use App\Services\PluginManifestParser;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -62,7 +63,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['supports_ios']);
         $this->assertTrue($checks['supports_android']);
@@ -80,7 +81,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['supports_ios']);
         $this->assertFalse($checks['supports_android']);
@@ -99,7 +100,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'resources/android', 'type' => 'tree'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['supports_ios']);
         $this->assertFalse($checks['supports_android']);
@@ -117,7 +118,7 @@ class ReviewPluginRepositoryTest extends TestCase
             'nativephp/mobile' => '^3.0.0',
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['requires_mobile_sdk']);
         $this->assertEquals('^3.0.0', $checks['mobile_sdk_constraint']);
@@ -132,7 +133,7 @@ class ReviewPluginRepositoryTest extends TestCase
 
         Http::fake($this->fakeGitHub('acme/no-sdk-plugin', composerRequire: ['php' => '^8.1']));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['requires_mobile_sdk']);
         $this->assertNull($checks['mobile_sdk_constraint']);
@@ -150,7 +151,7 @@ class ReviewPluginRepositoryTest extends TestCase
             'android' => ['min_version' => '24'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_ios_min_version']);
         $this->assertEquals('16.0', $checks['ios_min_version']);
@@ -167,7 +168,7 @@ class ReviewPluginRepositoryTest extends TestCase
 
         Http::fake($this->fakeGitHub('acme/no-manifest-plugin'));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['has_ios_min_version']);
         $this->assertNull($checks['ios_min_version']);
@@ -186,7 +187,7 @@ class ReviewPluginRepositoryTest extends TestCase
             'ios' => ['min_version' => '15.0'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_ios_min_version']);
         $this->assertEquals('15.0', $checks['ios_min_version']);
@@ -209,7 +210,7 @@ class ReviewPluginRepositoryTest extends TestCase
         $this->assertNull($plugin->reviewed_at);
         $this->assertNull($plugin->review_checks);
 
-        (new ReviewPluginRepository($plugin))->handle();
+        (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $plugin->refresh();
 
@@ -227,7 +228,7 @@ class ReviewPluginRepositoryTest extends TestCase
             'repository_url' => null,
         ]);
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['has_license_file']);
         $this->assertFalse($checks['has_release_version']);
@@ -250,7 +251,7 @@ class ReviewPluginRepositoryTest extends TestCase
             defaultBranch: 'master',
         ));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['supports_ios']);
         $this->assertTrue($checks['supports_android']);
@@ -271,7 +272,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_license_file']);
     }
@@ -288,7 +289,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_license_file']);
     }
@@ -304,7 +305,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'src/ServiceProvider.php', 'type' => 'blob'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['has_license_file']);
     }
@@ -320,7 +321,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ['path' => 'LICENSE', 'type' => 'tree'],
         ]));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['has_license_file']);
     }
@@ -334,7 +335,7 @@ class ReviewPluginRepositoryTest extends TestCase
 
         Http::fake($this->fakeGitHub('acme/released-plugin', latestRelease: 'v1.0.0'));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_release_version']);
         $this->assertEquals('v1.0.0', $checks['release_version']);
@@ -359,7 +360,7 @@ class ReviewPluginRepositoryTest extends TestCase
             ]
         ));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertTrue($checks['has_release_version']);
         $this->assertEquals('v0.5.0', $checks['release_version']);
@@ -374,9 +375,68 @@ class ReviewPluginRepositoryTest extends TestCase
 
         Http::fake($this->fakeGitHub('acme/unreleased-plugin'));
 
-        $checks = (new ReviewPluginRepository($plugin))->handle();
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
 
         $this->assertFalse($checks['has_release_version']);
         $this->assertNull($checks['release_version']);
+    }
+
+    /** @test */
+    public function it_flags_android_permissions_missing_a_matching_ios_usage_description(): void
+    {
+        $plugin = Plugin::factory()->create([
+            'repository_url' => 'https://github.com/acme/camera-plugin',
+        ]);
+
+        Http::fake($this->fakeGitHub('acme/camera-plugin', tree: [
+            ['path' => 'resources/ios/Plugin.swift', 'type' => 'blob'],
+        ], nativephpJson: [
+            'android' => ['permissions' => ['android.permission.CAMERA']],
+        ]));
+
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
+
+        $this->assertFalse($checks['permission_parity_complete']);
+        $this->assertSame('android.permission.CAMERA', $checks['missing_permission_parity'][0]['permission']);
+        $this->assertSame('NSCameraUsageDescription', $checks['missing_permission_parity'][0]['expected_key']);
+    }
+
+    /** @test */
+    public function it_passes_permission_parity_when_the_usage_description_is_declared(): void
+    {
+        $plugin = Plugin::factory()->create([
+            'repository_url' => 'https://github.com/acme/camera-plugin-ok',
+        ]);
+
+        Http::fake($this->fakeGitHub('acme/camera-plugin-ok', tree: [
+            ['path' => 'resources/ios/Plugin.swift', 'type' => 'blob'],
+        ], nativephpJson: [
+            'android' => ['permissions' => ['android.permission.CAMERA']],
+            'ios' => ['info_plist' => ['NSCameraUsageDescription' => 'Used to scan documents.']],
+        ]));
+
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
+
+        $this->assertTrue($checks['permission_parity_complete']);
+        $this->assertSame([], $checks['missing_permission_parity']);
+    }
+
+    /** @test */
+    public function it_skips_permission_parity_for_android_only_plugins(): void
+    {
+        $plugin = Plugin::factory()->create([
+            'repository_url' => 'https://github.com/acme/android-only-plugin',
+        ]);
+
+        Http::fake($this->fakeGitHub('acme/android-only-plugin', tree: [
+            ['path' => 'resources/android/Plugin.kt', 'type' => 'blob'],
+        ], nativephpJson: [
+            'android' => ['permissions' => ['android.permission.CAMERA']],
+        ]));
+
+        $checks = (new ReviewPluginRepository($plugin))->handle(new PluginManifestParser);
+
+        $this->assertTrue($checks['permission_parity_complete']);
+        $this->assertSame([], $checks['missing_permission_parity']);
     }
 }

--- a/tests/Feature/Jobs/SyncPluginReleasesTest.php
+++ b/tests/Feature/Jobs/SyncPluginReleasesTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Jobs;
 use App\Jobs\SyncPluginReleases;
 use App\Models\Plugin;
 use App\Models\PluginVersion;
+use App\Services\PluginManifestParser;
 use App\Services\SatisService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -44,7 +45,7 @@ class SyncPluginReleasesTest extends TestCase
         $satisService = $this->mock(SatisService::class);
 
         $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
-        $job->handle($satisService);
+        $job->handle($satisService, new PluginManifestParser);
 
         $plugin->refresh();
 
@@ -84,10 +85,149 @@ class SyncPluginReleasesTest extends TestCase
         $satisService = $this->mock(SatisService::class);
 
         $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
-        $job->handle($satisService);
+        $job->handle($satisService, new PluginManifestParser);
 
         $plugin->refresh();
 
+        $this->assertEquals('1.0.0', $plugin->latest_version);
+    }
+
+    public function test_it_stores_manifest_permissions_from_the_release_tags_nativephp_json(): void
+    {
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/releases*' => Http::response([
+                [
+                    'id' => 1,
+                    'tag_name' => 'v1.0.0',
+                    'body' => 'Initial release',
+                    'target_commitish' => 'abc123',
+                    'published_at' => '2026-01-01T00:00:00Z',
+                ],
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json*' => Http::response([
+                'content' => base64_encode(json_encode([
+                    'android' => ['permissions' => ['android.permission.CAMERA']],
+                ])),
+                'encoding' => 'base64',
+            ]),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        $satisService = $this->mock(SatisService::class);
+
+        $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
+        $job->handle($satisService, new PluginManifestParser);
+
+        $version = $plugin->versions()->first();
+
+        $this->assertSame(['android.permission.CAMERA'], $version->manifest_permissions['android_permissions']);
+        $this->assertFalse($version->permissions_expanded);
+        $this->assertFalse($version->requires_review);
+    }
+
+    public function test_it_flags_permission_expansion_and_still_publishes_in_flag_mode(): void
+    {
+        config(['plugins.permission_expansion_mode' => 'flag']);
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/releases*' => Http::response([
+                [
+                    'id' => 2,
+                    'tag_name' => 'v2.0.0',
+                    'body' => 'Adds camera support',
+                    'target_commitish' => 'def456',
+                    'published_at' => '2026-02-01T00:00:00Z',
+                ],
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json*' => Http::response([
+                'content' => base64_encode(json_encode([
+                    'android' => ['permissions' => ['android.permission.CAMERA']],
+                ])),
+                'encoding' => 'base64',
+            ]),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+        ]);
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => '2026-01-01T00:00:00Z',
+            'manifest_permissions' => ['android_permissions' => []],
+        ]);
+
+        $satisService = $this->mock(SatisService::class);
+
+        $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
+        $job->handle($satisService, new PluginManifestParser);
+
+        $plugin->refresh();
+        $newVersion = $plugin->versions()->where('tag_name', 'v2.0.0')->first();
+
+        $this->assertTrue($newVersion->permissions_expanded);
+        $this->assertFalse($newVersion->requires_review);
+        $this->assertEquals('2.0.0', $plugin->latest_version);
+        $this->assertDatabaseHas('plugin_activities', [
+            'plugin_id' => $plugin->id,
+            'type' => 'permissions_expanded',
+        ]);
+    }
+
+    public function test_it_gates_expanded_permissions_and_withholds_latest_version_in_gate_mode(): void
+    {
+        config(['plugins.permission_expansion_mode' => 'gate']);
+
+        Http::fake([
+            'api.github.com/repos/acme/test-plugin/releases*' => Http::response([
+                [
+                    'id' => 2,
+                    'tag_name' => 'v2.0.0',
+                    'body' => 'Adds camera support',
+                    'target_commitish' => 'def456',
+                    'published_at' => '2026-02-01T00:00:00Z',
+                ],
+            ]),
+            'api.github.com/repos/acme/test-plugin/contents/nativephp.json*' => Http::response([
+                'content' => base64_encode(json_encode([
+                    'android' => ['permissions' => ['android.permission.CAMERA']],
+                ])),
+                'encoding' => 'base64',
+            ]),
+        ]);
+
+        $plugin = Plugin::factory()->create([
+            'name' => 'acme/test-plugin',
+            'repository_url' => 'https://github.com/acme/test-plugin',
+            'latest_version' => '1.0.0',
+        ]);
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => '2026-01-01T00:00:00Z',
+            'manifest_permissions' => ['android_permissions' => []],
+        ]);
+
+        $satisService = $this->mock(SatisService::class);
+
+        $job = new SyncPluginReleases($plugin, triggerSatisBuild: false);
+        $job->handle($satisService, new PluginManifestParser);
+
+        $plugin->refresh();
+        $newVersion = $plugin->versions()->where('tag_name', 'v2.0.0')->first();
+
+        $this->assertTrue($newVersion->requires_review);
         $this->assertEquals('1.0.0', $plugin->latest_version);
     }
 }

--- a/tests/Feature/PluginOgImageTest.php
+++ b/tests/Feature/PluginOgImageTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Jobs\GeneratePluginOgImage;
 use App\Models\Plugin;
+use App\Services\PluginManifestParser;
 use App\Services\PluginOgLayout;
 use App\Services\PluginSyncService;
 use App\Services\SatisService;
@@ -58,7 +59,7 @@ class PluginOgImageTest extends TestCase
             'repository_url' => 'https://github.com/acme/test-plugin',
         ]);
 
-        (new PluginSyncService)->sync($plugin);
+        (new PluginSyncService(new PluginManifestParser))->sync($plugin);
 
         Queue::assertPushed(GeneratePluginOgImage::class, fn (GeneratePluginOgImage $job) => $job->plugin->is($plugin));
     }

--- a/tests/Feature/PluginPermissionAndChangelogDisplayTest.php
+++ b/tests/Feature/PluginPermissionAndChangelogDisplayTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Features\ShowPlugins;
+use App\Models\Plugin;
+use App\Models\PluginVersion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class PluginPermissionAndChangelogDisplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Feature::define(ShowPlugins::class, true);
+    }
+
+    public function test_it_shows_declared_permissions_from_the_latest_visible_version(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+            'manifest_permissions' => [
+                'android_permissions' => ['android.permission.CAMERA'],
+                'ios_background_modes' => ['fetch'],
+            ],
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertSee('What This Plugin Can Access');
+        $response->assertSee('Camera');
+        $response->assertSee('Background Fetch');
+    }
+
+    public function test_it_does_not_show_the_permission_panel_when_nothing_is_declared(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+            'manifest_permissions' => ['android_permissions' => []],
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertDontSee('What This Plugin Can Access');
+    }
+
+    public function test_a_version_pending_review_is_not_used_for_the_permission_panel(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+            'manifest_permissions' => ['android_permissions' => ['android.permission.CAMERA']],
+        ]);
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '2.0.0',
+            'tag_name' => 'v2.0.0',
+            'github_release_id' => '2',
+            'published_at' => now()->addDay(),
+            'manifest_permissions' => ['android_permissions' => ['android.permission.CAMERA', 'android.permission.ACCESS_FINE_LOCATION']],
+            'requires_review' => true,
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertSee('Camera');
+        $response->assertDontSee('Precise Location');
+    }
+
+    public function test_it_shows_version_history_with_rendered_release_notes(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '1.0.0',
+            'tag_name' => 'v1.0.0',
+            'github_release_id' => '1',
+            'published_at' => now(),
+            'release_notes' => '**Fixed** a crash on launch.',
+            'release_notes_html' => '<p><strong>Fixed</strong> a crash on launch.</p>',
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertSee('Version History');
+        $response->assertSee('<strong>Fixed</strong> a crash on launch.', false);
+    }
+
+    public function test_version_history_excludes_versions_pending_review(): void
+    {
+        $plugin = Plugin::factory()->approved()->create();
+
+        PluginVersion::create([
+            'plugin_id' => $plugin->id,
+            'version' => '2.0.0',
+            'tag_name' => 'v2.0.0',
+            'github_release_id' => '2',
+            'published_at' => now(),
+            'release_notes_html' => '<p>Secret unreleased notes.</p>',
+            'requires_review' => true,
+        ]);
+
+        $response = $this->get(route('plugins.show', $plugin->routeParams()));
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Secret unreleased notes.');
+    }
+}

--- a/tests/Feature/PluginSyncServiceTest.php
+++ b/tests/Feature/PluginSyncServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Plugin;
+use App\Services\PluginManifestParser;
 use App\Services\PluginSyncService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
@@ -46,7 +47,7 @@ class PluginSyncServiceTest extends TestCase
             'mobile_min_version' => null,
         ]);
 
-        $service = new PluginSyncService;
+        $service = new PluginSyncService(new PluginManifestParser);
         $result = $service->sync($plugin);
 
         $this->assertTrue($result);
@@ -75,7 +76,7 @@ class PluginSyncServiceTest extends TestCase
             'repository_url' => 'https://github.com/acme/test-plugin',
         ]);
 
-        $service = new PluginSyncService;
+        $service = new PluginSyncService(new PluginManifestParser);
         $result = $service->sync($plugin);
 
         $this->assertTrue($result);
@@ -104,7 +105,7 @@ class PluginSyncServiceTest extends TestCase
             'repository_url' => 'https://github.com/acme/test-plugin',
         ]);
 
-        $service = new PluginSyncService;
+        $service = new PluginSyncService(new PluginManifestParser);
         $result = $service->sync($plugin);
 
         $this->assertTrue($result);
@@ -135,7 +136,7 @@ class PluginSyncServiceTest extends TestCase
             'repository_url' => 'https://github.com/acme/test-plugin',
         ]);
 
-        $service = new PluginSyncService;
+        $service = new PluginSyncService(new PluginManifestParser);
         $result = $service->sync($plugin);
 
         $this->assertTrue($result);
@@ -168,7 +169,7 @@ class PluginSyncServiceTest extends TestCase
             'mobile_min_version' => '^2.0.0',
         ]);
 
-        $service = new PluginSyncService;
+        $service = new PluginSyncService(new PluginManifestParser);
         $result = $service->sync($plugin);
 
         $this->assertTrue($result);

--- a/tests/Unit/PluginManifestParserTest.php
+++ b/tests/Unit/PluginManifestParserTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\PluginManifestParser;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PluginManifestParserTest extends TestCase
+{
+    private PluginManifestParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parser = new PluginManifestParser;
+    }
+
+    #[Test]
+    public function sdk_constraint_reads_from_composer_require(): void
+    {
+        $this->assertSame('^2.0', $this->parser->sdkConstraint(['require' => ['nativephp/mobile' => '^2.0']]));
+        $this->assertNull($this->parser->sdkConstraint(['require' => []]));
+        $this->assertNull($this->parser->sdkConstraint(null));
+    }
+
+    #[Test]
+    public function min_versions_read_from_nativephp_json(): void
+    {
+        $data = ['ios' => ['min_version' => '18.0'], 'android' => ['min_version' => 29]];
+
+        $this->assertSame('18.0', $this->parser->iosMinVersion($data));
+        $this->assertSame('29', $this->parser->androidMinVersion($data));
+        $this->assertNull($this->parser->iosMinVersion(null));
+        $this->assertNull($this->parser->androidMinVersion(null));
+    }
+
+    #[Test]
+    public function permission_manifest_extracts_the_relevant_subset(): void
+    {
+        $manifest = $this->parser->permissionManifest([
+            'android' => [
+                'permissions' => ['android.permission.CAMERA'],
+                'features' => [['name' => 'android.hardware.camera', 'required' => true]],
+            ],
+            'ios' => [
+                'capabilities' => ['push-notifications'],
+                'entitlements' => ['com.apple.developer.healthkit' => true],
+                'background_modes' => ['fetch'],
+                'info_plist' => ['NSCameraUsageDescription' => 'Used for scanning.'],
+            ],
+        ]);
+
+        $this->assertSame(['android.permission.CAMERA'], $manifest['android_permissions']);
+        $this->assertSame(['push-notifications'], $manifest['ios_capabilities']);
+        $this->assertSame(['fetch'], $manifest['ios_background_modes']);
+        $this->assertArrayHasKey('com.apple.developer.healthkit', $manifest['ios_entitlements']);
+    }
+
+    #[Test]
+    public function permission_manifest_defaults_to_empty_arrays_when_manifest_is_missing(): void
+    {
+        $manifest = $this->parser->permissionManifest(null);
+
+        $this->assertSame([], $manifest['android_permissions']);
+        $this->assertSame([], $manifest['ios_capabilities']);
+    }
+
+    #[Test]
+    public function missing_usage_descriptions_flags_unmatched_android_permissions_when_ios_is_supported(): void
+    {
+        $manifest = $this->parser->permissionManifest([
+            'android' => ['permissions' => ['android.permission.CAMERA', 'android.permission.INTERNET']],
+        ]);
+
+        $missing = $this->parser->missingUsageDescriptions($manifest, supportsIos: true);
+
+        $this->assertCount(1, $missing);
+        $this->assertSame('android.permission.CAMERA', $missing[0]['permission']);
+        $this->assertSame('NSCameraUsageDescription', $missing[0]['expected_key']);
+    }
+
+    #[Test]
+    public function missing_usage_descriptions_is_empty_when_the_key_is_declared(): void
+    {
+        $manifest = $this->parser->permissionManifest([
+            'android' => ['permissions' => ['android.permission.CAMERA']],
+            'ios' => ['info_plist' => ['NSCameraUsageDescription' => 'Used for scanning.']],
+        ]);
+
+        $this->assertSame([], $this->parser->missingUsageDescriptions($manifest, supportsIos: true));
+    }
+
+    #[Test]
+    public function missing_usage_descriptions_is_skipped_when_the_plugin_does_not_support_ios(): void
+    {
+        $manifest = $this->parser->permissionManifest([
+            'android' => ['permissions' => ['android.permission.CAMERA']],
+        ]);
+
+        $this->assertSame([], $this->parser->missingUsageDescriptions($manifest, supportsIos: false));
+    }
+
+    #[Test]
+    public function has_expanded_permissions_is_false_with_no_previous_version(): void
+    {
+        $current = $this->parser->permissionManifest(['android' => ['permissions' => ['android.permission.CAMERA']]]);
+
+        $this->assertFalse($this->parser->hasExpandedPermissions(null, $current));
+    }
+
+    #[Test]
+    public function has_expanded_permissions_detects_a_new_android_permission(): void
+    {
+        $previous = $this->parser->permissionManifest([]);
+        $current = $this->parser->permissionManifest(['android' => ['permissions' => ['android.permission.CAMERA']]]);
+
+        $this->assertTrue($this->parser->hasExpandedPermissions($previous, $current));
+    }
+
+    #[Test]
+    public function has_expanded_permissions_detects_a_new_ios_entitlement(): void
+    {
+        $previous = $this->parser->permissionManifest([]);
+        $current = $this->parser->permissionManifest(['ios' => ['entitlements' => ['com.apple.developer.healthkit' => true]]]);
+
+        $this->assertTrue($this->parser->hasExpandedPermissions($previous, $current));
+    }
+
+    #[Test]
+    public function has_expanded_permissions_is_false_when_nothing_new_was_added(): void
+    {
+        $previous = $this->parser->permissionManifest(['android' => ['permissions' => ['android.permission.CAMERA']]]);
+        $current = $this->parser->permissionManifest(['android' => ['permissions' => ['android.permission.CAMERA']]]);
+
+        $this->assertFalse($this->parser->hasExpandedPermissions($previous, $current));
+    }
+
+    #[Test]
+    public function has_expanded_permissions_is_false_when_permissions_are_only_removed(): void
+    {
+        $previous = $this->parser->permissionManifest([
+            'android' => ['permissions' => ['android.permission.CAMERA', 'android.permission.RECORD_AUDIO']],
+        ]);
+        $current = $this->parser->permissionManifest(['android' => ['permissions' => ['android.permission.CAMERA']]]);
+
+        $this->assertFalse($this->parser->hasExpandedPermissions($previous, $current));
+    }
+}


### PR DESCRIPTION
## Summary
- Plugins now declare native permissions/entitlements/capabilities/background modes via `nativephp.json` (already a documented format, previously never parsed by this app) — captured per version so they can be diffed and displayed.
- When a new version expands what a plugin can access, it's logged on the plugin's activity timeline; `config('plugins.permission_expansion_mode')` can additionally gate the version behind admin approval before it becomes current/visible (default: log only).
- Admins get a Versions tab on the Plugin resource to inspect a version's declared permissions and approve gated ones.
- The existing review pipeline now flags Android permissions with no matching iOS `Info.plist` usage-description string — a common cause of App Store rejection that previously went unnoticed.
- Fixes three separate, never-reconciled code paths that each re-parsed composer.json/nativephp.json slightly differently (`ReviewPluginRepository`, `PluginSyncService`, and now `SyncPluginReleases`) by routing them all through one `PluginManifestParser`.
- The public plugin page now shows "What This Plugin Can Access" (sourced from the same manifest data) and a version history/changelog panel — both skip any version still pending admin review.

## Security fix included
While building the changelog panel, an automated review flagged that `CommonMark::convertToHtml()` (shared by README/license/release-notes rendering) is configured with `html_input => 'allow'` and outputs via `{!! !!}` with no sanitization — a plugin author could put a `<script>` tag in a GitHub release body or README and have it execute for every visitor. This affects existing README/license rendering too, not just this PR's new release-notes surface.

Added `league/commonmark`'s built-in `DisallowedRawHtmlExtension` (no new dependency) to neutralize `script`/`style`/`iframe`/etc. tags. This is a solid default but **not a complete fix** — it matches by tag name only, so an event-handler attribute on an otherwise-allowed tag (e.g. `<img onerror=...>`) still passes through. Fully closing that gap needs either a dedicated HTML sanitizer library or switching to `html_input => 'escape'`, both of which are separate decisions that affect how existing plugin READMEs render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)