### PR TITLE
Fix Admin MCP OAuth guest 500 (Route [login] not defined)

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,12 @@
 
 namespace App\Exceptions;
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Sentry\Laravel\Integration;
 use Throwable;
 
@@ -24,5 +29,33 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e): void {
             Integration::captureUnhandledException($e);
         });
+    }
+
+    /**
+     * Convert an authentication exception into a response.
+     *
+     * Passport's AuthorizationController throws AuthenticationException for guests.
+     * Laravel's default falls back to route('login'), which this app does not define
+     * at /login (customer login is customer.login; admin is filament.admin.auth.login).
+     *
+     * @param  Request  $request
+     * @return Response|JsonResponse|RedirectResponse
+     */
+    protected function unauthenticated($request, AuthenticationException $exception)
+    {
+        if ($this->shouldReturnJson($request, $exception)) {
+            return response()->json(['message' => $exception->getMessage()], 401);
+        }
+
+        if ($this->isOAuthAuthenticationRequest($request)) {
+            return redirect()->guest(route('filament.admin.auth.login'));
+        }
+
+        return redirect()->guest($exception->redirectTo($request) ?? route('customer.login'));
+    }
+
+    private function isOAuthAuthenticationRequest(Request $request): bool
+    {
+        return $request->is('oauth/*') || $request->routeIs('passport.*');
     }
 }

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -24,6 +24,8 @@ Route::get('/.well-known/oauth-protected-resource/mcp/oauth/admin', [McpOAuthCon
     ->name('mcp.oauth.admin.protected-resource');
 Route::get('/.well-known/oauth-authorization-server', [McpOAuthController::class, 'authorizationServer']);
 
+Route::redirect('/oauth/login', '/admin/login')->name('login');
+
 Route::prefix('oauth')->group(function (): void {
     Route::post('/register', RegisterClientController::class)->middleware('throttle:20,1');
     Route::post('/token', [AccessTokenController::class, 'issueToken'])

--- a/tests/Feature/Mcp/AdminMcpOAuthTest.php
+++ b/tests/Feature/Mcp/AdminMcpOAuthTest.php
@@ -89,6 +89,23 @@ class AdminMcpOAuthTest extends TestCase
         $this->assertContains('admin-search-support-tickets', $names);
     }
 
+    public function test_guest_authorize_redirects_to_admin_login_instead_of_500(): void
+    {
+        $client = $this->createMcpOAuthClient();
+        $parameters = $this->mcpOAuthAuthorizationParameters(
+            $client,
+            str_repeat('a', 64),
+            'mcp:admin',
+            $this->mcpAdminOAuthResource(),
+        );
+
+        $this->get('/oauth/authorize?'.http_build_query($parameters))
+            ->assertRedirect(route('filament.admin.auth.login'));
+
+        $this->assertSame(url('/oauth/login'), route('login'));
+        $this->get(route('login'))->assertRedirect('/admin/login');
+    }
+
     public function test_non_admins_cannot_approve_admin_mcp_scope(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- Override `Handler::unauthenticated` so OAuth guests redirect to Filament admin login (JSON still 401; other web guests keep `customer.login`)
- Register `Route::redirect('/oauth/login', '/admin/login')->name('login')` so `route('login')` resolves without stealing `/login`
- Feature test: guest `/oauth/authorize` redirects to `/admin/login` instead of 500

## Test plan
- [x] `php artisan test --filter=AdminMcpOAuthTest` (12 passed)
- [x] pint --dirty