### PR TITLE
Fix Algolia DocSearch config after package update

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -170,9 +170,8 @@ const docsPathMatch = window.location.pathname.match(
 const docsearchOptions = {
     appId: 'ZNII9QZ8WI',
     apiKey: '9be495a1aaf367b47c873d30a8e7ccf5',
-    indexName: 'nativephp',
+    indices: ['nativephp'],
     insights: true,
-    debug: false,
     ...(docsPathMatch && {
         transformItems(items) {
             const prefix = `/docs/${docsPathMatch[1]}/${docsPathMatch[2]}/`


### PR DESCRIPTION
The DocSearch package was updated by dependabot in #473 which broke the config and the search functionality. This PR fixes the config. The `debug: false` was dropped intentionally, it isn't supported anymore.

The update does change the styling of the modal, but I don't think that's a big issue. See the screenshots of the before and after versions:

3.x
<img width="1558" height="823" alt="3.x" src="https://github.com/user-attachments/assets/a3d29aa6-1842-47cf-868f-8348abbc655c" />

5.x
<img width="1641" height="875" alt="5.x" src="https://github.com/user-attachments/assets/8cc2c71d-02eb-4c9b-87ec-af18a9948fc5" />
