### PR TITLE
Add AI synopsis to new company domain signup emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,6 @@ TURNSTILE_SECRET_KEY=
 # Optional comma-separated allow list of hostnames the challenge may be solved on.
 # Leave empty to rely on the widget's domain list in the Cloudflare dashboard.
 TURNSTILE_HOSTNAMES=
+
+# Laravel AI SDK (Anthropic) — used for new-company-domain signup synopses
+ANTHROPIC_API_KEY=

--- a/app/Ai/Agents/CompanyDomainAnalyst.php
+++ b/app/Ai/Agents/CompanyDomainAnalyst.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Ai\Agents;
+
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Attributes\Timeout;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[Provider('anthropic')]
+#[Model('claude-haiku-4-5-20251001')]
+#[MaxTokens(256)]
+#[Timeout(30)]
+class CompanyDomainAnalyst implements Agent
+{
+    use Promptable;
+
+    /**
+     * Get the instructions that the agent should follow.
+     */
+    public function instructions(): Stringable|string
+    {
+        return <<<'INSTRUCTIONS'
+        You write a brief signup briefing for NativePHP accounts (ops).
+
+        You receive a person's name, email, company email domain, and an optional
+        plain-text excerpt scraped from https://{domain}. You may also rely on
+        well-known public facts about the company or person (e.g. LinkedIn /
+        company site) when you are confident they are accurate.
+
+        Reply with ONLY 30–50 words of plain text covering:
+        1) what the company appears to do, and
+        2) who the person appears to be when public info allows.
+
+        Rules:
+        - State only facts you are confident about; otherwise stay general or omit.
+        - Do not invent URLs, titles, employers, or bios.
+        - No markdown, bullets, labels, or preamble — just the synopsis paragraph.
+        INSTRUCTIONS;
+    }
+}

--- a/app/Notifications/NewCompanyDomainRegistered.php
+++ b/app/Notifications/NewCompanyDomainRegistered.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\User;
+use App\Services\CompanyDomainSynopsisGenerator;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -27,12 +28,20 @@ class NewCompanyDomainRegistered extends Notification implements ShouldQueue
 
     public function toMail(object $notifiable): MailMessage
     {
-        return (new MailMessage)
+        $synopsis = app(CompanyDomainSynopsisGenerator::class)->generate($this->user, $this->domain);
+
+        $message = (new MailMessage)
             ->subject('New company domain: '.$this->domain)
             ->greeting('A new company domain just signed up.')
             ->line("**Domain:** {$this->domain}")
             ->line("**Name:** {$this->user->name}")
             ->line("**Email:** {$this->user->email}")
             ->line('**Signed up:** '.$this->user->created_at?->toDayDateTimeString());
+
+        if (filled($synopsis)) {
+            $message->line('**Synopsis:** '.$synopsis);
+        }
+
+        return $message;
     }
 }

