### PR TITLE
Fix minimum PHP version in the v4 mobile docs

### DIFF
--- a/app/Livewire/ShowcaseSubmissionForm.php
+++ b/app/Livewire/ShowcaseSubmissionForm.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
 
 class ShowcaseSubmissionForm extends Component
@@ -152,7 +153,7 @@ class ShowcaseSubmissionForm extends Component
 
     /**
      * @param  array<int, string>  $existing
-     * @param  array<int, \Livewire\Features\SupportFileUploads\TemporaryUploadedFile>  $uploads
+     * @param  array<int, TemporaryUploadedFile>  $uploads
      * @return array<int, string>
      */
     protected function storeScreenshots(array $existing, array $uploads): array

--- a/resources/views/docs/mobile/4/getting-started/environment-setup.md
+++ b/resources/views/docs/mobile/4/getting-started/environment-setup.md
@@ -5,7 +5,7 @@ order: 100
 
 ## Requirements
 
-1. PHP 8.3+
+1. PHP 8.4+
 2. Laravel 11+
 
 If you don't already have PHP installed on your machine, the most painless way to get PHP up and running on Mac and

--- a/resources/views/docs/mobile/4/getting-started/upgrade-guide.md
+++ b/resources/views/docs/mobile/4/getting-started/upgrade-guide.md
@@ -6,8 +6,14 @@ order: 3
 ## Upgrading To 4.0 From 3.x
 
 v4's headline is [SuperNative](../architecture/super-native) — fully native UI. Most of the release is additive,
-but there is **one breaking change to your dependencies**: a handful of APIs that used to be separate plugins are
-now core built-ins.
+but there are **two breaking changes to your dependencies**: the minimum PHP version has gone up, and a handful of
+APIs that used to be separate plugins are now core built-ins.
+
+### PHP 8.4 is now the minimum
+
+v3 ran on PHP 8.3. `nativephp/mobile` v4 requires **PHP 8.4 or later**, so upgrade your CLI PHP before running
+`composer update` or Composer will refuse to resolve. See [Environment Setup](environment-setup) for the full
+list of requirements.
 
 ### Device, Dialog, File and System are now built in
 


### PR DESCRIPTION
`nativephp/mobile` v4 requires `"php": "^8.4"`, but the v4 environment setup page still listed PHP 8.3+, carried over from the v3 docs. v3 is correct as it stands (it's on `^8.3`), so only the v4 pages change here.

Also added a short section to the v4 upgrade guide. Going from 3.x to 4.0 on PHP 8.3 means `composer update` won't resolve, and the guide only mentioned the plugin conflict as a breaking change.

Checked both pages render and the relative link on the upgrade guide resolves. Docs tests pass.

One unrelated commit rides along: linting has been red on `main` since #475, and it was failing this PR too. It's straight `vendor/bin/pint` output on `app/Livewire/ShowcaseSubmissionForm.php` (docblock type imported instead of fully qualified). Happy to split it out if you'd rather keep this PR docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMWF3dousE6MmnUVfBs6Kh