### PR TITLE
Extend Admin MCP OAuth token lifetimes

### DIFF
--- a/app/Providers/McpOAuthServiceProvider.php
+++ b/app/Providers/McpOAuthServiceProvider.php
@@ -37,8 +37,8 @@ class McpOAuthServiceProvider extends ServiceProvider
             TokenAbility::AdminMcpServer->value => 'NativePHP site-admin MCP access (blog drafts, signups, support, plugins — no secrets)',
         ]);
         Passport::setDefaultScope([TokenAbility::AdminMcpServer->value]);
-        Passport::tokensExpireIn(CarbonInterval::hour());
-        Passport::refreshTokensExpireIn(CarbonInterval::days(30));
+        Passport::tokensExpireIn(CarbonInterval::days(30));
+        Passport::refreshTokensExpireIn(CarbonInterval::days(90));
         Passport::useAccessTokenEntity(McpAccessToken::class);
         Passport::authorizationView('mcp.authorize');
     }


### PR DESCRIPTION
## Summary
- `Passport::tokensExpireIn` → **30 days** (was 1 hour) for Admin MCP OAuth access tokens
- `Passport::refreshTokensExpireIn` → **90 days** (was 30) so refresh still outlives access
- Docs/tests had no hardcoded TTL assertions to update

## Test plan
- [x] `vendor/bin/pint --dirty`
- [x] `php artisan test tests/Feature/Mcp/AdminMcpOAuthTest.php` (19 passed)