### PR TITLE
Add Bifrost birthday banner to the site

### DIFF
--- a/resources/views/components/bifrost-birthday-banner.blade.php
+++ b/resources/views/components/bifrost-birthday-banner.blade.php
@@ -1,0 +1,71 @@
+<a
+    href="https://bifrost.nativephp.com/pricing?billing=yearly"
+    onclick="window.fathom?.trackEvent('bifrost_birthday_banner_click')"
+    data-site-banner
+    class="group relative z-30 flex flex-col flex-wrap items-center justify-center gap-x-3 gap-y-2.5 overflow-hidden bg-gradient-to-r from-pink-100 via-sky-50 to-indigo-100 px-5 py-3 select-none 3xs:flex-row dark:from-pink-950/50 dark:via-sky-950/50 dark:to-indigo-950/50"
+>
+    {{-- Label --}}
+    <div
+        class="flex items-center justify-center gap-3 transition duration-200 ease-in-out will-change-transform group-hover:-translate-x-0.5"
+    >
+        {{-- Icon --}}
+        <x-icons.party-popper
+            class="size-5 shrink-0 text-pink-600 dark:text-pink-400"
+            aria-hidden="true"
+        />
+
+        {{-- Text --}}
+        <div>
+            <style>
+                .bifrost-birthday-gradient-text {
+                    background-image: linear-gradient(
+                        90deg,
+                        var(--color-black) 0%,
+                        var(--color-pink-600) 35%,
+                        var(--color-black) 70%
+                    );
+                    background-size: 200% 100%;
+                    animation: bifrost-birthday-shine 2s linear infinite;
+                }
+                .dark .bifrost-birthday-gradient-text {
+                    background-image: linear-gradient(
+                        90deg,
+                        var(--color-white) 0%,
+                        var(--color-pink-400) 35%,
+                        var(--color-white) 70%
+                    );
+                }
+                @keyframes bifrost-birthday-shine {
+                    from {
+                        background-position: 200% center;
+                    }
+                    to {
+                        background-position: 0% center;
+                    }
+                }
+            </style>
+            <div
+                class="bifrost-birthday-gradient-text bg-clip-text tracking-tight text-pretty text-transparent sm:text-center"
+            >
+                <b>Bifrost turns 1!</b>
+                Get
+                <b>30% off</b>
+                annual plans with code
+            </div>
+        </div>
+    </div>
+
+    {{-- Discount code --}}
+    <span
+        class="shrink-0 rounded-md bg-white/70 px-2 py-0.5 font-mono text-sm font-bold tracking-wide text-pink-900 ring-1 ring-pink-200 dark:bg-white/10 dark:text-pink-100 dark:ring-white/10"
+    >
+        HAPPYBIRTHDAY
+    </span>
+
+    {{-- Arrow --}}
+    <div
+        class="transition duration-200 ease-in-out will-change-transform group-hover:translate-x-0.5"
+    >
+        <x-icons.right-arrow class="size-3 shrink-0" />
+    </div>
+</a>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -118,7 +118,7 @@
         "
         class="min-h-screen overflow-x-clip bg-white font-poppins antialiased selection:bg-black selection:text-[#b4a9ff] dark:bg-[#050714] dark:text-white"
     >
-        @if (now()->isBefore('2026-10-01T00:00:00Z'))
+        @if (now()->isBefore('2027-01-01T00:00:00Z'))
             <x-bifrost-birthday-banner />
         @else
             <x-newsletter-banner />

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -118,7 +118,11 @@
         "
         class="min-h-screen overflow-x-clip bg-white font-poppins antialiased selection:bg-black selection:text-[#b4a9ff] dark:bg-[#050714] dark:text-white"
     >
-        <x-newsletter-banner />
+        @if (now()->isBefore('2026-10-01T00:00:00Z'))
+            <x-bifrost-birthday-banner />
+        @else
+            <x-newsletter-banner />
+        @endif
 
         <x-navigation-bar />
 

