### PR TITLE
Expand admin-sales-summary with Ultra + products breakdown

### DIFF
--- a/app/Mcp/Servers/AdminNativePhpServer.php
+++ b/app/Mcp/Servers/AdminNativePhpServer.php
@@ -43,7 +43,7 @@ class AdminNativePhpServer extends Server
         5. admin-get-blog-post / admin-list-blog-posts — inspect drafts and published posts.
         6. admin-list-signups / admin-search-users / admin-get-user — user support lookups.
         7. admin-list-companies / admin-get-company — email-domain company rollups.
-        8. admin-search-plugins / admin-sales-summary — marketplace/plugin ops (no secrets).
+        8. admin-search-plugins / admin-sales-summary — marketplace ops + attributable revenue (plugins, products, Ultra Cashier; no secrets).
         9. admin-search-support-tickets / admin-get-support-ticket — support summaries.
     MARKDOWN;
 

--- a/app/Mcp/Tools/Admin/AdminSalesSummary.php
+++ b/app/Mcp/Tools/Admin/AdminSalesSummary.php
@@ -6,9 +6,15 @@ use App\Mcp\Tools\Concerns\RequiresAdmin;
 use App\Models\License;
 use App\Models\Plugin;
 use App\Models\PluginLicense;
+use App\Models\ProductLicense;
+use App\Models\Sale;
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Laravel\Cashier\Subscription;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Attributes\Description;
@@ -17,11 +23,13 @@ use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('admin-sales-summary')]
-#[Description('Read-only sales/license summaries: plugin license revenue and NativePHP license counts. Never returns raw license keys or Stripe secrets.')]
+#[Description('Read-only attributable inbound revenue: Ultra (Cashier) subscriptions + plugin + first-party product sales from sales_view, plus Anystack NativePHP license counts. Never returns raw license keys or Stripe secrets.')]
 #[IsReadOnly]
 class AdminSalesSummary extends Tool
 {
     use RequiresAdmin;
+
+    private const BY_PRODUCT_LIMIT = 50;
 
     public function handle(Request $request): Response
     {
@@ -30,51 +38,39 @@ class AdminSalesSummary extends Tool
         }
 
         $validated = $request->validate([
-            'days' => ['nullable', 'integer', 'min:1', 'max:365'],
+            'days' => ['nullable', 'integer', 'min:1', 'max:3650'],
+            'all_time' => ['nullable', 'boolean'],
         ]);
 
-        $days = (int) ($validated['days'] ?? 30);
-        $since = now()->subDays($days);
+        $allTime = (bool) ($validated['all_time'] ?? false);
+        $days = $allTime ? null : (int) ($validated['days'] ?? 30);
+        $since = $allTime ? null : now()->subDays($days);
 
-        $pluginRevenue = PluginLicense::query()
-            ->where('purchased_at', '>=', $since)
-            ->selectRaw('currency, COUNT(*) as licenses_count, COALESCE(SUM(price_paid), 0) as revenue_cents')
-            ->groupBy('currency')
-            ->get()
-            ->map(fn ($row): array => [
-                'currency' => $row->currency,
-                'licenses_count' => (int) $row->licenses_count,
-                'revenue_cents' => (int) $row->revenue_cents,
-            ])
-            ->all();
+        $pluginPaid = $this->aggregatePluginLicenses($since, paidOnly: true);
+        $productPaid = $this->aggregateProductLicenses($since, paidOnly: true);
+        $pluginCompedCount = $this->countPluginComps($since);
+        $productCompedCount = $this->countProductComps($since);
 
-        $topPluginRows = PluginLicense::query()
-            ->where('purchased_at', '>=', $since)
-            ->select('plugin_id', DB::raw('COUNT(*) as licenses_count'), DB::raw('COALESCE(SUM(price_paid), 0) as revenue_cents'))
-            ->groupBy('plugin_id')
-            ->orderByDesc('licenses_count')
-            ->limit(10)
-            ->get();
+        $ultra = $this->ultraSummary($since);
 
-        $plugins = Plugin::query()
-            ->whereIn('id', $topPluginRows->pluck('plugin_id'))
-            ->get(['id', 'name', 'status'])
-            ->keyBy('id');
+        $breakdown = $this->buildBreakdown($pluginPaid, $productPaid, $ultra);
+        $totalRevenueCents = $this->sumPreferredCurrency($breakdown);
 
-        $topPlugins = $topPluginRows->map(function ($row) use ($plugins): array {
-            $plugin = $plugins->get($row->plugin_id);
+        $pluginRevenue = $pluginPaid->map(fn (array $row): array => [
+            'currency' => $row['currency'],
+            'licenses_count' => $row['sales_count'],
+            'revenue_cents' => $row['revenue_cents'],
+        ])->values()->all();
 
-            return [
-                'plugin_id' => $row->plugin_id,
-                'plugin' => $plugin?->name,
-                'status' => $plugin?->status?->value,
-                'licenses_count' => (int) $row->licenses_count,
-                'revenue_cents' => (int) $row->revenue_cents,
-            ];
-        })->all();
+        $topPlugins = $this->topPlugins($since);
+        $byProduct = $this->byProduct($since);
 
-        $nativeLicenses = License::query()
-            ->where('created_at', '>=', $since)
+        $nativeLicensesQuery = License::query();
+        if ($since !== null) {
+            $nativeLicensesQuery->where('created_at', '>=', $since);
+        }
+
+        $nativeLicenses = $nativeLicensesQuery
             ->selectRaw('policy_name, COUNT(*) as count')
             ->groupBy('policy_name')
             ->orderByDesc('count')
@@ -87,13 +83,357 @@ class AdminSalesSummary extends Tool
 
         return Response::text($this->toJson([
             'days' => $days,
-            'since' => $since->toIso8601String(),
+            'all_time' => $allTime,
+            'since' => $since?->toIso8601String(),
+            'total_revenue_cents' => $totalRevenueCents,
+            'breakdown' => $breakdown,
+            'by_product' => $byProduct,
             'plugin_license_revenue' => $pluginRevenue,
             'top_plugins' => $topPlugins,
+            'ultra' => $ultra,
             'nativephp_licenses_created' => $nativeLicenses,
             'active_nativephp_licenses' => License::query()->whereActive()->count(),
-            'note' => 'Amounts are in cents. License keys and Stripe secrets are intentionally omitted.',
+            'comped' => [
+                'plugin_count' => $pluginCompedCount,
+                'product_count' => $productCompedCount,
+                'ultra_active_count' => $ultra['active_comped_count'],
+            ],
+            'note' => implode(' ', [
+                'Amounts are in cents (prefer USD when summing total_revenue_cents across currencies).',
+                'sales_view unions plugin_licenses + product_licenses (one-time sales); paid revenue excludes is_comped / $0 rows (comps counted separately).',
+                'Ultra is Laravel Cashier subscriptions on Max/Ultra Stripe prices (plan key max, display name Ultra) — not an Anystack policy.',
+                'Ultra revenue_cents_in_window sums subscriptions.price_paid for Ultra subs created in the window with price_paid > 0; HandleInvoicePaidJob overwrites price_paid with the latest invoice total (not cumulative), so renewals do not create new rows and window revenue under-counts renewals — same limitation as Filament SubscriberIncomeChart.',
+                'License keys and Stripe secrets are intentionally omitted.',
+            ]),
         ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function ultraPayingPriceIds(): array
+    {
+        return array_values(array_filter([
+            config('subscriptions.plans.max.stripe_price_id'),
+            config('subscriptions.plans.max.stripe_price_id_monthly'),
+            config('subscriptions.plans.max.stripe_price_id_eap'),
+            config('subscriptions.plans.max.stripe_price_id_discounted'),
+        ]));
+    }
+
+    protected function ultraCompedPriceId(): ?string
+    {
+        $id = config('subscriptions.plans.max.stripe_price_id_comped');
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function allUltraPriceIds(): array
+    {
+        return array_values(array_filter([
+            ...$this->ultraPayingPriceIds(),
+            $this->ultraCompedPriceId(),
+        ]));
+    }
+
+    /**
+     * @param  Builder<Subscription>  $query
+     * @param  list<string>  $priceIds
+     * @return Builder<Subscription>
+     */
+    protected function whereHasUltraPrice(Builder $query, array $priceIds): Builder
+    {
+        if ($priceIds === []) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function (Builder $inner) use ($priceIds): void {
+            $inner->whereIn('stripe_price', $priceIds)
+                ->orWhereHas('items', fn (Builder $items) => $items->whereIn('stripe_price', $priceIds));
+        });
+    }
+
+    /**
+     * @return array{
+     *     active_count: int,
+     *     active_comped_count: int,
+     *     created_in_window: int,
+     *     paid_created_in_window: int,
+     *     revenue_cents_in_window: int,
+     *     currency: string,
+     *     caveat: string
+     * }
+     */
+    protected function ultraSummary(?CarbonInterface $since): array
+    {
+        $payingIds = $this->ultraPayingPriceIds();
+        $compedId = $this->ultraCompedPriceId();
+        $allIds = $this->allUltraPriceIds();
+
+        $activePaying = Subscription::query()
+            ->active()
+            ->where(function (Builder $q): void {
+                $q->where('is_comped', false)->orWhereNull('is_comped');
+            });
+        $this->whereHasUltraPrice($activePaying, $payingIds);
+
+        $activeCompedCount = 0;
+        if ($compedId) {
+            $activeComped = Subscription::query()->active();
+            $this->whereHasUltraPrice($activeComped, [$compedId]);
+            $activeCompedCount = $activeComped->count();
+        }
+
+        $createdQuery = Subscription::query();
+        $this->whereHasUltraPrice($createdQuery, $allIds);
+        if ($since !== null) {
+            $createdQuery->where('created_at', '>=', $since);
+        }
+        $createdInWindow = (clone $createdQuery)->count();
+
+        $revenueQuery = Subscription::query()
+            ->whereNotNull('price_paid')
+            ->where('price_paid', '>', 0)
+            ->where(function (Builder $q): void {
+                $q->where('is_comped', false)->orWhereNull('is_comped');
+            });
+        $this->whereHasUltraPrice($revenueQuery, $payingIds);
+        if ($since !== null) {
+            $revenueQuery->where('created_at', '>=', $since);
+        }
+        $revenueCents = (int) (clone $revenueQuery)->sum('price_paid');
+        $paidSalesCount = (clone $revenueQuery)->count();
+
+        return [
+            'active_count' => $activePaying->count(),
+            'active_comped_count' => $activeCompedCount,
+            'created_in_window' => $createdInWindow,
+            'paid_created_in_window' => $paidSalesCount,
+            'revenue_cents_in_window' => $revenueCents,
+            'currency' => 'USD',
+            'caveat' => 'price_paid is overwritten on each paid invoice (not cumulative); renewals do not add rows. Window revenue only includes Ultra/Max subs created in-range with price_paid > 0.',
+        ];
+    }
+
+    /**
+     * @return Collection<int, array{currency: string, sales_count: int, revenue_cents: int}>
+     */
+    protected function aggregatePluginLicenses(?CarbonInterface $since, bool $paidOnly): Collection
+    {
+        $query = PluginLicense::query();
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+        if ($paidOnly) {
+            $query->where('is_grandfathered', false)->where('price_paid', '>', 0);
+        }
+
+        return $query
+            ->selectRaw('currency, COUNT(*) as sales_count, COALESCE(SUM(price_paid), 0) as revenue_cents')
+            ->groupBy('currency')
+            ->get()
+            ->map(fn ($row): array => [
+                'currency' => $row->currency ?: 'USD',
+                'sales_count' => (int) $row->sales_count,
+                'revenue_cents' => (int) $row->revenue_cents,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array{currency: string, sales_count: int, revenue_cents: int}>
+     */
+    protected function aggregateProductLicenses(?CarbonInterface $since, bool $paidOnly): Collection
+    {
+        $query = ProductLicense::query();
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+        if ($paidOnly) {
+            $query->where('is_comped', false)->where('price_paid', '>', 0);
+        }
+
+        return $query
+            ->selectRaw('currency, COUNT(*) as sales_count, COALESCE(SUM(price_paid), 0) as revenue_cents')
+            ->groupBy('currency')
+            ->get()
+            ->map(fn ($row): array => [
+                'currency' => $row->currency ?: 'USD',
+                'sales_count' => (int) $row->sales_count,
+                'revenue_cents' => (int) $row->revenue_cents,
+            ]);
+    }
+
+    protected function countPluginComps(?CarbonInterface $since): int
+    {
+        $query = PluginLicense::query()->where(function (Builder $q): void {
+            $q->where('is_grandfathered', true)->orWhere('price_paid', '<=', 0);
+        });
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+
+        return $query->count();
+    }
+
+    protected function countProductComps(?CarbonInterface $since): int
+    {
+        $query = ProductLicense::query()->where(function (Builder $q): void {
+            $q->where('is_comped', true)->orWhere('price_paid', '<=', 0);
+        });
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+
+        return $query->count();
+    }
+
+    /**
+     * @param  Collection<int, array{currency: string, sales_count: int, revenue_cents: int}>  $pluginPaid
+     * @param  Collection<int, array{currency: string, sales_count: int, revenue_cents: int}>  $productPaid
+     * @param  array{revenue_cents_in_window: int, currency: string, caveat: string, created_in_window: int, paid_created_in_window: int}  $ultra
+     * @return list<array{source: string, revenue_cents: int, sales_count: int, currency: string, caveat?: string}>
+     */
+    protected function buildBreakdown(Collection $pluginPaid, Collection $productPaid, array $ultra): array
+    {
+        $rows = [];
+
+        foreach ($pluginPaid as $row) {
+            $rows[] = [
+                'source' => 'plugins',
+                'revenue_cents' => $row['revenue_cents'],
+                'sales_count' => $row['sales_count'],
+                'currency' => $row['currency'],
+            ];
+        }
+
+        if ($pluginPaid->isEmpty()) {
+            $rows[] = [
+                'source' => 'plugins',
+                'revenue_cents' => 0,
+                'sales_count' => 0,
+                'currency' => 'USD',
+            ];
+        }
+
+        foreach ($productPaid as $row) {
+            $rows[] = [
+                'source' => 'products',
+                'revenue_cents' => $row['revenue_cents'],
+                'sales_count' => $row['sales_count'],
+                'currency' => $row['currency'],
+            ];
+        }
+
+        if ($productPaid->isEmpty()) {
+            $rows[] = [
+                'source' => 'products',
+                'revenue_cents' => 0,
+                'sales_count' => 0,
+                'currency' => 'USD',
+            ];
+        }
+
+        $rows[] = [
+            'source' => 'ultra_subscriptions',
+            'revenue_cents' => $ultra['revenue_cents_in_window'],
+            'sales_count' => $ultra['paid_created_in_window'],
+            'currency' => $ultra['currency'],
+            'caveat' => $ultra['caveat'],
+        ];
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<array{source: string, revenue_cents: int, sales_count: int, currency: string}>  $breakdown
+     */
+    protected function sumPreferredCurrency(array $breakdown): int
+    {
+        $byCurrency = collect($breakdown)->groupBy('currency');
+
+        if ($byCurrency->has('USD')) {
+            return (int) $byCurrency->get('USD')->sum('revenue_cents');
+        }
+
+        if ($byCurrency->count() === 1) {
+            return (int) $byCurrency->first()->sum('revenue_cents');
+        }
+
+        return (int) collect($breakdown)->sum('revenue_cents');
+    }
+
+    /**
+     * @return list<array{plugin_id: int, plugin: ?string, status: ?string, licenses_count: int, revenue_cents: int}>
+     */
+    protected function topPlugins(?CarbonInterface $since): array
+    {
+        $query = PluginLicense::query()
+            ->where('is_grandfathered', false)
+            ->where('price_paid', '>', 0);
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+
+        $topPluginRows = $query
+            ->select('plugin_id', DB::raw('COUNT(*) as licenses_count'), DB::raw('COALESCE(SUM(price_paid), 0) as revenue_cents'))
+            ->groupBy('plugin_id')
+            ->orderByDesc('licenses_count')
+            ->limit(10)
+            ->get();
+
+        $plugins = Plugin::query()
+            ->whereIn('id', $topPluginRows->pluck('plugin_id'))
+            ->get(['id', 'name', 'status'])
+            ->keyBy('id');
+
+        return $topPluginRows->map(function ($row) use ($plugins): array {
+            $plugin = $plugins->get($row->plugin_id);
+
+            return [
+                'plugin_id' => $row->plugin_id,
+                'plugin' => $plugin?->name,
+                'status' => $plugin?->status?->value,
+                'licenses_count' => (int) $row->licenses_count,
+                'revenue_cents' => (int) $row->revenue_cents,
+            ];
+        })->all();
+    }
+
+    /**
+     * @return list<array{product_name: ?string, source: string, revenue_cents: int, sales_count: int, currency: string}>
+     */
+    protected function byProduct(?CarbonInterface $since): array
+    {
+        $query = Sale::query()
+            ->where(function (Builder $q): void {
+                $q->where('is_comped', false)->orWhereNull('is_comped');
+            })
+            ->where('price_paid', '>', 0);
+
+        if ($since !== null) {
+            $query->where('purchased_at', '>=', $since);
+        }
+
+        // sales_view ids are pl_{id} (plugins) or pr_{id} (products)
+        $sourceExpression = "CASE WHEN id LIKE 'pl_%' THEN 'plugins' ELSE 'products' END";
+
+        return $query
+            ->selectRaw("product_name, currency, {$sourceExpression} as source, COUNT(*) as sales_count, COALESCE(SUM(price_paid), 0) as revenue_cents")
+            ->groupByRaw("product_name, currency, {$sourceExpression}")
+            ->orderByDesc('revenue_cents')
+            ->limit(self::BY_PRODUCT_LIMIT)
+            ->get()
+            ->map(fn ($row): array => [
+                'product_name' => $row->product_name,
+                'source' => $row->source,
+                'revenue_cents' => (int) $row->revenue_cents,
+                'sales_count' => (int) $row->sales_count,
+                'currency' => $row->currency ?: 'USD',
+            ])
+            ->all();
     }
 
     /**
@@ -102,7 +442,8 @@ class AdminSalesSummary extends Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'days' => $schema->integer()->description('Lookback window in days (default 30, max 365).'),
+            'days' => $schema->integer()->description('Lookback window in days (default 30, max 3650). Ignored when all_time is true.'),
+            'all_time' => $schema->boolean()->description('When true, ignore days/since and include all attributable revenue.'),
         ];
     }
 }

--- a/tests/Feature/Mcp/AdminSalesSummaryTest.php
+++ b/tests/Feature/Mcp/AdminSalesSummaryTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Enums\Subscription as SubscriptionPlan;
+use App\Models\License;
+use App\Models\Plugin;
+use App\Models\PluginLicense;
+use App\Models\Product;
+use App\Models\ProductLicense;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Subscription;
+use Laravel\Cashier\SubscriptionItem;
+use Tests\Concerns\InteractsWithMcpOAuth;
+use Tests\TestCase;
+
+class AdminSalesSummaryTest extends TestCase
+{
+    use InteractsWithMcpOAuth;
+    use RefreshDatabase;
+
+    private const COMPED_ULTRA_PRICE_ID = 'price_test_ultra_comped';
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configureMcpOAuthKeys();
+        $this->admin = User::factory()->create(['email' => 'admin-sales@nativephp.com']);
+        config([
+            'filament.users' => [$this->admin->email],
+            'subscriptions.plans.max.stripe_price_id_comped' => self::COMPED_ULTRA_PRICE_ID,
+            'subscriptions.plans.max.stripe_price_id_monthly' => 'price_max_monthly',
+            'subscriptions.plans.max.stripe_price_id_discounted' => 'price_max_discounted',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function salesSummary(array $arguments = []): array
+    {
+        $tokens = $this->issueMcpOAuthTokens($this->admin);
+        $response = $this->callMcpTool($tokens['access_token'], 'admin-sales-summary', $arguments)->assertOk();
+        $this->assertFalse($response->json('result.isError'), (string) data_get($response->json(), 'result.content.0.text'));
+
+        return json_decode((string) data_get($response->json(), 'result.content.0.text'), true);
+    }
+
+    private function createPaidUltraSubscription(User $user, int $pricePaid, ?\DateTimeInterface $createdAt = null): Subscription
+    {
+        $user->update(['stripe_id' => 'cus_'.uniqid()]);
+        $priceId = SubscriptionPlan::Max->stripePriceId();
+
+        $subscription = Subscription::factory()
+            ->for($user)
+            ->active()
+            ->create([
+                'stripe_price' => $priceId,
+                'is_comped' => false,
+                'price_paid' => $pricePaid,
+                'created_at' => $createdAt ?? now(),
+                'updated_at' => $createdAt ?? now(),
+            ]);
+
+        SubscriptionItem::factory()
+            ->for($subscription, 'subscription')
+            ->create([
+                'stripe_price' => $priceId,
+                'quantity' => 1,
+            ]);
+
+        return $subscription;
+    }
+
+    private function createCompedUltraSubscription(User $user): Subscription
+    {
+        $user->update(['stripe_id' => 'cus_'.uniqid()]);
+
+        $subscription = Subscription::factory()
+            ->for($user)
+            ->active()
+            ->create([
+                'stripe_price' => self::COMPED_ULTRA_PRICE_ID,
+                'is_comped' => false,
+                'price_paid' => 0,
+            ]);
+
+        SubscriptionItem::factory()
+            ->for($subscription, 'subscription')
+            ->create([
+                'stripe_price' => self::COMPED_ULTRA_PRICE_ID,
+                'quantity' => 1,
+            ]);
+
+        return $subscription;
+    }
+
+    public function test_sales_summary_breakdown_includes_plugins_products_and_ultra(): void
+    {
+        $buyer = User::factory()->create();
+        $plugin = Plugin::factory()->approved()->create(['name' => 'acme/camera']);
+        $product = Product::factory()->create(['name' => 'Plugin Dev Kit']);
+
+        PluginLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'plugin_id' => $plugin->id,
+            'price_paid' => 2500,
+            'currency' => 'USD',
+            'is_grandfathered' => false,
+            'purchased_at' => now()->subDays(2),
+        ]);
+        PluginLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'plugin_id' => $plugin->id,
+            'price_paid' => 0,
+            'currency' => 'USD',
+            'is_grandfathered' => true,
+            'purchased_at' => now()->subDays(1),
+        ]);
+
+        ProductLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'product_id' => $product->id,
+            'price_paid' => 9900,
+            'currency' => 'USD',
+            'is_comped' => false,
+            'purchased_at' => now()->subDays(3),
+        ]);
+        ProductLicense::factory()->create([
+            'user_id' => User::factory(),
+            'product_id' => $product->id,
+            'price_paid' => 0,
+            'currency' => 'USD',
+            'is_comped' => true,
+            'purchased_at' => now()->subDay(),
+        ]);
+
+        $this->createPaidUltraSubscription($buyer, 35000, now()->subDays(5));
+        $this->createCompedUltraSubscription(User::factory()->create());
+        $this->createPaidUltraSubscription(User::factory()->create(), 35000, now()->subDays(400));
+
+        License::factory()->withoutSubscriptionItem()->active()->mini()->create([
+            'user_id' => $buyer->id,
+            'created_at' => now()->subDays(4),
+        ]);
+
+        $payload = $this->salesSummary(['days' => 30]);
+
+        $this->assertSame(30, $payload['days']);
+        $this->assertFalse($payload['all_time']);
+        $this->assertNotNull($payload['since']);
+        $this->assertSame(2500 + 9900 + 35000, $payload['total_revenue_cents']);
+
+        $bySource = collect($payload['breakdown'])->keyBy('source');
+        $this->assertSame(2500, $bySource['plugins']['revenue_cents']);
+        $this->assertSame(1, $bySource['plugins']['sales_count']);
+        $this->assertSame(9900, $bySource['products']['revenue_cents']);
+        $this->assertSame(1, $bySource['products']['sales_count']);
+        $this->assertSame(35000, $bySource['ultra_subscriptions']['revenue_cents']);
+        $this->assertSame(1, $bySource['ultra_subscriptions']['sales_count']);
+        $this->assertArrayHasKey('caveat', $bySource['ultra_subscriptions']);
+
+        $this->assertSame(2, $payload['ultra']['active_count']); // recent + old paid Ultra still active
+        $this->assertSame(1, $payload['ultra']['active_comped_count']);
+        $this->assertSame(2, $payload['ultra']['created_in_window']); // paid + comped in window; old paid excluded
+        $this->assertSame(35000, $payload['ultra']['revenue_cents_in_window']);
+
+        $this->assertSame(1, $payload['comped']['plugin_count']);
+        $this->assertSame(1, $payload['comped']['product_count']);
+
+        $this->assertSame(2500, $payload['plugin_license_revenue'][0]['revenue_cents']);
+        $this->assertSame('acme/camera', $payload['top_plugins'][0]['plugin']);
+
+        $byProductNames = collect($payload['by_product'])->pluck('product_name');
+        $this->assertTrue($byProductNames->contains('acme/camera'));
+        $this->assertTrue($byProductNames->contains('Plugin Dev Kit'));
+
+        $this->assertNotEmpty($payload['nativephp_licenses_created']);
+        $this->assertGreaterThanOrEqual(1, $payload['active_nativephp_licenses']);
+        $this->assertStringContainsString('renewals', $payload['note']);
+        $this->assertStringContainsString('sales_view', $payload['note']);
+        $this->assertStringContainsString('Cashier', $payload['note']);
+    }
+
+    public function test_all_time_includes_old_ultra_and_sales(): void
+    {
+        $buyer = User::factory()->create();
+        PluginLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'price_paid' => 1000,
+            'currency' => 'USD',
+            'purchased_at' => now()->subYears(3),
+        ]);
+        $this->createPaidUltraSubscription($buyer, 35000, now()->subYears(2));
+
+        $payload = $this->salesSummary(['all_time' => true]);
+
+        $this->assertTrue($payload['all_time']);
+        $this->assertNull($payload['days']);
+        $this->assertNull($payload['since']);
+        $this->assertSame(1000 + 35000, $payload['total_revenue_cents']);
+        $this->assertSame(35000, $payload['ultra']['revenue_cents_in_window']);
+    }
+
+    public function test_days_window_can_exceed_one_year(): void
+    {
+        $buyer = User::factory()->create();
+        PluginLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'price_paid' => 1500,
+            'currency' => 'USD',
+            'purchased_at' => now()->subDays(500),
+        ]);
+        PluginLicense::factory()->create([
+            'user_id' => $buyer->id,
+            'price_paid' => 999,
+            'currency' => 'USD',
+            'purchased_at' => now()->subDays(800),
+        ]);
+
+        $payload = $this->salesSummary(['days' => 600]);
+
+        $this->assertSame(600, $payload['days']);
+        $this->assertSame(1500, $payload['total_revenue_cents']);
+    }
+}


### PR DESCRIPTION
## Summary
- Expands Admin MCP `admin-sales-summary` so attributable inbound dollars include **Ultra (Cashier Max/Ultra)** subscriptions, **plugin** sales, and **first-party product** sales — not only PluginLicense + Anystack license counts.
- Adds `breakdown`, `by_product`, `ultra` (active / comped / window revenue), `comped` counts, `all_time` + `days` up to 3650, and keeps `plugin_license_revenue` / `top_plugins` / Anystack license fields for compatibility.
- Documents that Cashier `subscriptions.price_paid` is overwritten on invoice paid (renewals do not create rows), matching Filament `SubscriberIncomeChart`.

## Response shape (approx)
```json
{
  "days": 30,
  "all_time": false,
  "since": "…",
  "total_revenue_cents": 0,
  "breakdown": [
    { "source": "plugins", "revenue_cents": 0, "sales_count": 0, "currency": "USD" },
    { "source": "products", "revenue_cents": 0, "sales_count": 0, "currency": "USD" },
    { "source": "ultra_subscriptions", "revenue_cents": 0, "sales_count": 0, "currency": "USD", "caveat": "…" }
  ],
  "by_product": [{ "product_name": "…", "source": "plugins|products", "revenue_cents": 0, "sales_count": 0, "currency": "USD" }],
  "plugin_license_revenue": [{ "currency": "USD", "licenses_count": 0, "revenue_cents": 0 }],
  "top_plugins": [],
  "ultra": {
    "active_count": 0,
    "active_comped_count": 0,
    "created_in_window": 0,
    "paid_created_in_window": 0,
    "revenue_cents_in_window": 0,
    "currency": "USD",
    "caveat": "…"
  },
  "nativephp_licenses_created": [],
  "active_nativephp_licenses": 0,
  "comped": { "plugin_count": 0, "product_count": 0, "ultra_active_count": 0 },
  "note": "…"
}
```

## Caveats
- **Ultra renewals**: `price_paid` is latest invoice total only; window revenue under-counts renewals.
- **Comps / $0**: excluded from paid revenue; counted under `comped`.
- **Ultra ≠ Anystack policy**: plan key `max` is named Ultra and lives on Cashier `subscriptions`.

## Test plan
- [x] `php artisan test --filter=AdminSalesSummaryTest`
- [x] Pint on dirty files
- [ ] Manual MCP call with `days` / `all_time` against staging or local admin OAuth (optional)