--- a/app/Services/CompanyDomainSynopsisGenerator.php
+++ b/app/Services/CompanyDomainSynopsisGenerator.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Services;
+
+use App\Ai\Agents\CompanyDomainAnalyst;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+class CompanyDomainSynopsisGenerator
+{
+    public const SITE_TIMEOUT_SECONDS = 5;
+
+    public const SITE_EXCERPT_CHARS = 4000;
+
+    /**
+     * Build a 30–50 word AI synopsis for a newly registered company domain.
+     *
+     * Soft-fails: any HTTP/AI error returns null and logs a warning so signup
+     * and the basic accounts email are never blocked.
+     */
+    public function generate(User $user, string $domain): ?string
+    {
+        try {
+            $siteExcerpt = $this->fetchSiteExcerpt($domain);
+
+            $prompt = $this->buildPrompt($user, $domain, $siteExcerpt);
+
+            $response = CompanyDomainAnalyst::make()->prompt($prompt);
+            $synopsis = trim((string) $response);
+
+            if ($synopsis === '') {
+                Log::warning('Company domain synopsis empty', [
+                    'domain' => $domain,
+                    'user_id' => $user->id,
+                ]);
+
+                return null;
+            }
+
+            return $synopsis;
+        } catch (Throwable $e) {
+            report($e);
+
+            Log::warning('Company domain synopsis failed', [
+                'domain' => $domain,
+                'user_id' => $user->id,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ]);
+
+            return null;
+        }
+    }
+
+    public function fetchSiteExcerpt(string $domain): ?string
+    {
+        try {
+            $response = Http::timeout(self::SITE_TIMEOUT_SECONDS)
+                ->withHeaders([
+                    'User-Agent' => 'NativePHPCompanySynopsis/1.0',
+                    'Accept' => 'text/html,application/xhtml+xml',
+                ])
+                ->get('https://'.$domain);
+
+            if (! $response->successful()) {
+                Log::warning('Company domain site fetch unsuccessful', [
+                    'domain' => $domain,
+                    'status' => $response->status(),
+                ]);
+
+                return null;
+            }
+
+            return $this->htmlToExcerpt($response->body());
+        } catch (Throwable $e) {
+            Log::warning('Company domain site fetch failed', [
+                'domain' => $domain,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ]);
+
+            return null;
+        }
+    }
+
+    public function htmlToExcerpt(string $html): ?string
+    {
+        $html = preg_replace('/<script\b[^>]*>.*?<\/script>/is', ' ', $html) ?? $html;
+        $html = preg_replace('/<style\b[^>]*>.*?<\/style>/is', ' ', $html) ?? $html;
+        $html = preg_replace('/<noscript\b[^>]*>.*?<\/noscript>/is', ' ', $html) ?? $html;
+
+        $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = preg_replace('/\s+/u', ' ', $text) ?? $text;
+        $text = trim($text);
+
+        if ($text === '') {
+            return null;
+        }
+
+        return Str::limit($text, self::SITE_EXCERPT_CHARS, '');
+    }
+
+    public function buildPrompt(User $user, string $domain, ?string $siteExcerpt): string
+    {
+        $excerpt = filled($siteExcerpt)
+            ? $siteExcerpt
+            : '(no site excerpt available)';
+
+        return <<<PROMPT
+Write the signup synopsis for this registration.
+
+Name: {$user->name}
+Email: {$user->email}
+Domain: {$domain}
+Company site excerpt from https://{$domain}:
+{$excerpt}
+PROMPT;
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,0 +1,129 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default AI Provider Names
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the AI providers below should be the
+    | default for AI operations when no explicit provider is provided
+    | for the operation. This should be any provider defined below.
+    |
+    */
+
+    'default' => 'openai',
+    'default_for_images' => 'gemini',
+    'default_for_audio' => 'openai',
+    'default_for_transcription' => 'openai',
+    'default_for_embeddings' => 'openai',
+    'default_for_reranking' => 'cohere',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Caching
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure caching strategies for AI related operations
+    | such as embedding generation. You are free to adjust these values
+    | based on your application's available caching stores and needs.
+    |
+    */
+
+    'caching' => [
+        'embeddings' => [
+            'cache' => false,
+            'store' => env('CACHE_STORE', 'database'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI Providers
+    |--------------------------------------------------------------------------
+    |
+    | Below are each of your AI providers defined for this application. Each
+    | represents an AI provider and API key combination which can be used
+    | to perform tasks like text, image, and audio creation via agents.
+    |
+    */
+
+    'providers' => [
+        'anthropic' => [
+            'driver' => 'anthropic',
+            'key' => env('ANTHROPIC_API_KEY'),
+        ],
+
+        'azure' => [
+            'driver' => 'azure',
+            'key' => env('AZURE_OPENAI_API_KEY'),
+            'url' => env('AZURE_OPENAI_URL'),
+            'api_version' => env('AZURE_OPENAI_API_VERSION', '2024-10-21'),
+            'deployment' => env('AZURE_OPENAI_DEPLOYMENT', 'gpt-4o'),
+            'embedding_deployment' => env('AZURE_OPENAI_EMBEDDING_DEPLOYMENT', 'text-embedding-3-small'),
+        ],
+
+        'cohere' => [
+            'driver' => 'cohere',
+            'key' => env('COHERE_API_KEY'),
+        ],
+
+        'deepseek' => [
+            'driver' => 'deepseek',
+            'key' => env('DEEPSEEK_API_KEY'),
+        ],
+
+        'eleven' => [
+            'driver' => 'eleven',
+            'key' => env('ELEVENLABS_API_KEY'),
+        ],
+
+        'gemini' => [
+            'driver' => 'gemini',
+            'key' => env('GEMINI_API_KEY'),
+        ],
+
+        'groq' => [
+            'driver' => 'groq',
+            'key' => env('GROQ_API_KEY'),
+        ],
+
+        'jina' => [
+            'driver' => 'jina',
+            'key' => env('JINA_API_KEY'),
+        ],
+
+        'mistral' => [
+            'driver' => 'mistral',
+            'key' => env('MISTRAL_API_KEY'),
+        ],
+
+        'ollama' => [
+            'driver' => 'ollama',
+            'key' => env('OLLAMA_API_KEY', ''),
+            'url' => env('OLLAMA_BASE_URL', 'http://localhost:11434'),
+        ],
+
+        'openai' => [
+            'driver' => 'openai',
+            'key' => env('OPENAI_API_KEY'),
+        ],
+
+        'openrouter' => [
+            'driver' => 'openrouter',
+            'key' => env('OPENROUTER_API_KEY'),
+        ],
+
+        'voyageai' => [
+            'driver' => 'voyageai',
+            'key' => env('VOYAGEAI_API_KEY'),
+        ],
+
+        'xai' => [
+            'driver' => 'xai',
+            'key' => env('XAI_API_KEY'),
+        ],
+    ],
+
+];

--- a/tests/Feature/NewCompanyDomainRegistrationTest.php
+++ b/tests/Feature/NewCompanyDomainRegistrationTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Ai\Agents\CompanyDomainAnalyst;
 use App\Models\User;
 use App\Notifications\NewCompanyDomainRegistered;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
+use RuntimeException;
 use Tests\TestCase;
 
 class NewCompanyDomainRegistrationTest extends TestCase
@@ -74,5 +77,107 @@ class NewCompanyDomainRegistrationTest extends TestCase
         $response->assertRedirect(route('dashboard'));
 
         Notification::assertSentOnDemandTimes(NewCompanyDomainRegistered::class, 0);
+    }
+
+    public function test_accounts_email_includes_ai_synopsis_when_enrichment_succeeds(): void
+    {
+        Notification::fake();
+        config(['services.turnstile.secret_key' => null]);
+
+        Http::fake([
+            'acme.com/*' => Http::response(
+                '<html><head><title>Acme</title></head><body><h1>Acme Corp</h1><p>We build industrial widgets for manufacturers worldwide.</p></body></html>',
+                200
+            ),
+            'acme.com' => Http::response(
+                '<html><head><title>Acme</title></head><body><h1>Acme Corp</h1><p>We build industrial widgets for manufacturers worldwide.</p></body></html>',
+                200
+            ),
+        ]);
+
+        $synopsis = 'Acme Corp builds industrial widgets for manufacturers. Ada Lovelace appears to be an early registrant from that company domain.';
+
+        CompanyDomainAnalyst::fake([$synopsis]);
+
+        $response = $this->post('/register', $this->registrationPayload());
+
+        $response->assertRedirect(route('dashboard'));
+
+        Notification::assertSentOnDemandTimes(NewCompanyDomainRegistered::class, 1);
+
+        $notification = null;
+        $notifiable = null;
+
+        Notification::assertSentOnDemand(
+            NewCompanyDomainRegistered::class,
+            function (NewCompanyDomainRegistered $sent, array $channels, object $route) use (&$notification, &$notifiable): bool {
+                $notification = $sent;
+                $notifiable = $route;
+
+                return $route->routes['mail'] === 'accounts@nativephp.com'
+                    && $sent->domain === 'acme.com';
+            }
+        );
+
+        $mail = $notification->toMail($notifiable);
+
+        CompanyDomainAnalyst::assertPrompted(function ($prompt) {
+            return $prompt->contains('ada@acme.com')
+                && $prompt->contains('acme.com')
+                && $prompt->contains('industrial widgets');
+        });
+
+        $this->assertTrue(
+            collect($mail->introLines)->contains(
+                fn (string $line): bool => str_contains($line, '**Synopsis:** '.$synopsis)
+            )
+        );
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'acme.com'));
+    }
+
+    public function test_accounts_email_still_sent_when_ai_synopsis_fails(): void
+    {
+        Notification::fake();
+        config(['services.turnstile.secret_key' => null]);
+
+        Http::fake([
+            'acme.com/*' => Http::response('<html><body>Acme widgets</body></html>', 200),
+            'acme.com' => Http::response('<html><body>Acme widgets</body></html>', 200),
+        ]);
+
+        CompanyDomainAnalyst::fake(fn () => throw new RuntimeException('provider down'));
+
+        $response = $this->post('/register', $this->registrationPayload());
+
+        $response->assertRedirect(route('dashboard'));
+
+        $notification = null;
+        $notifiable = null;
+
+        Notification::assertSentOnDemand(
+            NewCompanyDomainRegistered::class,
+            function (NewCompanyDomainRegistered $sent, array $channels, object $route) use (&$notification, &$notifiable): bool {
+                $notification = $sent;
+                $notifiable = $route;
+
+                return $route->routes['mail'] === 'accounts@nativephp.com'
+                    && $sent->domain === 'acme.com';
+            }
+        );
+
+        $mail = $notification->toMail($notifiable);
+
+        $this->assertTrue(
+            collect($mail->introLines)->contains(
+                fn (string $line): bool => str_contains($line, '**Domain:** acme.com')
+            )
+        );
+
+        $this->assertTrue(
+            collect($mail->introLines)->doesntContain(
+                fn (string $line): bool => str_contains($line, '**Synopsis:**')
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- When the first user registers with a non-consumer email domain, the queued `NewCompanyDomainRegistered` mail to `accounts@nativephp.com` now optionally includes a **Synopsis:** line (30–50 words) covering what the company does and who the person is.
- Synopsis generation runs **inside the already-queued notification** (`toMail`), so signup stays fast. It fetches `https://{domain}` (short timeout, HTML stripped to a text excerpt), then prompts an Anthropic Haiku agent via Laravel AI (`CompanyDomainAnalyst`).
- Soft-fail: HTTP/AI errors are logged as warnings and the basic domain/name/email/time email still sends without a synopsis. Consumer domains and non-first users remain skipped.

## How it works
1. `NotifyAccountsOfNewCompanyDomain` unchanged (consumer skip + first-user-only).
2. Queued `NewCompanyDomainRegistered::toMail()` calls `CompanyDomainSynopsisGenerator`.
3. Generator fetches the company site excerpt → builds prompt (name/email/domain/excerpt) → `CompanyDomainAnalyst::make()->prompt(...)`.
4. Agent instructions: only confident public facts; no invented URLs; plain 30–50 word paragraph.

## Config / prod
- Published `config/ai.php` (laravel/ai). Anthropic key via `ANTHROPIC_API_KEY`.
- Added `ANTHROPIC_API_KEY=` to `.env.example`.
- **Prod needs `ANTHROPIC_API_KEY` set** (same as Bifrost). Without it, synopsis soft-fails and the basic email still goes out.
- Note: this app is on `laravel/ai` **v0.1.5**, so the agent uses `#[Provider('anthropic')]` (string). Bifrost’s newer SDK accepts `Lab::Anthropic` / `HasProviderOptions` for disabling thinking; that API is not available here yet.

## Tests
- Extended `NewCompanyDomainRegistrationTest`: synopsis included on success (Http + AI faked); email still sent when AI throws; gmail still skipped; first/second user behavior unchanged.
- `./vendor/bin/phpunit --filter NewCompanyDomainRegistrationTest` — 5 passed.

## Test plan
- [ ] Confirm staging/prod has `ANTHROPIC_API_KEY`
- [ ] Register a fresh company-domain user and verify accounts@ mail includes Synopsis when the site/AI succeed
- [ ] Break AI key or block outbound HTTP and confirm the basic accounts email still arrives
- [ ] Confirm gmail / second user on same domain still do not notify