--- a/tests/Feature/BifrostBirthdayBannerTest.php
+++ b/tests/Feature/BifrostBirthdayBannerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BifrostBirthdayBannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function the_banner_offers_the_birthday_discount_on_annual_bifrost_plans(): void
+    {
+        $this->blade('<x-bifrost-birthday-banner />')
+            ->assertSee('Bifrost turns 1!')
+            ->assertSee('30% off')
+            ->assertSee('HAPPYBIRTHDAY')
+            ->assertSee('https://bifrost.nativephp.com/pricing?billing=yearly', escape: false)
+            ->assertSee('bifrost_birthday_banner_click', escape: false);
+    }
+
+    #[Test]
+    public function the_homepage_carries_the_birthday_banner_instead_of_the_newsletter_offer_during_the_sale(): void
+    {
+        $this->travelTo(Carbon::parse('2026-09-30T23:59:59Z'));
+
+        $this->get('/')
+            ->assertOk()
+            ->assertSee('HAPPYBIRTHDAY')
+            ->assertDontSee('newsletter_banner_click', escape: false);
+    }
+
+    #[Test]
+    public function the_newsletter_offer_takes_the_banner_slot_back_once_the_sale_ends(): void
+    {
+        $this->travelTo(Carbon::parse('2026-10-01T00:00:00Z'));
+
+        $this->get('/')
+            ->assertOk()
+            ->assertDontSee('HAPPYBIRTHDAY')
+            ->assertSee('newsletter_banner_click', escape: false);
+    }
+}

--- a/tests/Feature/BifrostBirthdayBannerTest.php
+++ b/tests/Feature/BifrostBirthdayBannerTest.php
@@ -25,7 +25,7 @@ class BifrostBirthdayBannerTest extends TestCase
     #[Test]
     public function the_homepage_carries_the_birthday_banner_instead_of_the_newsletter_offer_during_the_sale(): void
     {
-        $this->travelTo(Carbon::parse('2026-09-30T23:59:59Z'));
+        $this->travelTo(Carbon::parse('2026-12-31T23:59:59Z'));
 
         $this->get('/')
             ->assertOk()
@@ -36,7 +36,7 @@ class BifrostBirthdayBannerTest extends TestCase
     #[Test]
     public function the_newsletter_offer_takes_the_banner_slot_back_once_the_sale_ends(): void
     {
-        $this->travelTo(Carbon::parse('2026-10-01T00:00:00Z'));
+        $this->travelTo(Carbon::parse('2027-01-01T00:00:00Z'));
 
         $this->get('/')
             ->assertOk()

--- a/tests/Feature/NewsletterSignupTest.php
+++ b/tests/Feature/NewsletterSignupTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -10,9 +11,16 @@ class NewsletterSignupTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * Bifrost's birthday sale borrows the site banner slot until the end of
+     * September 2026, so this checks the newsletter offer once the slot has
+     * been handed back. The swap is covered by BifrostBirthdayBannerTest.
+     */
     #[Test]
     public function the_site_banner_offers_the_discount_and_opens_the_signup_modal()
     {
+        $this->travelTo(Carbon::parse('2026-10-01T00:00:00Z'));
+
         $this->get('/')
             ->assertOk()
             ->assertSee('Celebrate')

--- a/tests/Feature/NewsletterSignupTest.php
+++ b/tests/Feature/NewsletterSignupTest.php
@@ -13,13 +13,13 @@ class NewsletterSignupTest extends TestCase
 
     /**
      * Bifrost's birthday sale borrows the site banner slot until the end of
-     * September 2026, so this checks the newsletter offer once the slot has
-     * been handed back. The swap is covered by BifrostBirthdayBannerTest.
+     * 2026, so this checks the newsletter offer once the slot has been handed
+     * back. The swap is covered by BifrostBirthdayBannerTest.
      */
     #[Test]
     public function the_site_banner_offers_the_discount_and_opens_the_signup_modal()
     {
-        $this->travelTo(Carbon::parse('2026-10-01T00:00:00Z'));
+        $this->travelTo(Carbon::parse('2027-01-01T00:00:00Z'));
 
         $this->get('/')
             ->assertOk()


### PR DESCRIPTION
Bifrost turned one, so this swaps the site banner for one advertising 30% off annual Bifrost plans with the code HAPPYBIRTHDAY. It links to Bifrost's pricing page with yearly billing selected.

The layout shows the birthday banner until 2026-10-01 00:00 UTC and then puts the newsletter banner back on its own, so nobody has to remember to revert it.

Things to look at:

- The end date is a placeholder. I couldn't find how long the code runs for, so if it's different, change the date in `layout.blade.php` and in the tests that travel to it.
- `NewsletterSignupTest` checked the homepage banner at the real date, which fails while the sale is on. It now travels to the day the sale ends. `BifrostBirthdayBannerTest` covers both sides of the switch.

Bifrost's own marketing site gets a matching banner in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)