### PR TITLE
Add totals to the Paid and Due to Seller columns in the admin

### DIFF
--- a/app/Filament/Resources/PluginPayoutResource.php
+++ b/app/Filament/Resources/PluginPayoutResource.php
@@ -132,11 +132,13 @@ class PluginPayoutResource extends Resource
                 Tables\Columns\TextColumn::make('gross_amount')
                     ->label('Paid')
                     ->formatStateUsing(fn (int $state): string => '$'.number_format($state / 100, 2))
+                    ->summarize(Tables\Columns\Summarizers\Sum::make('sum')->money('USD', divideBy: 100))
                     ->sortable(),
 
                 Tables\Columns\TextColumn::make('developer_amount')
                     ->label('Due to Seller')
                     ->formatStateUsing(fn (int $state): string => '$'.number_format($state / 100, 2))
+                    ->summarize(Tables\Columns\Summarizers\Sum::make('sum')->money('USD', divideBy: 100))
                     ->sortable(),
 
                 Tables\Columns\TextColumn::make('status')

--- a/app/Filament/Resources/ThirdPartySaleResource.php
+++ b/app/Filament/Resources/ThirdPartySaleResource.php
@@ -79,11 +79,13 @@ class ThirdPartySaleResource extends Resource
                 Tables\Columns\TextColumn::make('price_paid')
                     ->label('Paid')
                     ->formatStateUsing(fn (int $state): string => '$'.number_format($state / 100, 2))
+                    ->summarize(Tables\Columns\Summarizers\Sum::make('sum')->money('USD', divideBy: 100))
                     ->sortable(),
 
                 Tables\Columns\TextColumn::make('payout.developer_amount')
                     ->label('Due to Seller')
                     ->formatStateUsing(fn (?int $state): string => $state === null ? '—' : '$'.number_format($state / 100, 2))
+                    ->summarize(Tables\Columns\Summarizers\Sum::make('sum')->money('USD', divideBy: 100))
                     ->placeholder('—'),
 
                 Tables\Columns\TextColumn::make('payout_status')

--- a/tests/Feature/Filament/PluginPayoutResourceTest.php
+++ b/tests/Feature/Filament/PluginPayoutResourceTest.php
@@ -66,6 +66,29 @@ class PluginPayoutResourceTest extends TestCase
             ->assertSee('$14.00');
     }
 
+    public function test_list_page_totals_paid_and_due_to_seller(): void
+    {
+        PluginPayout::factory()->create([
+            'gross_amount' => 2000,
+            'platform_fee' => 600,
+            'developer_amount' => 1400,
+        ]);
+
+        PluginPayout::factory()->create([
+            'gross_amount' => 5000,
+            'platform_fee' => 1500,
+            'developer_amount' => 3500,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListPluginPayouts::class)
+            ->assertSuccessful()
+            ->assertTableColumnSummarySet('gross_amount', 'sum', 7000)
+            ->assertTableColumnSummarySet('developer_amount', 'sum', 4900)
+            ->assertSee('$70.00')
+            ->assertSee('$49.00');
+    }
+
     public function test_view_page_renders_successfully(): void
     {
         $payout = PluginPayout::factory()->failed()->create();

--- a/tests/Feature/Filament/ThirdPartySaleResourceTest.php
+++ b/tests/Feature/Filament/ThirdPartySaleResourceTest.php
@@ -122,6 +122,43 @@ class ThirdPartySaleResourceTest extends TestCase
             ->assertCanNotSeeTableRecords([$granted]);
     }
 
+    public function test_totals_paid_and_due_to_seller(): void
+    {
+        $plugin = $this->createThirdPartyPlugin();
+
+        $first = PluginLicense::factory()->create([
+            'plugin_id' => $plugin->id,
+            'price_paid' => 2000,
+        ]);
+        PluginPayout::factory()->create([
+            'plugin_license_id' => $first->id,
+            'developer_account_id' => $plugin->developer_account_id,
+            'gross_amount' => 2000,
+            'platform_fee' => 600,
+            'developer_amount' => 1400,
+        ]);
+
+        $second = PluginLicense::factory()->create([
+            'plugin_id' => $plugin->id,
+            'price_paid' => 5000,
+        ]);
+        PluginPayout::factory()->create([
+            'plugin_license_id' => $second->id,
+            'developer_account_id' => $plugin->developer_account_id,
+            'gross_amount' => 5000,
+            'platform_fee' => 1500,
+            'developer_amount' => 3500,
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(ListThirdPartySales::class)
+            ->assertSuccessful()
+            ->assertTableColumnSummarySet('price_paid', 'sum', 7000)
+            ->assertTableColumnSummarySet('payout.developer_amount', 'sum', 4900)
+            ->assertSee('$70.00')
+            ->assertSee('$49.00');
+    }
+
     public function test_filters_sales_missing_payouts(): void
     {
         $plugin = $this->createThirdPartyPlugin();


### PR DESCRIPTION
Adds a summary row under the table on two admin screens so you can see what the Paid and Due to Seller columns add up to without exporting anything.

Filament renders two summary lines: one for the current page and one for all matching records. Both respect whatever filters or search are active, so filtering by payout status or plugin gives you the total for that subset.

Changed screens:

- Payouts (`PluginPayoutResource`) — `gross_amount` and `developer_amount`
- Third-Party Sales (`ThirdPartySaleResource`) — `price_paid` and `payout.developer_amount`

The request just said "the Payouts sales screen" and both of those have columns with those exact labels, so I did both. Happy to drop one.

Amounts are stored in cents, so the summarizer uses `->money('USD', divideBy: 100)`. That produces the same output as the existing per-row `'$'.number_format($state / 100, 2)` formatting.

One thing worth a look: on Third-Party Sales the Due to Seller total only counts rows that actually have a payout. Sales showing "—" (payout missing) contribute nothing, so the two totals won't reconcile when there are missing payouts. That seemed right, but it's a judgement call.

Tests added to both resource test files covering the summed value and the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)